### PR TITLE
Fix issue #45: comparing two maybe_null_dbg's can cause fail_fast

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -202,6 +202,8 @@ public:
 
     bool operator==(const T& rhs) const { tested_ = true; return ptr_ == rhs; }
     bool operator!=(const T& rhs) const { return !(*this == rhs); }
+    bool operator==(const maybe_null_dbg& rhs) const { tested_ = true; rhs.tested_ = true; return ptr_ == rhs.ptr_; }
+    bool operator!=(const maybe_null_dbg& rhs) const { return !(*this == rhs); }
 
     T get() const {
         fail_fast_assert(tested_);

--- a/tests/maybenull_tests.cpp
+++ b/tests/maybenull_tests.cpp
@@ -189,6 +189,58 @@ SUITE(MaybeNullTests)
         CHECK(q.present());
         CHECK(q->foo());
     }
+
+    TEST(TestMaybeNullCompare)
+    {
+        int i1 = 1;
+        int i2 = 2;
+
+        maybe_null_dbg<int*> p1 = &i1;
+        maybe_null_dbg<int*> p1_2 = &i1;
+        maybe_null_dbg<int*> p2 = &i2;
+
+        CHECK_THROW(p1.get(), fail_fast);
+        CHECK_THROW(p1_2.get(), fail_fast);
+        CHECK_THROW(p2.get(), fail_fast);
+
+        CHECK(p1 != p2);
+        CHECK(!(p1 == p2));
+        CHECK(p1 == p1);
+        CHECK(p1 == p1_2);
+
+        // Make sure we no longer throw here
+        CHECK(p1.get() != nullptr);
+        CHECK(p1_2.get() != nullptr);
+        CHECK(p2.get() != nullptr);
+    }
+
+    TEST(TestMaybeNullCopy)
+    {
+        int i1 = 1;
+        int i2 = 2;
+
+        maybe_null_dbg<int*> p1 = &i1;
+        maybe_null_dbg<int*> p1_2 = &i1;
+        maybe_null_dbg<int*> p2 = &i2;
+
+        CHECK(p1 != p2);
+        CHECK(p1 == p1_2);
+
+        // Make sure we no longer throw here
+        CHECK(p1.get() != nullptr);
+        CHECK(p2.get() != nullptr);
+
+        p1 = p2;
+
+        // Make sure we now throw
+        CHECK_THROW(p1.get(), fail_fast);
+
+        CHECK(p1 == p2);
+        CHECK(p1 != p1_2);
+
+        // Make sure we no longer throw here
+        CHECK(p1.get() != nullptr);
+    }
 }
 
 int main(int, const char *[])


### PR DESCRIPTION
Add tests for maybe_null_dbg and fix bug where comparing two of them results in an implicit conversion to T, and a call to get().