### PR TITLE
Add workarounds for g++ 4.9

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -45,7 +45,7 @@
 
 #endif // _MSC_VER
 
-#if (__GNUC__ < 5) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ < 5) && !defined(__clang__)
 #define constexpr /* nothing */
 #endif
 

--- a/include/gsl.h
+++ b/include/gsl.h
@@ -45,6 +45,10 @@
 
 #endif // _MSC_VER
 
+#if (__GNUC__ < 5) && !defined(__clang__)
+#define constexpr /* nothing */
+#endif
+
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROWS_FOR_TESTING
 #define noexcept /* nothing */ 

--- a/include/span.h
+++ b/include/span.h
@@ -60,6 +60,10 @@
 
 #endif // _MSC_VER
 
+#if (__GNUC__ < 5) && !defined(__clang__)
+#define constexpr /* nothing */
+#endif
+
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROWS_FOR_TESTING
 #define noexcept /* nothing */ 
@@ -227,6 +231,9 @@ private:
 
 #ifndef _MSC_VER
 
+#if (__GNUC__ < 5) && !defined(__clang__)
+const std::ptrdiff_t dynamic_range = -1;
+#else
 struct static_bounds_dynamic_range_t
 {
     template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
@@ -262,6 +269,8 @@ constexpr bool operator !=(T left, static_bounds_dynamic_range_t right) noexcept
 }
 
 constexpr static_bounds_dynamic_range_t dynamic_range{};
+#endif
+
 #else
 const std::ptrdiff_t dynamic_range = -1;
 #endif

--- a/include/span.h
+++ b/include/span.h
@@ -60,7 +60,7 @@
 
 #endif // _MSC_VER
 
-#if (__GNUC__ < 5) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ < 5) && !defined(__clang__)
 #define constexpr /* nothing */
 #endif
 
@@ -231,7 +231,7 @@ private:
 
 #ifndef _MSC_VER
 
-#if (__GNUC__ < 5) && !defined(__clang__)
+#if defined(__GNUC__) && (__GNUC__ < 5) && !defined(__clang__)
 const std::ptrdiff_t dynamic_range = -1;
 #else
 struct static_bounds_dynamic_range_t


### PR DESCRIPTION
This change uses some of the MSVC workarounds for older g++ compilers (gcc < 5.1) which have similar issues with constexpr.

Tests pass on:
- gcc-4.9.2/Linux
- gcc-5.2.1/Linux
- clang-3.6.1/Linux
- MSVC 2015/Windows