### PR TITLE
Fixing move constructor/semantics of Final_act

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -50,16 +50,17 @@ template <class F>
 class Final_act
 {
 public:
-    explicit Final_act(F f) : f_(std::move(f)) {}
-    
-    Final_act(const Final_act&& other) : f_(other.f_) {}
+    explicit Final_act(F f) : f_(std::move(f)), invoke_(true) {}
+
+    Final_act(Final_act&& other) : f_(std::move(other.f_)), invoke_(true) { other._invoke = false; }
     Final_act(const Final_act&) = delete;
     Final_act& operator=(const Final_act&) = delete;
-    
-    ~Final_act() { f_(); }
+
+    ~Final_act() { if (invoke_) f_(); }
 
 private:
     F f_;
+    bool invoke_;
 };
 
 // finally() - convenience function to generate a Final_act

--- a/include/gsl.h
+++ b/include/gsl.h
@@ -52,7 +52,7 @@ class Final_act
 public:
     explicit Final_act(F f) : f_(std::move(f)), invoke_(true) {}
 
-    Final_act(Final_act&& other) : f_(std::move(other.f_)), invoke_(true) { other._invoke = false; }
+    Final_act(Final_act&& other) : f_(std::move(other.f_)), invoke_(true) { other.invoke_ = false; }
     Final_act(const Final_act&) = delete;
     Final_act& operator=(const Final_act&) = delete;
 

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -37,6 +37,20 @@ SUITE(utils_tests)
         CHECK(i == 1);
     }
 
+    TEST(finally_lambda_move)
+    {
+        int i = 0;
+        {
+            auto _1 = finally([&]() {f(i);});
+            {
+                auto _2 = std::move(_1);
+                CHECK(i == 0);   
+            }
+            CHECK(i == 1);   
+        }
+        CHECK(i == 1);
+    }
+
     TEST(finally_function_with_bind)
     {
         int i = 0;


### PR DESCRIPTION
The move constructor of Final_act is updated to accept a non-const r-value reference. It also properly moves from the r-value function object member to the function object member of the object being constructed during the move operation. It now has a boolean to indicate whether or not the function object should be invoked in the destructor so that temporary objects that have been moved from do not invoke the function object improperly, removing dependence on copy elision for correct behavior. Finally, a test is added to verify that Final_act objects can be moved, if necessary. This resolves the issues discussed in issue #42.