### PR TITLE
fixes pragma undef warnings in MSVC2013

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -219,7 +219,7 @@ namespace std
 #pragma warning(pop)
 
 #ifndef GSL_THROWS_FOR_TESTING
-#pragma undef noexcept
+#undef noexcept
 #endif // GSL_THROWS_FOR_TESTING
 
 #endif // _MSC_VER <= 1800

--- a/include/span.h
+++ b/include/span.h
@@ -2038,7 +2038,7 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 #pragma warning(pop)
 
 #ifndef GSL_THROWS_FOR_TESTING
-#pragma undef noexcept
+#undef noexcept
 #endif // GSL_THROWS_FOR_TESTING
 
 #undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG 


### PR DESCRIPTION
use "#undef" instead of "#pragma undef"