### PR TITLE
Move and exception safety for final_act. resolves #11 resolves #12

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,20 @@ add_test(
     COMMAND bounds_tests
 )
 
+add_executable(final_act_tests
+    final_act_tests.cpp    
+)
+target_link_libraries(final_act_tests
+    UnitTest++
+)
+install(TARGETS final_act_tests
+    RUNTIME DESTINATION bin
+)
+add_test(
+    NAME final_act_tests
+    COMMAND final_act_tests
+)
+
 add_executable(maybenull_tests
     maybenull_tests.cpp
 )

--- a/tests/final_act_tests.cpp
+++ b/tests/final_act_tests.cpp
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <UnitTest++/UnitTest++.h>
+#include <gsl.h>
+#include <exception>
+
+using namespace std;
+using namespace Guide;
+
+struct Increment {
+  int* i_;
+
+  Increment(int& i) : i_(&i) {}
+
+  void operator()() const noexcept { ++*i_; }
+};
+
+struct ThrowOnInvocation {
+  class Exception : public exception {};
+  void operator()() const { throw Exception(); }
+};
+
+SUITE(finallyTests) {
+  TEST(SingleInvocationOnConvenienceConstruction) {
+    int i = 0;
+    { auto f = finally(Increment(i)); }
+    CHECK(i == 1);
+  }
+
+  TEST(SingleInvocationOnMoveConstruction) {
+    int i = 0;
+    {
+      auto f = Final_act<Increment>(Increment(i));
+      auto ff(move(f));
+    }
+    CHECK(i == 1);
+  }
+
+  TEST(NoexceptFinalActIsCreated) {
+    int i = 0;
+    auto f = finally(Increment(i));
+    CHECK((is_same<decltype(f), Final_act_noexcept<Increment>>::value));
+  }
+
+  TEST(FinalActDoesNotThrow) {
+    bool exceptionCaught = false;
+    try {
+      finally(ThrowOnInvocation());
+    } catch (...) {
+      exceptionCaught = true;
+    }
+    CHECK(!exceptionCaught);
+  }
+}
+
+int main(int, const char* []) { return UnitTest::RunAllTests(); }


### PR DESCRIPTION
Copy elision no longer required for `finally`.
Move construction does not result in multiple function object invocation.
Object returned by final_act cannot terminate program if it throws.
Tests added.