### PR TITLE
Guide::finally can make use of move semantics

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -50,7 +50,7 @@ template <class F>
 class Final_act
 {
 public:
-    explicit Final_act(F f) : f_(f) {}
+    explicit Final_act(F f) : f_(std::move(f)) {}
     
     Final_act(const Final_act&& other) : f_(other.f_) {}
     Final_act(const Final_act&) = delete;
@@ -64,7 +64,10 @@ private:
 
 // finally() - convenience function to generate a Final_act
 template <class F>
-Final_act<F> finally(F f) { return Final_act<F>(f); }
+Final_act<F> finally(const F &f) { return Final_act<F>(f); }
+
+template <class F>
+Final_act<F> finally(F &&f) { return Final_act<F>(std::forward<F>(f)); }
 
 // narrow_cast(): a searchable way to do narrowing casts of values
 template<class T, class U>


### PR DESCRIPTION
for eg consider this case
````cpp
string value = "someVeryLongErrorMessageIAm";
finally([value] { PrintErrorMessage(value); } 
````

With the current changes before the call to PrintErrorMessage there will be 3 calls to copy constructor for string(1 when it's captured in closure, 2nd when finally is called and 3rd when it's passed to Final_act) . With my patch there will be 1 call to the copy constructor and 2 to the move constructor for the scenario in example, so 2 potential deep copies will be saved for  objects that support move semantics and are passed to or are captured in closures in call to  <code> finally </code>. 
Validated that code builds from project root, and all tests pass after my change. Also validated that indeed copy constructor calls are saved for objects that support move semantics.