### PR TITLE
Fix issues #49 #50

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -223,12 +223,12 @@ public:
 
 
     template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
-    maybe_null_dbg(const maybe_null_dbg<U> &other) : ptr_(other.get()), tested_(false) {}
+    maybe_null_dbg(const maybe_null_dbg<U> &other) : ptr_(other.ptr_), tested_(false) {}
 
     template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
     maybe_null_dbg& operator=(const maybe_null_dbg<U> &other)
     {
-        ptr_ = other.get();
+        ptr_ = other.ptr_;
         tested_ = false;
         return *this;
     }

--- a/include/gsl.h
+++ b/include/gsl.h
@@ -267,6 +267,9 @@ public:
     maybe_null_ret& operator=(const T& p) { if (ptr_ != p) { ptr_ = p; } return *this; }
     maybe_null_ret& operator=(const maybe_null_ret& rhs) = default;
 
+	bool operator==(const T& rhs) const { return ptr_ == rhs; }
+	bool operator!=(const T& rhs) const { return ptr_ != rhs; }
+
     bool present() const { return ptr_ != nullptr; }
 
     T get() const { return ptr_; }

--- a/tests/maybenull_tests.cpp
+++ b/tests/maybenull_tests.cpp
@@ -241,6 +241,20 @@ SUITE(MaybeNullTests)
         // Make sure we no longer throw here
         CHECK(p1.get() != nullptr);
     }
+
+    TEST(TestMaybeNullPtrT)
+    {
+        maybe_null<std::nullptr_t> p1;
+        maybe_null<std::nullptr_t> p2;
+
+        CHECK_THROW(p1.get(), fail_fast);
+
+        CHECK(p1 == p2);
+
+        // Make sure we no longer throw here
+        CHECK(p1.get() == nullptr);
+        CHECK(p2.get() == nullptr);
+    }
 }
 
 int main(int, const char *[])

--- a/tests/maybenull_tests.cpp
+++ b/tests/maybenull_tests.cpp
@@ -256,42 +256,64 @@ SUITE(MaybeNullTests)
         CHECK(p1.get() != nullptr);
     }
 
-    TEST(TestMaybeNullAssignmentOps)
-    {
-        MyBase base;
-        MyDerived derived;
-        Unrelated unrelated;
+	template<class maybe_null_type>
+	void TestMaybeNullAssignmentOpsHelper()
+	{
+		MyBase base;
+		MyDerived derived;
+		Unrelated unrelated;
 
-        not_null<MyBase*> nnBase(&base);
-        not_null<MyDerived*> nnDerived(&derived);
-        not_null<Unrelated*> nnUnrelated(&unrelated);
+		not_null<MyBase*> nnBase(&base);
+		not_null<MyDerived*> nnDerived(&derived);
+		not_null<Unrelated*> nnUnrelated(&unrelated);
 
-        maybe_null_ret<MyBase*> mnBase_ret1(&base), mnBase_ret2;
-        mnBase_ret2 = mnBase_ret1; // maybe_null_ret<T> = maybe_null_ret<T>
-        mnBase_ret2 = nnBase; // maybe_null_ret<T> = not_null<T>
+		maybe_null_type::type<MyBase*> mnBase_ret1(&base), mnBase_ret2;
+		mnBase_ret2 = mnBase_ret1; // maybe_null_ret<T> = maybe_null_ret<T>
+		mnBase_ret2 = nnBase; // maybe_null_ret<T> = not_null<T>
 
-        maybe_null_ret<MyDerived*> mnDerived_ret(&derived);
-        mnBase_ret2 = mnDerived_ret; // maybe_null_ret<T> = maybe_null_ret<U>
-        mnBase_ret1 = &derived; // maybe_null_ret<T> = U;
-        mnBase_ret1 = nnDerived; // maybe_null_ret<T> = not_null<U>
+		maybe_null_type::type<MyDerived*> mnDerived_ret(&derived);
+		mnBase_ret2 = mnDerived_ret; // maybe_null_ret<T> = maybe_null_ret<U>
+		mnBase_ret1 = &derived; // maybe_null_ret<T> = U;
+		mnBase_ret1 = nnDerived; // maybe_null_ret<T> = not_null<U>
 
-        maybe_null_ret<Unrelated*> mnUnrelated_ret;
-        mnUnrelated_ret = &unrelated; // maybe_null_ret<T> = T
+		maybe_null_type::type<Unrelated*> mnUnrelated_ret;
+		mnUnrelated_ret = &unrelated; // maybe_null_ret<T> = T
 
-        maybe_null_dbg<MyBase*> mnBase_dbg1(&base), mnBase_dbg2;
-        mnBase_dbg2 = mnBase_dbg1; // maybe_null_dbg<T> = maybe_null_dbg<T>
-        mnBase_dbg2 = nnBase; // maybe_null_dbg<T> = not_null<T>
+		maybe_null_type::type<MyBase*> mnBase_dbg1(&base), mnBase_dbg2;
+		mnBase_dbg2 = mnBase_dbg1; // maybe_null_dbg<T> = maybe_null_dbg<T>
+		mnBase_dbg2 = nnBase; // maybe_null_dbg<T> = not_null<T>
 
-        maybe_null_dbg<MyDerived*> mnDerived_dbg(&derived);
-        CHECK(mnDerived_dbg.present());
-        mnBase_dbg2 = mnDerived_dbg; // maybe_null_dbg<T> = maybe_null_dbg<U>
-        
-        mnBase_dbg1 = &derived; // maybe_null_dbg<T> = U;
-        mnBase_dbg1 = nnDerived; // maybe_null_dbg<T> = not_null<U>
+		maybe_null_type::type<MyDerived*> mnDerived_dbg(&derived);
+		CHECK(mnDerived_dbg.present());
+		mnBase_dbg2 = mnDerived_dbg; // maybe_null_dbg<T> = maybe_null_dbg<U>
 
-        maybe_null_dbg<Unrelated*> mnUnrelated_dbg;
-        mnUnrelated_dbg = &unrelated; // maybe_null_dbg<T> = T
-    }
+		mnBase_dbg1 = &derived; // maybe_null_dbg<T> = U;
+		mnBase_dbg1 = nnDerived; // maybe_null_dbg<T> = not_null<U>
+
+		maybe_null_type::type<Unrelated*> mnUnrelated_dbg;
+		mnUnrelated_dbg = &unrelated; // maybe_null_dbg<T> = T
+	}
+
+	struct maybe_null_ret_type
+	{
+		template<typename T>
+		using type = maybe_null_ret<T>;
+	};
+	struct maybe_null_dbg_type
+	{
+		template<typename T>
+		using type = maybe_null_dbg<T>;
+	};
+
+	TEST(TestMaybeNullRetAssignmentOps)
+	{
+		TestMaybeNullAssignmentOpsHelper<maybe_null_ret_type>();
+	}
+
+	TEST(TestMaybeNullDbgAssignmentOps)
+	{
+		TestMaybeNullAssignmentOpsHelper<maybe_null_dbg_type>();
+	}
 }
 
 int main(int, const char *[])


### PR DESCRIPTION
Grouped these all into one PR, as they're small and related.  In addition to not allowing not dereferencable types `ptee_size_` was adding unnecessary size overhead to maybe_null.