### PR TITLE
VS2013: macro max, move ctors, pragma warning

### DIFF
--- a/include/span.h
+++ b/include/span.h
@@ -45,6 +45,12 @@
 #pragma push_macro("constexpr")
 #define constexpr
 
+// On Windows, if NOMINMAX is not defined, then windows.h defines the macro max
+#ifdef _WIN32
+#pragma push_macro("max")
+#define max max
+#endif
+
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
 
@@ -2195,6 +2201,11 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 
 #undef constexpr
 #pragma pop_macro("constexpr")
+
+#ifdef _WIN32
+#undef max
+#pragma pop_macro("max")
+#endif
 
 #if _MSC_VER <= 1800
 #pragma warning(pop)

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -235,13 +235,28 @@ public:
     constexpr basic_string_span(const basic_string_span& other) = default;
 
     // move
+#ifdef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+    constexpr basic_string_span(basic_string_span&& other)
+		: span_(std::move(other.span_))
+	{
+	}
+#else
     constexpr basic_string_span(basic_string_span&& other) = default;
+#endif
 
     // assign
     constexpr basic_string_span& operator=(const basic_string_span& other) = default;
 
     // move assign
+#ifdef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+    constexpr basic_string_span& operator=(basic_string_span&& other)
+	{
+		span_ = std::move(other.span_);
+		return *this;
+	}
+#else
     constexpr basic_string_span& operator=(basic_string_span&& other) = default;
+#endif
 
     // from nullptr and length
     constexpr basic_string_span(std::nullptr_t ptr, size_type length) noexcept
@@ -560,8 +575,6 @@ bool operator>=(const gsl::basic_string_span<CharT, Extent>& one, const gsl::bas
 #pragma pop_macro("constexpr")
 
 #if _MSC_VER <= 1800
-
-#pragma warning(pop)
 
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #undef noexcept


### PR DESCRIPTION

Hi,

I had some small issues when using GSL with VS2013. Maybe, you would like to integrate some of my fixes back in your code.
- First, the macro max defined by Windows.h conflicts with std::max, so I temporarily undefined max in span.h, so that it works for windows users even if NOMINMAX is not defined.
- Second, with VS2013, the move constructors cannot be defaulted so I had to implement them for string_span.
- Third, with VS2013, there is a pragma warning pop without any corresponding pragma warning push in string_span.h

Finally, I have some trouble compiling the unit tests for string_span with VS2013. There is an ICE because of the constructor of string_span taking a span. I am trying to work around it but I don't have a good workaroung yet.

Regards
