### PR TITLE
not_null and maybe_null_* should have explicit conversion operators.

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -142,7 +142,7 @@ public:
         return ptr_;
     } // the assume() should help the optimizer
 
-    operator T() const {  return get(); }
+    explicit operator T() const { return get(); }
     T operator->() const { return get(); }
 
 	bool operator==(const T& rhs) const { return ptr_ == rhs; }
@@ -258,7 +258,7 @@ public:
         return ptr_; 
     }
 
-    operator T() const { return get(); }
+    explicit operator T() const { return get(); }
     T operator->() const { return get(); }
 
 private:
@@ -328,7 +328,7 @@ public:
 
     T get() const { return ptr_; }
 
-    operator T() const { return get(); }
+    explicit operator T() const { return get(); }
     T operator->() const { return get(); }
 
 private:


### PR DESCRIPTION
Implicit conversion operators are bad and are also against the
guidelines.