### PR TITLE
Added explicit cast to size_type in span constructor

### DIFF
--- a/include/span.h
+++ b/include/span.h
@@ -1267,7 +1267,7 @@ public:
         && std::is_convertible<DataType (*)[], value_type (*)[]>::value
         && std::is_same<std::decay_t<decltype(std::declval<Cont>().size(), *std::declval<Cont>().data())>, DataType>::value>
     >
-    constexpr span (Cont& cont) : span(static_cast<pointer>(cont.data()), details::newBoundsHelper<bounds_type>(cont.size()))
+    constexpr span (Cont& cont) : span(static_cast<pointer>(cont.data()), details::newBoundsHelper<bounds_type>(static_cast<size_type>(cont.size())))
     {}
 
     constexpr span(const span &) = default;


### PR DESCRIPTION
This silences implicit sign conversion warnings when constructing span
from containers which return size_t from size().