### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+ColumnLimit: 0
+
+UseTab: Never
+IndentWidth: 4
+AccessModifierOffset: -4
+NamespaceIndentation: Inner
+
+BreakBeforeBraces: Allman
+AlwaysBreakTemplateDeclarations: false
+BreakConstructorInitializersBeforeComma: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+
+PointerAlignment: Left
+AlignConsecutiveAssignments: false
+AlignTrailingComments: false
+
+SpaceAfterCStyleCast: true


### PR DESCRIPTION
To have any hope of achieving consistent formatting there needs to be a standard and a mechanism for enforcing it. This is a first step in that direction.

It should be noted that this pull request _does not_ reformat any existing code. Instead contributors should use clang-format to format portions of code that they modify.

This format specification is intended to mimic the existing style insofar as the current source has any consistent style. For example the determination as to whether ref qualifiers should bind to the
type or variable name was made by trying both and seeing which produced fewer changes. One exception is the use of tabs vs. spaces, which was decided based on a comment by neilmacintosh [here][1].

To use clang-format with Visual Studio [download][2] and install the clang-format plugin. In VS ctrl-r, ctrl-f formats the current line or text selection.

[1]: https://github.com/Microsoft/GSL/issues/55
[2]: http:llvm.org/builds/