### PR TITLE
Fix missing #include <string> in string_span.h

### DIFF
--- a/include/string_span.h
+++ b/include/string_span.h
@@ -23,6 +23,7 @@
 #include "gsl_util.h"
 #include "span.h"
 #include <cstring>
+#include <string>
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION

`string_span.h` uses `std::string`, but `<string>` is not included.