### PR TITLE
Fixed unittest directory check to look in the source directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     endif()
 endif()
 
-if (NOT EXISTS tests/unittest-cpp)
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/tests/unittest-cpp)
   message(FATAL_ERROR "Could not find unittest-cpp enlistment. Please run 'git clone https://github.com/Microsoft/unittest-cpp.git unittest-cpp' in the tests directory")
 endif()
 


### PR DESCRIPTION
The relative path in the original check caused cmake to look in the binary directory sometimes. 
