### PR TITLE
Issue #23   missing header <stdexcept> 

### DIFF
--- a/include/fail_fast.h
+++ b/include/fail_fast.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <exception>
+#include <stdexcept>
 
 namespace Guide
 {


### PR DESCRIPTION
 Missing header <stdexcept> in fail_fast.h #23 