### PR TITLE
Dev/annagrin/string span fixes

### DIFF
--- a/include/span.h
+++ b/include/span.h
@@ -51,8 +51,8 @@
 #define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
 #define GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
 
-// noexcept is not understood
-#ifndef GSL_THROWS_ON_CONTRACT_VIOLATION
+// noexcept is not understood 
+#ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
 #define noexcept /* nothing */
 #endif

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -23,14 +23,36 @@
 #include "span.h"
 #include <cstring>
 
-// VS 2013 workarounds
 #ifdef _MSC_VER
+
+// No MSVC does constexpr fully yet
+#pragma push_macro("constexpr")
+#define constexpr /* nothing */
+
+// VS 2013 workarounds
 #if _MSC_VER <= 1800
 
 #define GSL_MSVC_HAS_TYPE_DEDUCTION_BUG 
 
+// noexcept is not understood 
+#ifndef GSL_THROW_ON_CONTRACT_VIOLATION
+#pragma push_macro("noexcept")
+#define noexcept /* nothing */ 
+#endif
+
 #endif // _MSC_VER <= 1800
 #endif // _MSC_VER
+
+// In order to test the library, we need it to throw exceptions that we can catch
+#ifdef GSL_THROW_ON_CONTRACT_VIOLATION
+
+#ifdef _MSC_VER
+#pragma push_macro("noexcept")
+#endif
+
+#define noexcept /* nothing */ 
+
+#endif // GSL_THROW_ON_CONTRACT_VIOLATION 
 
 namespace gsl
 {
@@ -57,27 +79,6 @@ template<std::ptrdiff_t Extent = dynamic_range>
 using wzstring = wchar_t*;
 
 //
-// string_span and relatives
-//
-// Note that Extent is always single-dimension only
-//
-template <class CharT, std::ptrdiff_t Extent = dynamic_range>
-using basic_string_span = span<CharT, Extent>;
-
-template<std::ptrdiff_t Extent = dynamic_range>
-using string_span = basic_string_span<char, Extent>;
-
-template<std::ptrdiff_t Extent = dynamic_range>
-using cstring_span = basic_string_span<const char, Extent>;
-
-template<std::ptrdiff_t Extent = dynamic_range>
-using wstring_span = basic_string_span<wchar_t, Extent>;
-
-template<std::ptrdiff_t Extent = dynamic_range>
-using cwstring_span = basic_string_span<const wchar_t, Extent>;
-
-
-//
 // ensure_sentinel() 
 //
 // Provides a way to obtain an span from a contiguous sequence
@@ -86,7 +87,7 @@ using cwstring_span = basic_string_span<const wchar_t, Extent>;
 // Will fail-fast if sentinel cannot be found before max elements are examined.
 //
 template<class T, const T Sentinel>
-span<T, dynamic_range> ensure_sentinel(const T* seq, std::ptrdiff_t max = PTRDIFF_MAX)
+span<T, dynamic_range> ensure_sentinel(T* seq, std::ptrdiff_t max = PTRDIFF_MAX)
 {
     auto cur = seq;
     while ((cur - seq) < max && *cur != Sentinel) ++cur;
@@ -101,45 +102,340 @@ span<T, dynamic_range> ensure_sentinel(const T* seq, std::ptrdiff_t max = PTRDIF
 // the limit of size_type.
 //
 template<class T>
-inline basic_string_span<T, dynamic_range> ensure_z(T* const & sz, std::ptrdiff_t max = PTRDIFF_MAX)
+inline span<T, dynamic_range> ensure_z(T* const & sz, std::ptrdiff_t max = PTRDIFF_MAX)
 {
     return ensure_sentinel<T, 0>(sz, max);
 }
 
 // TODO (neilmac) there is probably a better template-magic way to get the const and non-const overloads to share an implementation
-inline basic_string_span<char, dynamic_range> ensure_z(char* const& sz, std::ptrdiff_t max)
+inline span<char, dynamic_range> ensure_z(char* const& sz, std::ptrdiff_t max)
 {
     auto len = strnlen(sz, max);
     Ensures(sz[len] == 0);
     return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
-inline basic_string_span<const char, dynamic_range> ensure_z(const char* const& sz, std::ptrdiff_t max)
+inline span<const char, dynamic_range> ensure_z(const char* const& sz, std::ptrdiff_t max)
 {
     auto len = strnlen(sz, max);
     Ensures(sz[len] == 0); return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
-inline basic_string_span<wchar_t, dynamic_range> ensure_z(wchar_t* const& sz, std::ptrdiff_t max)
+inline span<wchar_t, dynamic_range> ensure_z(wchar_t* const& sz, std::ptrdiff_t max)
 {
     auto len = wcsnlen(sz, max);
     Ensures(sz[len] == 0); return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
-inline basic_string_span<const wchar_t, dynamic_range> ensure_z(const wchar_t* const& sz, std::ptrdiff_t max)
+inline span<const wchar_t, dynamic_range> ensure_z(const wchar_t* const& sz, std::ptrdiff_t max)
 {
     auto len = wcsnlen(sz, max);
     Ensures(sz[len] == 0); return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
 template<class T, size_t N>
-basic_string_span<T, dynamic_range> ensure_z(T(&sz)[N]) { return ensure_z(&sz[0], static_cast<std::ptrdiff_t>(N)); }
+span<T, dynamic_range> ensure_z(T(&sz)[N]) { return ensure_z(&sz[0], static_cast<std::ptrdiff_t>(N)); }
 
 template<class Cont>
-basic_string_span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_range> ensure_z(Cont& cont)
+span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_range> ensure_z(Cont& cont)
 {
     return ensure_z(cont.data(), static_cast<std::ptrdiff_t>(cont.length()));
 }
+
+
+// TODO (neilmac) there is probably a better template-magic way to get the const and non-const overloads to share an implementation
+inline span<char, dynamic_range> remove_z(char* const& sz, std::ptrdiff_t max)
+{
+    auto len = strnlen(sz, max);
+    return{ sz, static_cast<std::ptrdiff_t>(len) };
+}
+
+inline span<const char, dynamic_range> remove_z(const char* const& sz, std::ptrdiff_t max)
+{
+    auto len = strnlen(sz, max);
+    return{ sz, static_cast<std::ptrdiff_t>(len) };
+}
+
+inline span<wchar_t, dynamic_range> remove_z(wchar_t* const& sz, std::ptrdiff_t max)
+{
+    auto len = wcsnlen(sz, max);
+    return{ sz, static_cast<std::ptrdiff_t>(len) };
+}
+
+inline span<const wchar_t, dynamic_range> remove_z(const wchar_t* const& sz, std::ptrdiff_t max)
+{
+    auto len = wcsnlen(sz, max);
+    return{ sz, static_cast<std::ptrdiff_t>(len) };
+}
+
+template<class T, size_t N>
+span<T, dynamic_range> remove_z(T(&sz)[N])
+{
+    return remove_z(&sz[0], static_cast<std::ptrdiff_t>(N));
+}
+
+template<class Cont>
+span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_range> remove_z(Cont& cont)
+{
+    return remove_z(cont.data(), static_cast<std::ptrdiff_t>(cont.length()));
+}
+
+template<typename ValueType, std::ptrdiff_t>
+class basic_string_span;
+
+namespace details
+{
+    template <typename T>
+    struct is_basic_string_span_oracle : std::false_type
+    {};
+
+    template <typename ValueType, std::ptrdiff_t Extent>
+    struct is_basic_string_span_oracle<basic_string_span<ValueType, Extent>> : std::true_type
+    {};
+
+    template <typename T>
+    struct is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
+    {};
+}
+
+//
+// string_span and relatives
+//
+// Note that Extent is always single-dimension only
+//
+template <class CharT, std::ptrdiff_t Extent = dynamic_range>
+class basic_string_span
+{
+    using value_type = CharT;
+    using const_value_type = std::add_const_t<value_type>;
+    using pointer = std::add_pointer_t<value_type>;
+    using reference = std::add_lvalue_reference_t<value_type>;
+    using const_reference = std::add_lvalue_reference_t<const_value_type>;
+    using bounds_type = static_bounds<Extent>;
+    using underlying_type = span<value_type, Extent>;
+
+public:
+    using size_type = ptrdiff_t;
+    using iterator = typename underlying_type::iterator;
+    using const_iterator = typename underlying_type::const_iterator;
+    using reverse_iterator = typename underlying_type::reverse_iterator;
+    using const_reverse_iterator = typename underlying_type::const_reverse_iterator;
+
+    // empty
+    constexpr basic_string_span() noexcept
+        : real(nullptr)
+    {}
+
+    // copy
+    constexpr basic_string_span(const basic_string_span& other) noexcept
+        : real(other.real)
+    {}
+
+    // move
+    constexpr basic_string_span(const basic_string_span&& other) noexcept
+        : real(std::move(other.real))
+    {}
+
+    // from nullptr and length
+    constexpr basic_string_span(nullptr_t ptr, size_type length) noexcept
+        : real(ptr, length)
+    {}
+
+    // For pointers and static arrays - if 0-terminated, remove 0 from the view
+
+    // from c string
+    
+    constexpr basic_string_span(pointer& ptr) noexcept
+        : real(ensure_z(ptr))
+    {}
+
+    // from non-const pointer to const span
+    template<typename Dummy = std::enable_if_t<std::is_const<value_type>::value>>
+    constexpr basic_string_span(std::remove_const_t<value_type>*& ptr) noexcept
+        : real(ensure_z(ptr))
+    {}
+
+    // from raw data and length - remove 0 if needed
+    constexpr basic_string_span(pointer ptr, size_type length) noexcept
+        : real(remove_z(ptr, length))
+    {}
+
+    // from static arrays and string literals
+    template<size_t N>
+    constexpr basic_string_span(value_type(&arr)[N]) noexcept
+        : real(remove_z(arr))
+    {}
+
+    // Those allow 0s in the middle, so we keep them
+
+    constexpr basic_string_span(std::string& s) noexcept
+        : real(&(s.at(0)), static_cast<ptrdiff_t>(s.length()))
+    {}
+
+    // from containers. It must have .size() and .data() function signatures
+    template <typename Cont, typename DataType = typename Cont::value_type,
+        typename Dummy = std::enable_if_t<!details::is_span<Cont>::value
+        && !details::is_basic_string_span<Cont>::value 
+        && !(!std::is_const<value_type>::value && std::is_const<Cont>::value) // no converting const containers to non-const span
+        && std::is_convertible<DataType*, value_type*>::value
+        && std::is_same<std::decay_t<decltype(std::declval<Cont>().size(), *std::declval<Cont>().data())>, DataType>::value>
+    >
+    constexpr basic_string_span(Cont& cont)
+        : real(cont.data(), cont.size())
+    {}
+
+    // from span
+    template <typename OtherValueType, std::ptrdiff_t OtherExtent,
+        typename OtherBounds = static_bounds<OtherExtent>,
+        typename Dummy = std::enable_if_t<std::is_convertible<OtherValueType*, value_type*>::value && std::is_convertible<OtherBounds, bounds_type>::value>
+    >
+    constexpr basic_string_span(const span<OtherValueType, OtherExtent>& other) noexcept
+        : real(other)
+    {}
+
+    // from string_span
+    template <typename OtherValueType, std::ptrdiff_t OtherExtent,
+        typename OtherBounds = static_bounds<OtherExtent>,
+        typename Dummy = std::enable_if_t<std::is_convertible<OtherValueType*, value_type*>::value && std::is_convertible<OtherBounds, bounds_type>::value>
+    >
+    constexpr basic_string_span(const basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+        : real(other.data(), other.length())
+    {}
+
+    // section on linear space
+    template<size_type Count>
+    constexpr basic_string_span<value_type, Count> first() const noexcept
+    {
+        return{ real.first<Count>() };
+    }
+
+    constexpr basic_string_span<value_type, dynamic_range> first(size_type count) const noexcept
+    {
+        return{ real.first(count); }
+    }
+
+    template<size_type Count>
+    constexpr basic_string_span<value_type, Count> last() const noexcept
+    {
+        return{ real.last<Count>() };
+    }
+
+    constexpr basic_string_span<value_type, dynamic_range> last(size_type count) const noexcept
+    {
+        return{ real.last(count); }
+    }
+
+    template<size_type Offset, size_type Count>
+    constexpr basic_string_span<value_type, Count> sub() const noexcept
+    {
+        return{ real.sub<Count>() };
+    }
+
+    constexpr basic_string_span<value_type, dynamic_range> sub(size_type offset, size_type count = dynamic_range) const noexcept
+    {
+        return{ real.sub(offset, count) };
+    }
+
+    constexpr const_reference operator[](size_type idx) const noexcept
+    {
+        return real[idx];
+    }
+
+    constexpr reference operator[](size_type idx) noexcept
+    {
+        return real[idx];
+    }
+
+    constexpr pointer data() const noexcept
+    {
+        return real.data();
+    }
+
+    constexpr size_type length() const noexcept
+    {
+        return real.size();
+    }
+
+    constexpr size_type size() const noexcept
+    {
+        return real.size();
+    }
+
+    constexpr size_type used_length() const noexcept
+    {
+        return length();
+    }
+
+    constexpr size_type bytes() const noexcept
+    {
+        return real.bytes();
+    }
+
+    constexpr size_type used_bytes() const noexcept
+    {
+        return bytes();
+    }
+
+    constexpr explicit operator bool() const noexcept
+    {
+        return real;
+    }
+
+    constexpr iterator begin() const noexcept
+    {
+        return real.begin();
+    }
+
+    constexpr iterator end() const noexcept
+    {
+        return real.end();
+    }
+
+    constexpr const_iterator cbegin() const noexcept
+    {
+        return real.cbegin();
+    }
+
+    constexpr const_iterator cend() const noexcept
+    {
+        real.cend();
+    }
+
+    constexpr reverse_iterator rbegin() const noexcept
+    {
+        return real.rbegin();
+    }
+
+    constexpr reverse_iterator rend() const noexcept
+    {
+        return real.rend();
+    }
+
+    constexpr const_reverse_iterator crbegin() const noexcept
+    {
+        return real.crbegin();
+    }
+
+    constexpr const_reverse_iterator crend() const noexcept
+    {
+        return real.crend();
+    }
+
+private:
+    span<CharT, Extent> real;
+};
+
+template<std::ptrdiff_t Extent = dynamic_range>
+using string_span = basic_string_span<char, Extent>;
+
+template<std::ptrdiff_t Extent = dynamic_range>
+using cstring_span = basic_string_span<const char, Extent>;
+
+template<std::ptrdiff_t Extent = dynamic_range>
+using wstring_span = basic_string_span<wchar_t, Extent>;
+
+template<std::ptrdiff_t Extent = dynamic_range>
+using cwstring_span = basic_string_span<const wchar_t, Extent>;
 
 //
 // to_string() allow (explicit) conversions from string_span to string
@@ -213,14 +509,89 @@ template <size_t Max = dynamic_range>
 using wzstring_builder = basic_zstring_builder<wchar_t, Max>;
 }
 
+
+constexpr bool operator==(const gsl::cstring_span<>& one, const gsl::cstring_span<>& other) noexcept
+{
+    return std::equal(one.begin(), one.end(), other.begin(), other.end());
+}
+
+constexpr bool operator==(const gsl::string_span<>& one, const gsl::string_span<>& other) noexcept
+{
+    return std::equal(one.begin(), one.end(), other.begin(), other.end());
+}
+
+
+// TODO: ca we make twmplate ops work?
+//template <typename ValueType, std::ptrdiff_t Extent>
+//constexpr bool operator==(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<ValueType, Extent>& other) noexcept
+//{
+//    return std::equal(one.begin(), one.end(), other.begin(), other.end());
+//}
+/*
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator==(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return std::equal(one.begin(), one.end(), other.begin(), other.end());
+}
+
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator!=(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return !(one == other);
+}
+
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator<(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return std::lexicographical_compare(one.begin(), one.end(), other.begin(), other.end());
+}
+
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator<=(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return !(other < one);
+}
+
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator>(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return other < one;
+}
+
+template <typename ValueType, std::ptrdiff_t Extent, typename OtherValueType, std::ptrdiff_t OtherExtent, typename Dummy = std::enable_if_t<std::is_same<std::remove_cv_t<ValueType>, std::remove_cv_t<OtherValueType>>::value>>
+constexpr bool operator>=(const gsl::basic_string_span<ValueType, Extent>& one, const gsl::basic_string_span<OtherValueType, OtherExtent>& other) noexcept
+{
+    return !(one < other);
+}
+*/
 // VS 2013 workarounds
 #ifdef _MSC_VER
+
+#undef constexpr
+#pragma pop_macro("constexpr")
+
 #if _MSC_VER <= 1800
 
-#undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG 
+#pragma warning(pop)
+
+#ifndef GSL_THROW_ON_CONTRACT_VIOLATION
+#undef noexcept
+#pragma pop_macro("noexcept")
+#endif // GSL_THROW_ON_CONTRACT_VIOLATION
+
+#undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
 
 #endif // _MSC_VER <= 1800
 #endif // _MSC_VER
 
+#if defined(GSL_THROW_ON_CONTRACT_VIOLATION) 
+
+#undef noexcept
+
+#ifdef _MSC_VER
+#pragma pop_macro("noexcept")
+#endif
+
+#endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
 #endif // GSL_STRING_SPAN_H

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -336,16 +336,16 @@ public:
         return{ span_.last(count) };
     }
 
-    // Count elements starting from Offset
+    // create a subview of Count elements starting from Offset
     template<size_type Offset, size_type Count>
-    constexpr basic_string_span<value_type, Count> sub() const noexcept
+    constexpr basic_string_span<value_type, Count> subspan() const noexcept
     {
-        return{ span_.template sub<Offset, Count>() };
+        return{ span_.template subspan<Offset, Count>() };
     }
 
-    constexpr basic_string_span<value_type, dynamic_range> sub(size_type offset, size_type count = dynamic_range) const noexcept
+    constexpr basic_string_span<value_type, dynamic_range> subspan(size_type offset, size_type count = dynamic_range) const noexcept
     {
-        return{ span_.sub(offset, count) };
+        return{ span_.subspan(offset, count) };
     }
 
     constexpr reference operator[](size_type idx) const noexcept
@@ -358,19 +358,28 @@ public:
         return span_.data();
     }
 
+    // length of the span in elements
     constexpr size_type length() const noexcept
     {
         return span_.size();
     }
 
+    // length of the span in elements
     constexpr size_type size() const noexcept
     {
         return span_.size();
     }
 
-    constexpr size_type bytes() const noexcept
+    // length of the span in bytes
+    constexpr size_type size_bytes() const noexcept
     {
-        return span_.bytes();
+        return span_.size_bytes();
+    }
+
+    // length of the span in bytes
+    constexpr size_type length_bytes() const noexcept
+    {
+        return span_.length_bytes();
     }
 
     constexpr iterator begin() const noexcept

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -18,6 +18,8 @@
 #include <string_span.h>
 #include <vector>
 #include <cstdlib>
+#include <map>
+#include <unordered_map>
 
 using namespace std;
 using namespace gsl;
@@ -27,7 +29,7 @@ SUITE(string_span_tests)
 {
 
     TEST(TestLiteralConstruction)
-	{
+    {
         cwstring_span<> v = ensure_z(L"Hello");
 
         CHECK(5 == v.length());
@@ -35,7 +37,7 @@ SUITE(string_span_tests)
 #ifdef CONFIRM_COMPILATION_ERRORS
         wstring_span<> v2 = ensure0(L"Hello");
 #endif
-	}
+    }
 
     TEST(TestConstructFromStdString)
     {
@@ -51,8 +53,8 @@ SUITE(string_span_tests)
         CHECK(v.length() == static_cast<string_span<>::size_type>(vec.size()));
     }
 
-	TEST(TestStackArrayConstruction)
-	{
+    TEST(TestStackArrayConstruction)
+    {
         wchar_t stack_string[] = L"Hello";
 
         {
@@ -62,7 +64,7 @@ SUITE(string_span_tests)
 
         {
             cwstring_span<> v = stack_string;
-            CHECK(v.length() == 6);
+            CHECK(v.length() == 5);
         }
 
         {
@@ -72,7 +74,7 @@ SUITE(string_span_tests)
 
         {
             wstring_span<> v = stack_string;
-            CHECK(v.length() == 6);
+            CHECK(v.length() == 5);
         }
 	}
 
@@ -95,7 +97,7 @@ SUITE(string_span_tests)
     {
         char stack_string[] = "Hello";
         cstring_span<> v = ensure_z(stack_string);
-	(void)v;
+        (void)v;
 #ifdef CONFIRM_COMPILATION_ERRORS
         string_span<> v2 = v;
         string_span<> v3 = "Hello";
@@ -113,6 +115,391 @@ SUITE(string_span_tests)
         CHECK(static_cast<cstring_span<>::size_type>(s2.length()) == v.length());
         CHECK(s2.length() == 5);
     }
+
+    TEST(ComparisonAndImplicitConstructors)
+    {
+        {
+            cstring_span<> span = "Hello";
+
+            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar1[] = "Hello";
+            const char ar2[10] = "Hello";
+            const char* ptr = "Hello";
+            const std::string str = "Hello";
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+
+            // comparison to  literal
+            CHECK(span == cstring_span<>("Hello"));
+
+            // comparison to static array with no null termination
+            CHECK(span == cstring_span<>(ar)); 
+
+            // comparison to static array with null at the end
+            CHECK(span == cstring_span<>(ar1));
+
+            // comparison to static array with null in the middle
+            CHECK(span == cstring_span<>(ar2)); 
+
+            // comparison to null-terminated c string
+            CHECK(span == cstring_span<>(ptr, 5)); 
+
+            // comparison to string
+            CHECK(span == cstring_span<>(str)); 
+
+            // comparison to vector of charaters with no null termination
+            CHECK(span == cstring_span<>(vec)); 
+
+            // comparison of the original data to string
+            CHECK(span.data() == std::string("Hello"));
+
+            CHECK(span == "Hello");
+            CHECK(span == ar);
+            CHECK(span == ar1);
+            CHECK(span == ar2);
+            CHECK(span == ptr);
+            CHECK(span == str);
+            CHECK(span == vec);
+            
+            char _ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char _ar1[] = "Hello";
+            char _ar2[10] = "Hello";
+            char* _ptr = _ar1;
+            std::string _str = "Hello";
+            std::vector<char> _vec = { 'H', 'e', 'l', 'l', 'o' };
+
+            CHECK(span == _ar);
+            CHECK(span == _ar1);
+            CHECK(span == _ar2);
+            CHECK(span == _ptr);
+            CHECK(span == _str);
+            CHECK(span == _vec);
+
+            string_span<> _span{ _ptr };
+
+            CHECK(_span == _ar);
+            CHECK(_span == _ar1);
+            CHECK(_span == _ar2);
+            CHECK(_span == _ptr);
+            CHECK(_span == _str);
+            CHECK(_span == _vec);
+
+            CHECK(_span == "Hello");
+            CHECK(_span == ar);
+            CHECK(_span == ar1);
+            CHECK(_span == ar2);
+            CHECK(_span == ptr);
+            CHECK(_span == str);
+            CHECK(_span == vec);
+        }
+
+        {
+            std::vector<char> str1 = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> span1 = str1;
+            std::vector<char> str2 = std::move(str1);
+            cstring_span<> span2 = str2;
+
+            // comparison of spans from the same vector before and after move (ok)
+            CHECK(span1 == span2);
+        }
+    }
+
+    TEST(EnzureRemoveZ)
+    {
+        // remove z from literals
+        {
+            cstring_span<> sp = "hello";
+            CHECK((sp.length() == 5));
+        }
+
+        // take the string as is
+        {
+            auto str = std::string("hello");
+            cstring_span<> sp = str;
+            CHECK((sp.length() == 5));
+        }
+
+        // ensure z on c strings
+        {
+            char* ptr = new char[3];
+
+            ptr[0] = 'a';
+            ptr[1] = 'b';
+            ptr[2] = '\0';
+
+            string_span<> span(ptr);
+            CHECK(span.length() == 2);
+
+            delete[] ptr;
+        }
+
+        // ensuze z on c strings
+        {
+            char* ptr = new char[2];
+
+            ptr[0] = 'a';
+            ptr[1] = 'b';
+
+            // do we want to have a constructor from pointer at all?
+            // the behavior is unpredictable if the string is not 0-terminated
+
+            // CHECK_THROW((string_span<>(ptr).length() == 2), fail_fast);
+
+            cstring_span<> sp1{ ptr, 2 }; // good
+            cstring_span<> sp2{ ptr, 3 }; // bad... but can't help there
+
+            CHECK(sp1[1] == 'b');
+            CHECK_THROW((sp1[2] == 'c'), fail_fast);
+
+            CHECK(sp2[1] == 'b');
+            //CHECK_THROW((sp1[2] == 'c'), fail_fast); // buffer overflow
+
+            delete[] ptr;
+        }
+    }
+
+    TEST(Constructors)
+    {
+        // from string temporary
+#ifdef CONFIRM_COMPILATION_ERRORS
+        {
+            cstring_span<> span = std::string("Hello");
+        }
+#endif
+
+        // from string literal
+        {
+            cstring_span<> span = "Hello";
+            CHECK(span.length() == 5);
+        }
+
+        // from const static array
+        {
+            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> span = ar;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const static array
+        {
+            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> span = ar;
+            CHECK(span.length() == 5);
+        }
+
+        // from const ptr and length
+        {
+            const char* ptr = "Hello";
+            cstring_span<> span{ ptr, 5 };
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const ptr and length
+        {
+            char* ptr = "Hello";
+            cstring_span<> span{ ptr, 5 };
+            CHECK(span.length() == 5);
+        }
+
+        // from const string
+        {
+            const std::string str = "Hello";
+            cstring_span<> span = str;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const string
+        {
+            std::string str = "Hello";
+            cstring_span<> span = str;
+            CHECK(span.length() == 5);
+        }
+
+        // from const vector
+        {
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> span = vec;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const vector
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> span = vec;
+            CHECK(span.length() == 5);
+        }
+
+        // from const span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const span<const char> inner = vec;
+            cstring_span<> span = inner;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            span<char> inner = vec;
+            cstring_span<> span = inner;
+            CHECK(span.length() == 5);
+        }
+
+        // from const string_span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> tmp = vec;
+            cstring_span<> span = tmp;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const string_span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> tmp = vec;
+            cstring_span<> span = tmp;
+            CHECK(span.length() == 5);
+        }
+
+        ///////////////////////////////////////////////////
+        // How string_span should behave with const data
+
+        // from string literal
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            string_span<> span = "Hello";
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from const static array
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = ar;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const static array
+        {
+            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = ar;
+            CHECK(span.length() == 5);
+        }
+
+        // from const ptr and length
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const char* ptr = "Hello";
+            string_span<> span{ ptr, 5 };
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const ptr and length
+        {
+            char* ptr = "Hello";
+            string_span<> span{ ptr, 5 };
+            CHECK(span.length() == 5);
+        }
+
+        // from const string
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const std::string str = "Hello";
+            string_span<> span = str;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const string
+        {
+            std::string str = "Hello";
+            string_span<> span = str;
+            CHECK(span.length() == 5);
+        }
+
+        // from const vector
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = vec;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const vector
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = vec;
+            CHECK(span.length() == 5);
+        }
+
+        // from const span
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const span<const char> inner = vec;
+            string_span<> span = inner;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            span<char> inner = vec;
+            string_span<> span = inner;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const span of non-const data from const vector (looks like a bug)
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const span<char> inner = vec; // fix error (happens inside the constructor)
+            string_span<> span = inner;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from const string_span
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            cstring_span<> tmp = vec;
+            string_span<> span = tmp;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from non-const string_span
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> tmp = vec;
+            string_span<> span = tmp;
+            CHECK(span.length() == 5);
+        }
+
+        // from non-const string_span from const vector
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> tmp = vec;
+            string_span<> span = tmp;
+            CHECK(span.length() == 5);
+#endif
+        }
+
+        // from const string_span of non-const data
+        {
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const string_span<> tmp = vec; // what does "const span" mean?
+            string_span<> span = tmp;
+            CHECK(span.length() == 5);
+        }
+    }
+
 }
 
 int main(int, const char *[])

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -248,7 +248,7 @@ SUITE(string_span_tests)
             cstring_span<> sp2{ ptr, 3 }; // bad... but can't help there
 
             CHECK(sp1[1] == 'b');
-            CHECK_THROW((sp1[2] == 'c'), fail_fast);
+            CHECK_THROW((void)(sp1[2] == 'c'), fail_fast);
 
             CHECK(sp2[1] == 'b');
             //CHECK_THROW((sp1[2] == 'c'), fail_fast); // buffer overflow
@@ -295,9 +295,12 @@ SUITE(string_span_tests)
 
         // from non-const ptr and length
         {
+            // does not compile with GCC (ISO standard does not allow converting string literals to char*)
+#ifdef CONFIRM_COMPILATION_ERRORS
             char* ptr = "Hello";
             cstring_span<> span{ ptr, 5 };
             CHECK(span.length() == 5);
+#endif
         }
 
         // from const string
@@ -398,9 +401,12 @@ SUITE(string_span_tests)
 
         // from non-const ptr and length
         {
+            // does not compile with GCC (ISO standard does not allows converting string literals to char*)
+#ifdef CONFIRM_COMPILATION_ERRORS
             char* ptr = "Hello";
             string_span<> span{ ptr, 5 };
             CHECK(span.length() == 5);
+#endif
         }
 
         // from const string

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -14,12 +14,10 @@
 // 
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <UnitTest++/UnitTest++.h> 
+#include <UnitTest++/UnitTest++.h>
 #include <string_span.h>
 #include <vector>
 #include <cstdlib>
-#include <map>
-#include <unordered_map>
 
 using namespace std;
 using namespace gsl;
@@ -76,7 +74,7 @@ SUITE(string_span_tests)
             wstring_span<> v = stack_string;
             CHECK(v.length() == 5);
         }
-	}
+    }
 
     TEST(TestConstructFromConstCharPointer)
     {
@@ -89,7 +87,7 @@ SUITE(string_span_tests)
     {
         char stack_string[] = "Hello";
         string_span<> v = ensure_z(stack_string);
-        cstring_span<> v2 = v; 
+        cstring_span<> v2 = v;
         CHECK(v.length() == v2.length());
     }
 
@@ -116,7 +114,7 @@ SUITE(string_span_tests)
         CHECK(s2.length() == 5);
     }
 
-    TEST(ComparisonAndImplicitConstructors)
+    TEST(EqualityAndImplicitConstructors)
     {
         {
             cstring_span<> span = "Hello";
@@ -132,25 +130,60 @@ SUITE(string_span_tests)
             CHECK(span == cstring_span<>("Hello"));
 
             // comparison to static array with no null termination
-            CHECK(span == cstring_span<>(ar)); 
+            CHECK(span == cstring_span<>(ar));
 
             // comparison to static array with null at the end
             CHECK(span == cstring_span<>(ar1));
 
             // comparison to static array with null in the middle
-            CHECK(span == cstring_span<>(ar2)); 
+            CHECK(span == cstring_span<>(ar2));
 
             // comparison to null-terminated c string
-            CHECK(span == cstring_span<>(ptr, 5)); 
+            CHECK(span == cstring_span<>(ptr, 5));
 
             // comparison to string
-            CHECK(span == cstring_span<>(str)); 
+            CHECK(span == cstring_span<>(str));
 
             // comparison to vector of charaters with no null termination
-            CHECK(span == cstring_span<>(vec)); 
+            CHECK(span == cstring_span<>(vec));
 
             // comparison of the original data to string
             CHECK(span.data() == std::string("Hello"));
+        }
+
+        {
+            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+
+            string_span<> span = ar;
+
+            char ar1[] = "Hello";
+            char ar2[10] = "Hello";
+            char* ptr = ar;
+            std::string str = "Hello";
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+
+            // comparison to static array with no null termination
+            CHECK(span == string_span<>(ar));
+
+            // comparison to static array with null at the end
+            CHECK(span == string_span<>(ar1));
+
+            // comparison to static array with null in the middle
+            CHECK(span == string_span<>(ar2));
+
+            // comparison to null-terminated c string
+            CHECK(span == string_span<>(ptr, 5));
+
+            // comparison to string
+            CHECK(span == string_span<>(str));
+
+            // comparison to vector of charaters with no null termination
+            CHECK(span == string_span<>(vec));
+        }
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        {
+            cstring_span<> span = "Hello";
 
             CHECK(span == "Hello");
             CHECK(span == ar);
@@ -159,7 +192,7 @@ SUITE(string_span_tests)
             CHECK(span == ptr);
             CHECK(span == str);
             CHECK(span == vec);
-            
+
             char _ar[] = { 'H', 'e', 'l', 'l', 'o' };
             char _ar1[] = "Hello";
             char _ar2[10] = "Hello";
@@ -191,6 +224,7 @@ SUITE(string_span_tests)
             CHECK(_span == str);
             CHECK(_span == vec);
         }
+#endif
 
         {
             std::vector<char> str1 = { 'H', 'e', 'l', 'l', 'o' };
@@ -203,6 +237,78 @@ SUITE(string_span_tests)
         }
     }
 
+
+    TEST(ComparisonAndImplicitConstructors)
+    {
+        {
+            cstring_span<> span = "Hello";
+
+            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar1[] = "Hello";
+            const char ar2[10] = "Hello";
+            const char* ptr = "Hello";
+            const std::string str = "Hello";
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+
+            // comparison to  literal
+            CHECK(span < cstring_span<>("Helloo"));
+            CHECK(span > cstring_span<>("Hell"));
+
+            // comparison to static array with no null termination
+            CHECK(span >= cstring_span<>(ar));
+
+            // comparison to static array with null at the end
+            CHECK(span <= cstring_span<>(ar1));
+
+            // comparison to static array with null in the middle
+            CHECK(span >= cstring_span<>(ar2));
+
+            // comparison to null-terminated c string
+            CHECK(span <= cstring_span<>(ptr, 5));
+
+            // comparison to string
+            CHECK(span >= cstring_span<>(str));
+
+            // comparison to vector of charaters with no null termination
+            CHECK(span <= cstring_span<>(vec));
+        }
+
+        {
+            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+
+            string_span<> span = ar;
+
+            char larr[] = "Hell";
+            char rarr[] = "Helloo";
+
+            char ar1[] = "Hello";
+            char ar2[10] = "Hello";
+            char* ptr = ar;
+            std::string str = "Hello";
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+
+
+            // comparison to static array with no null termination
+            CHECK(span <= string_span<>(ar));
+            CHECK(span < string_span<>(rarr));
+            CHECK(span > string_span<>(larr));
+
+            // comparison to static array with null at the end
+            CHECK(span >= string_span<>(ar1));
+
+            // comparison to static array with null in the middle
+            CHECK(span <= string_span<>(ar2));
+
+            // comparison to null-terminated c string
+            CHECK(span >= string_span<>(ptr, 5));
+
+            // comparison to string
+            CHECK(span <= string_span<>(str));
+
+            // comparison to vector of charaters with no null termination
+            CHECK(span >= string_span<>(vec));
+        }
+    }
     TEST(EnzureRemoveZ)
     {
         // remove z from literals
@@ -226,32 +332,8 @@ SUITE(string_span_tests)
             ptr[1] = 'b';
             ptr[2] = '\0';
 
-            string_span<> span(ptr);
+            string_span<> span = ensure_z(ptr);
             CHECK(span.length() == 2);
-
-            delete[] ptr;
-        }
-
-        // ensuze z on c strings
-        {
-            char* ptr = new char[2];
-
-            ptr[0] = 'a';
-            ptr[1] = 'b';
-
-            // do we want to have a constructor from pointer at all?
-            // the behavior is unpredictable if the string is not 0-terminated
-
-            // CHECK_THROW((string_span<>(ptr).length() == 2), fail_fast);
-
-            cstring_span<> sp1{ ptr, 2 }; // good
-            cstring_span<> sp2{ ptr, 3 }; // bad... but can't help there
-
-            CHECK(sp1[1] == 'b');
-            CHECK_THROW((void)(sp1[2] == 'c'), fail_fast);
-
-            CHECK(sp2[1] == 'b');
-            //CHECK_THROW((sp1[2] == 'c'), fail_fast); // buffer overflow
 
             delete[] ptr;
         }
@@ -259,6 +341,8 @@ SUITE(string_span_tests)
 
     TEST(Constructors)
     {
+        // creating cstring_span
+
         // from string temporary
 #ifdef CONFIRM_COMPILATION_ERRORS
         {
@@ -363,14 +447,12 @@ SUITE(string_span_tests)
             CHECK(span.length() == 5);
         }
 
-        ///////////////////////////////////////////////////
-        // How string_span should behave with const data
+        // creating string_span
 
         // from string literal
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             string_span<> span = "Hello";
-            CHECK(span.length() == 5);
 #endif
         }
 
@@ -401,12 +483,10 @@ SUITE(string_span_tests)
 
         // from non-const ptr and length
         {
-            // does not compile with GCC (ISO standard does not allows converting string literals to char*)
-#ifdef CONFIRM_COMPILATION_ERRORS
-            char* ptr = "Hello";
+            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char* ptr = ar;
             string_span<> span{ ptr, 5 };
             CHECK(span.length() == 5);
-#endif
         }
 
         // from const string
@@ -459,11 +539,11 @@ SUITE(string_span_tests)
             CHECK(span.length() == 5);
         }
 
-        // from non-const span of non-const data from const vector (looks like a bug)
+        // from non-const span of non-const data from const vector
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            const span<char> inner = vec; // fix error (happens inside the constructor)
+            const span<char> inner = vec;
             string_span<> span = inner;
             CHECK(span.length() == 5);
 #endif
@@ -500,12 +580,106 @@ SUITE(string_span_tests)
         // from const string_span of non-const data
         {
             std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            const string_span<> tmp = vec; // what does "const span" mean?
+            const string_span<> tmp = vec;
             string_span<> span = tmp;
             CHECK(span.length() == 5);
         }
     }
 
+    template<typename T>
+    T move_wrapper(T&& t)
+    {
+        return std::move(t);
+    }
+
+    template <class T>
+    T create() { return T{}; }
+
+    template <class T>
+    void use(basic_string_span<T, gsl::dynamic_range> s) {}
+
+    TEST(MoveConstructors)
+    {
+        // move string_span
+        {
+            cstring_span<> span = "Hello";
+            auto span1 = std::move(span);
+            CHECK(span1.length() == 5);
+        }
+        {
+            cstring_span<> span = "Hello";
+            auto span1 = move_wrapper(std::move(span));
+            CHECK(span1.length() == 5);
+        }
+        {
+            cstring_span<> span = "Hello";
+            auto span1 = move_wrapper(std::move(span));
+            CHECK(span1.length() == 5);
+        }
+
+        // move span
+        {
+            span<const char> span = ensure_z("Hello");
+            cstring_span<> span1 = std::move(span);
+            CHECK(span1.length() == 5);
+        }
+        {
+            span<const char> span = ensure_z("Hello");
+            cstring_span<> span2 = move_wrapper(std::move(span));
+            CHECK(span2.length() == 5);
+        }
+
+        // move string
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::string str = "Hello";
+            string_span<> span = std::move(str);
+            CHECK(span.length() == 5);
+#endif
+        }
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::string str = "Hello";
+            string_span<> span = move_wrapper<std::string>(std::move(str));
+            CHECK(span.length() == 5);
+#endif
+        }
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            use<char>(create<string>());
+#endif
+        }
+
+        // move container
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = std::move(vec);
+            CHECK(span.length() == 5);
+#endif
+        }
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            string_span<> span = move_wrapper<std::vector<char>>(std::move(vec));
+            CHECK(span.length() == 5);
+#endif
+        }
+        {
+#ifdef CONFIRM_COMPILATION_ERRORS
+            use<char>(create<std::vector<char>>());
+#endif
+        }
+    }
+
+    TEST(Conversion)
+    {
+#ifdef CONFIRM_COMPPILATION_ERRORS
+        cstring_span<> span = "Hello";
+        cwstring_span<> wspan{ span };
+        CHECK(wspan.length() == 5);
+#endif
+    }
 }
 
 int main(int, const char *[])

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -1,18 +1,19 @@
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
 ///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
 
 #include <UnitTest++/UnitTest++.h>
 #include <string_span.h>


### PR DESCRIPTION
Rewrote string_span as a separate class, changed handling of 0-teminated strings to ensure we do not include a 0 in the span, unless it was included in the length of the original collection the span is created from.  Added tests.