### PR TITLE
Combine a few rendunant functions per TODO comment

### DIFF
--- a/include/string_span.h
+++ b/include/string_span.h
@@ -90,7 +90,7 @@ using wzstring = wchar_t*;
 template <typename T, T Sentinel>
 span<T, dynamic_range> ensure_sentinel(T const* const seq, ptrdiff_t const max = PTRDIFF_MAX)
 {
-    auto const it = std::find(seq, seq + max, Sentinal);
+    auto const it = std::find(seq, seq + max, Sentinel);
     Ensures(*it == Sentinel);
     return{ seq, it - seq };
 }
@@ -108,7 +108,7 @@ namespace details
     }
 
     template <typename T, typename U = std::remove_cv_t<T>>
-    using is_char_t = std::bool_constant<
+    using is_char_t = std::integral_constant<bool,
         std::is_same<char, U>::value || std::is_same<wchar_t, U>::value>;
 
     template <typename T, typename U = std::remove_pointer_t<T>>

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -66,7 +66,6 @@ SUITE(string_span_tests)
     TEST(TestConstructFromStdArray)
     {
         std::array<char, 5> arr {"1234"};
-        auto const size = static_cast<cstring_span<>::size_type>(arr.size());
 
         string_span<> v = arr;
         CHECK(v.length() == 5);

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -40,15 +40,39 @@ SUITE(string_span_tests)
     TEST(TestConstructFromStdString)
     {
         std::string s = "Hello there world";
+        auto const len = static_cast<cstring_span<>::size_type>(s.length());
+
         cstring_span<> v = s;
-        CHECK(v.length() == static_cast<cstring_span<>::size_type>(s.length()));
+        CHECK(v.length() == len);
+
+        s.back() = 0;
+        v = ensure_z(s);
+        CHECK(v.length() == len - 1);
     }
 
     TEST(TestConstructFromStdVector)
     {
         std::vector<char> vec(5, 'h');
+        auto const size = static_cast<cstring_span<>::size_type>(vec.size());
+
         string_span<> v = vec;
-        CHECK(v.length() == static_cast<string_span<>::size_type>(vec.size()));
+        CHECK(v.length() == size);
+
+        vec.back() = 0;
+        v = ensure_z(vec);
+        CHECK(v.length() == size - 1);
+    }
+
+    TEST(TestConstructFromStdArray)
+    {
+        std::array<char, 5> arr {"1234"};
+        auto const size = static_cast<cstring_span<>::size_type>(arr.size());
+
+        string_span<> v = arr;
+        CHECK(v.length() == 5);
+
+        v = ensure_z(arr);
+        CHECK(v.length() == 4);
     }
 
     TEST(TestStackArrayConstruction)
@@ -264,7 +288,7 @@ SUITE(string_span_tests)
             string_span<> _span{ _ptr, 5 };
 
             // non-const span, non-const other type
-            
+
             CHECK(_span == _ar);
             CHECK(_span == _ar1);
             CHECK(_span == _ar2);


### PR DESCRIPTION
Noticed a TODO in `string_span.h` when I was playing around with gsl and decided to make a small contribution:

+ Per TODO (neilmac), merged the `ensure_z` implementations.
+ Simplified `details::length_func`.
+ Use `std::find` rather than a naked loop for `ensure_sentinel`.
+ Removed a few instances of trailing whitespace.
+ Added a few new tests for the container version of `ensure_z`, and changed it to use `Cont::size` rather than `length`.
+ Used unqualified `size_t` and `ptrdiff_t` as they are synonyms for the `std::` versions; is there any specific reason the `std::` names were being used explicitly?