### PR TITLE
Vs2013 fix string span ctors

### DIFF
--- a/include/span.h
+++ b/include/span.h
@@ -45,6 +45,12 @@
 #pragma push_macro("constexpr")
 #define constexpr
 
+// On Windows, if NOMINMAX is not defined, then windows.h defines the macro max
+#ifdef _WIN32
+#pragma push_macro("max")
+#define max max
+#endif
+
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
 
@@ -2195,6 +2201,11 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 
 #undef constexpr
 #pragma pop_macro("constexpr")
+
+#ifdef _WIN32
+#undef max
+#pragma pop_macro("max")
+#endif
 
 #if _MSC_VER <= 1800
 #pragma warning(pop)

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -34,6 +34,7 @@
 #if _MSC_VER <= 1800
 
 #define GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
+#define GSL_MSVC2013_ICE_WHEN_USING_DUMMY_TEMPLATE_PARAMETER
 
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
@@ -283,6 +284,74 @@ public:
         : span_(&(s.at(0)), narrow_cast<std::ptrdiff_t>(s.length()))
     {}
 
+#ifdef GSL_MSVC2013_ICE_WHEN_USING_DUMMY_TEMPLATE_PARAMETER
+    template<
+        typename Cont,
+        typename DataType = typename Cont::value_type
+    >
+    constexpr basic_string_span(
+        Cont& cont,
+        std::enable_if_t<
+            !details::is_span<Cont>::value
+            && !details::is_basic_string_span<Cont>::value
+            && !(!std::is_const<value_type>::value && std::is_const<Cont>::value)
+            && std::is_convertible<DataType*, value_type*>::value
+            && std::is_same<std::decay_t<decltype(std::declval<Cont>().size(), *std::declval<Cont>().data())>, DataType>::value
+        >* = nullptr
+        )
+    : span_(cont.data(), cont.size())
+    {}
+
+    // disallow creation from temporary containers and strings
+    template<
+        typename Cont,
+        typename DataType = typename Cont::value_type
+    >
+    explicit basic_string_span(
+        Cont&& cont
+        ,
+        std::enable_if_t<
+            !details::is_span<Cont>::value
+            && !details::is_basic_string_span<Cont>::value
+            && std::is_convertible<DataType*, value_type*>::value
+            && std::is_same<std::decay_t<decltype(std::declval<Cont>().size(), *std::declval<Cont>().data())>, DataType>::value
+        >* = nullptr
+        ) = delete;
+
+    // from span
+    template<
+        typename OtherValueType,
+        std::ptrdiff_t... OtherDimensions,
+        typename OtherBounds = static_bounds<OtherDimensions...>
+    >
+    constexpr basic_string_span(
+        span<OtherValueType, OtherDimensions...> other,
+        typename std::enable_if<
+            std::is_convertible<OtherValueType, value_type>::value &&
+            std::is_convertible<OtherBounds, bounds_type>::value
+            >::type* = nullptr
+    ) noexcept
+        : span_(other)
+    {}
+
+    // from string_span
+    template<
+        typename OtherValueType,
+        std::ptrdiff_t OtherExtent,
+        typename OtherBounds = static_bounds<OtherExtent>
+    >
+    constexpr basic_string_span(
+        basic_string_span<OtherValueType, OtherExtent> other,
+        std::enable_if_t<
+            std::is_convertible<OtherValueType*, value_type*>::value
+            && std::is_convertible<OtherBounds, bounds_type>::value
+        >* = nullptr
+        ) noexcept
+        : span_(other.data(), other.length())
+    {}
+
+#else // GSL_MSVC2013_ICE_WHEN_USING_DUMMY_TEMPLATE_PARAMETER
+
     // from containers. Containers must have .size() and .data() function signatures
     template <typename Cont, typename DataType = typename Cont::value_type,
         typename Dummy = std::enable_if_t<!details::is_span<Cont>::value
@@ -321,6 +390,7 @@ public:
     constexpr basic_string_span(basic_string_span<OtherValueType, OtherExtent> other) noexcept
         : span_(other.data(), other.length())
     {}
+#endif // GSL_MSVC2013_ICE_WHEN_USING_DUMMY_TEMPLATE_PARAMETER
 
     constexpr bool empty() const noexcept
     {
@@ -581,6 +651,7 @@ bool operator>=(const gsl::basic_string_span<CharT, Extent>& one, const gsl::bas
 #pragma pop_macro("noexcept")
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
+#undef GSL_MSVC2013_ICE_WHEN_USING_DUMMY_TEMPLATE_PARAMETER
 #undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
 
 #endif // _MSC_VER <= 1800

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -235,13 +235,28 @@ public:
     constexpr basic_string_span(const basic_string_span& other) = default;
 
     // move
+#ifdef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+    constexpr basic_string_span(basic_string_span&& other)
+		: span_(std::move(other.span_))
+	{
+	}
+#else
     constexpr basic_string_span(basic_string_span&& other) = default;
+#endif
 
     // assign
     constexpr basic_string_span& operator=(const basic_string_span& other) = default;
 
     // move assign
+#ifdef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+    constexpr basic_string_span& operator=(basic_string_span&& other)
+	{
+		span_ = std::move(other.span_);
+		return *this;
+	}
+#else
     constexpr basic_string_span& operator=(basic_string_span&& other) = default;
+#endif
 
     // from nullptr and length
     constexpr basic_string_span(std::nullptr_t ptr, size_type length) noexcept
@@ -560,8 +575,6 @@ bool operator>=(const gsl::basic_string_span<CharT, Extent>& one, const gsl::bas
 #pragma pop_macro("constexpr")
 
 #if _MSC_VER <= 1800
-
-#pragma warning(pop)
 
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #undef noexcept


### PR DESCRIPTION
Hi,
I fixed an ICE when using the string_span ctors that have a dummy defaulted template type parameter used for SFINAE.
I replaced the template type parameter by a function parameter.

Warning : I am not an expert of std::enable_if, so I may have introduced some mistakes.

Note : I checked again that I have VS2013 U5, but maybe my installation is buggy and the ICE is due to that. In this case feel free to ignore my pull request :-)