### PR TITLE
Added missing owner<T>, corrected array_view::sub().

### DIFF
--- a/include/array_view.h
+++ b/include/array_view.h
@@ -1824,15 +1824,15 @@ public:
 	template<size_t Offset, size_t Count>
 	_CONSTEXPR array_view<ValueTypeOpt, Count> sub() const _NOEXCEPT
 	{
-		static_assert(bounds_type::static_size == dynamic_range || ((Offset == 0 || Offset < bounds_type::static_size) && Offset + Count <= bounds_type::static_size), "Index is out of bound");
-		fail_fast_assert(bounds_type::static_size != dynamic_range || ((Offset == 0 || Offset < this->size()) && Offset + Count <= this->size()));
+		static_assert(bounds_type::static_size == dynamic_range || ((Offset == 0 || Offset <= bounds_type::static_size) && Offset + Count <= bounds_type::static_size), "Index is out of bound");
+		fail_fast_assert(bounds_type::static_size != dynamic_range || ((Offset == 0 || Offset <= this->size()) && Offset + Count <= this->size()));
 		return { this->data() + Offset, Count };
 	}
 
-	_CONSTEXPR array_view<ValueTypeOpt, dynamic_range> sub(size_type offset, size_type count) const _NOEXCEPT
+	_CONSTEXPR array_view<ValueTypeOpt, dynamic_range> sub(size_type offset, size_type count = dynamic_range) const _NOEXCEPT
 	{
-		fail_fast_assert((offset == 0 || offset < this->size()) && offset + count <= this->size());
-		return { this->data() + offset, count };
+		fail_fast_assert((offset == 0 || offset <= this->size()) && (count == dynamic_range || (offset + count) <= this->size()));
+		return { this->data() + offset, count == dynamic_range ? this->length() - offset : count };
 	}
 
 	// size

--- a/include/gsl.h
+++ b/include/gsl.h
@@ -29,6 +29,9 @@ namespace Guide
 using std::unique_ptr;
 using std::shared_ptr;
 
+template <class T>
+using owner = T;
+
 //
 // GSL.assert: assertions
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -142,3 +142,17 @@ add_test(
     NAME utils_tests
     COMMAND utils_tests
 )
+
+add_executable(owner_tests
+    owner_tests.cpp
+)
+target_link_libraries(owner_tests
+    UnitTest++
+)
+install(TARGETS owner_tests
+    RUNTIME DESTINATION bin
+)
+add_test(
+    NAME owner_tests
+    COMMAND owner_tests
+)

--- a/tests/array_view_tests.cpp
+++ b/tests/array_view_tests.cpp
@@ -1329,6 +1329,7 @@ SUITE(array_view_tests)
 			CHECK((av.sub<2,2>().bounds() == static_bounds<size_t, 2>()));
 			CHECK((av.sub<2,2>().length() == 2));
 			CHECK(av.sub(2,2).length() == 2);
+            CHECK(av.sub(2,3).length() == 3);
 		}
 
 
@@ -1344,15 +1345,16 @@ SUITE(array_view_tests)
 			CHECK((av.sub<0,5>().bounds() == static_bounds<size_t, 5>()));
 			CHECK((av.sub<0,5>().length() == 5));
 			CHECK(av.sub(0,5).length() == 5);
+            CHECK_THROW(av.sub(0,6).length(), fail_fast);
+            CHECK_THROW(av.sub(1,5).length(), fail_fast);
 		}
 
 		{
 			array_view<int, 5> av = arr;
-#ifdef CONFIRM_COMPILATION_ERRORS
 			CHECK((av.sub<5,0>().bounds() == static_bounds<size_t, 0>()));
-			CHECK((av.sub<5,0>().length() == 0));
-#endif
-			CHECK_THROW(av.sub(5,0).length(), fail_fast);
+            CHECK((av.sub<5, 0>().length() == 0));
+            CHECK(av.sub(5,0).length() == 0);
+            CHECK_THROW(av.sub(6,0).length(), fail_fast);
 		}
 
 		{
@@ -1360,8 +1362,39 @@ SUITE(array_view_tests)
 			CHECK((av.sub<0,0>().bounds() == static_bounds<size_t, 0>()));
 			CHECK((av.sub<0,0>().length() == 0));
 			CHECK(av.sub(0,0).length() == 0);
+            CHECK_THROW((av.sub<1,0>().length()), fail_fast);
 		}
-	}
+
+        {
+            array_view<int> av;
+            CHECK(av.sub(0).length() == 0);
+            CHECK_THROW(av.sub(1).length(), fail_fast);
+        }
+
+        {
+            array_view<int> av = arr;
+            CHECK(av.sub(0).length() == 5);
+            CHECK(av.sub(1).length() == 4);
+            CHECK(av.sub(4).length() == 1);
+            CHECK(av.sub(5).length() == 0);
+            CHECK_THROW(av.sub(6).length(), fail_fast);
+            auto av2 = av.sub(1);
+            for (int i = 0; i < 4; ++i)
+                CHECK(av2[i] == i+2);
+        }
+        
+        {
+            array_view<int,5> av = arr;
+            CHECK(av.sub(0).length() == 5);
+            CHECK(av.sub(1).length() == 4);
+            CHECK(av.sub(4).length() == 1);
+            CHECK(av.sub(5).length() == 0);
+            CHECK_THROW(av.sub(6).length(), fail_fast);
+            auto av2 = av.sub(1);
+            for (int i = 0; i < 4; ++i)
+                CHECK(av2[i] == i+2);
+        }
+    }
 
 	void AssertNullEmptyProperties(array_view<int, dynamic_range>& av)
 	{

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -1,0 +1,42 @@
+/////////////////////////////////////////////////////////////////////////////// 
+// 
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
+// 
+// This code is licensed under the MIT License (MIT). 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+// THE SOFTWARE. 
+// 
+///////////////////////////////////////////////////////////////////////////////
+
+#include <UnitTest++/UnitTest++.h> 
+#include <gsl.h>
+#include <functional>
+
+using namespace Guide;
+
+SUITE(owner_tests)
+{
+    void f(int* i)
+    {
+        *i += 1;
+    }
+
+    TEST(basic_test)
+    {
+        owner<int*> p = new int(120);
+        CHECK(*p == 120);
+        f(p);
+        CHECK(*p == 121);
+    }
+}
+
+int main(int, const char *[])
+{
+    return UnitTest::RunAllTests();
+}


### PR DESCRIPTION
This PR adds the missing owner<T> and corrects the implementation of array_view::sub() to be as per earlier prototypes (in other words, to be correct).