### PR TITLE
it's better to pass a small (e.g. 16 bytes) object by value then by c…

### DIFF
--- a/include/string_view.h
+++ b/include/string_view.h
@@ -137,7 +137,7 @@ basic_string_view<typename std::remove_pointer<typename Cont::pointer>::type, dy
 // to_string() allow (explicit) conversions from string_view to string
 //
 template<class CharT, size_t Extent>
-std::basic_string<typename std::remove_const<CharT>::type> to_string(const basic_string_view<CharT, Extent>& view)
+std::basic_string<typename std::remove_const<CharT>::type> to_string(basic_string_view<CharT, Extent> view)
 {
     return{ view.data(), view.length() };
 }


### PR DESCRIPTION
…onst reference

Less typing and less alias analysis for compiler. Same as narrow_cast https://github.com/Microsoft/GSL/blob/master/include/gsl.h#L74