### PR TITLE
Made conversion of span<> to bool explicit

### DIFF
--- a/include/span.h
+++ b/include/span.h
@@ -1434,7 +1434,7 @@ public:
         return m_pdata;
     }
 
-    constexpr operator bool() const noexcept
+    constexpr explicit operator bool() const noexcept
     {
         return m_pdata != nullptr;
     }
@@ -1676,7 +1676,7 @@ public:
         return m_pdata;
     }
 
-    constexpr operator bool() const noexcept
+    constexpr explicit operator bool() const noexcept
     {
         return m_pdata != nullptr;
     }


### PR DESCRIPTION
This should prevent some accidental implicit conversions from span to integers.