### PR TITLE
Follow standard-rules for macros

### DIFF
--- a/include/gsl.h
+++ b/include/gsl.h
@@ -19,7 +19,7 @@
 #ifndef GSL_GSL_H
 #define GSL_GSL_H
 
-#include "gsl_assert.h"  // Ensures/Expects
+#include "gsl_assert.h"  // GSL_ENSURES/GSL_EXPECTS
 #include "gsl_util.h"    // finally()/narrow()/narrow_cast()...
 #include "span.h"           // span, strided_span...
 #include "string_span.h"    // zstring, string_span, zstring_builder...
@@ -120,7 +120,7 @@ private:
 
     // we assume that the compiler can hoist/prove away most of the checks inlined from this function
     // if not, we could make them optional via conditional compilation
-    void ensure_invariant() const { Expects(ptr_ != nullptr); }
+    void ensure_invariant() const { GSL_EXPECTS(ptr_ != nullptr); }
 
     // unwanted operators...pointers only point to single objects!
     // TODO ensure all arithmetic ops on this type are unavailable

--- a/include/gsl.h
+++ b/include/gsl.h
@@ -25,17 +25,20 @@
 #include "string_span.h"    // zstring, string_span, zstring_builder...
 #include <memory>
 
+#define GSL_IMPL_CONSTEXPR constexpr
+#define GSL_IMPL_NOEXCEPT noexcept
+
 #ifdef _MSC_VER
 
 // No MSVC does constexpr fully yet
-#pragma push_macro("constexpr")
-#define constexpr 
+#undef GSL_IMPL_CONSTEXPR
+#define GSL_IMPL_CONSTEXPR
 
 // MSVC 2013 workarounds
 #if _MSC_VER <= 1800
-// noexcept is not understood 
-#pragma push_macro("noexcept")
-#define noexcept  
+// noexcept is not understood
+#undef GSL_IMPL_NOEXCEPT
+#define GSL_IMPL_NOEXCEPT
 
 // turn off some misguided warnings
 #pragma warning(push)
@@ -149,20 +152,12 @@ namespace std
 
 } // namespace std
 
-#ifdef _MSC_VER
 
-#undef constexpr
-#pragma pop_macro("constexpr")
+#undef GSL_IMPL_CONSTEXPR
+#undef GSL_IMPL_NOEXCEPT
 
-#if _MSC_VER <= 1800
-
-#undef noexcept
-#pragma pop_macro("noexcept")
- 
+#if defined(_MSC_VER) and (_MSC_VER <= 1800)
 #pragma warning(pop)
-
 #endif // _MSC_VER <= 1800
-
-#endif // _MSC_VER
 
 #endif // GSL_GSL_H

--- a/include/gsl_assert.h
+++ b/include/gsl_assert.h
@@ -54,25 +54,38 @@ struct fail_fast : public std::runtime_error
 };
 }
 
-#define Expects(cond)  if (!(cond)) \
+#define GSL_EXPECTS(cond)  if (!(cond)) \
     throw gsl::fail_fast("GSL: Precondition failure at " __FILE__ ": " GSL_STRINGIFY(__LINE__));
-#define Ensures(cond)  if (!(cond)) \
+#define GSL_ENSURES(cond)  if (!(cond)) \
     throw gsl::fail_fast("GSL: Postcondition failure at " __FILE__ ": " GSL_STRINGIFY(__LINE__));
 
 
 #elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
 
-#define Expects(cond)           if (!(cond)) std::terminate(); 
-#define Ensures(cond)           if (!(cond)) std::terminate();
+#define GSL_EXPECTS(cond)           if (!(cond)) std::terminate(); 
+#define GSL_ENSURES(cond)           if (!(cond)) std::terminate();
 
 
 #elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
 
-#define Expects(cond)           
-#define Ensures(cond)           
+#define GSL_EXPECTS(cond)           
+#define GSL_ENSURES(cond)           
 
 #endif 
 
+// Keep the global macro-namespace clean by default,
+// but offer the dirty solution as well:
+#if defined(GSL_USE_UNPREFIXED_CONTRACTS)
+#define EXPECTS(cond) GSL_EXPECTS(cond)
+#define ENSURES(cond) GSL_ENSURES(cond)
+#endif
+
+// For those who like to live dangerous,
+// offer macros that are not ALL_CAPS:
+#if defined(GSL_USE_UNPREFIXED_AND_LOWERCASE_CONTRACTS)
+#define Expects(cond) GSL_EXPECTS(cond)
+#define Ensures(cond) GSL_ENSURES(cond)
+#endif
 
 #endif // GSL_CONTRACTS_H

--- a/include/gsl_util.h
+++ b/include/gsl_util.h
@@ -19,7 +19,7 @@
 #ifndef GSL_UTIL_H
 #define GSL_UTIL_H
 
-#include "gsl_assert.h"  // Ensures/Expects
+#include "gsl_assert.h"  // GSL_ENSURES/GSL_EXPECTS
 #include <array>
 #include <utility>
 #include <exception>
@@ -100,15 +100,15 @@ inline T narrow(U u)
 //
 template <class T, size_t N> 
 constexpr T& at(T(&arr)[N], size_t index)
-{ Expects(index < N); return arr[index]; }
+{ GSL_EXPECTS(index < N); return arr[index]; }
 
 template <class T, size_t N>
 constexpr T& at(std::array<T, N>& arr, size_t index)
-{ Expects(index < N); return arr[index]; }
+{ GSL_EXPECTS(index < N); return arr[index]; }
 
 template <class Cont>
 constexpr typename Cont::value_type& at(Cont& cont, size_t index)
-{ Expects(index < cont.size()); return cont[index]; }
+{ GSL_EXPECTS(index < cont.size()); return cont[index]; }
 
 } // namespace gsl
 

--- a/include/span.h
+++ b/include/span.h
@@ -37,7 +37,7 @@
 
 #ifdef _MSC_VER
 
-// turn off some warnings that are noisy about our Expects statements
+// turn off some warnings that are noisy about our GSL_EXPECTS statements
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
 
@@ -149,14 +149,14 @@ public:
     // Preconditions: component_idx < rank
     constexpr reference operator[](size_t component_idx)
     {
-        Expects(component_idx < Rank); // Component index must be less than rank
+        GSL_EXPECTS(component_idx < Rank); // Component index must be less than rank
         return elems[component_idx];
     }
 
     // Preconditions: component_idx < rank
     constexpr const_reference operator[](size_t component_idx) const noexcept
     {
-        Expects(component_idx < Rank); // Component index must be less than rank
+        GSL_EXPECTS(component_idx < Rank); // Component index must be less than rank
         return elems[component_idx];
     }
 
@@ -355,7 +355,7 @@ namespace details
         BoundsRanges(const std::ptrdiff_t* const arr)
             : Base(arr + 1), m_bound(*arr * this->Base::totalSize())
         {
-            Expects(0 <= *arr);
+            GSL_EXPECTS(0 <= *arr);
         }
 
         BoundsRanges() : m_bound(0) {}
@@ -379,7 +379,7 @@ namespace details
         size_type linearize(const T& arr) const
         {
             const size_type index = this->Base::totalSize() * arr[Dim];
-            Expects(index < m_bound);
+            GSL_EXPECTS(index < m_bound);
             return index + this->Base::template linearize<T, Dim + 1>(arr);
         }
 
@@ -445,7 +445,7 @@ namespace details
         template <typename T, size_t Dim = 0>
         size_type linearize(const T& arr) const
         {
-            Expects(arr[Dim] < CurrentRange); // Index is out of range
+            GSL_EXPECTS(arr[Dim] < CurrentRange); // Index is out of range
             return this->Base::totalSize() * arr[Dim] +
                    this->Base::template linearize<T, Dim + 1>(arr);
         }
@@ -619,7 +619,7 @@ public:
                   details::BoundsRanges<FirstRange, RestRanges...>>::value>>
     constexpr static_bounds(const static_bounds<Ranges...>& other) : m_ranges(other.m_ranges)
     {
-        Expects((MyRanges::DynamicNum == 0 && details::BoundsRanges<Ranges...>::DynamicNum == 0) ||
+        GSL_EXPECTS((MyRanges::DynamicNum == 0 && details::BoundsRanges<Ranges...>::DynamicNum == 0) ||
                 MyRanges::DynamicNum > 0 || other.m_ranges.totalSize() >= m_ranges.totalSize());
     }
 
@@ -627,10 +627,10 @@ public:
         : m_ranges(static_cast<const std::ptrdiff_t*>(il.begin()))
     {
         // Size of the initializer list must match the rank of the array
-        Expects((MyRanges::DynamicNum == 0 && il.size() == 1 && *il.begin() == static_size) ||
+        GSL_EXPECTS((MyRanges::DynamicNum == 0 && il.size() == 1 && *il.begin() == static_size) ||
                 MyRanges::DynamicNum == il.size());
         // Size of the range must be less than the max element of the size type
-        Expects(m_ranges.totalSize() <= PTRDIFF_MAX);
+        GSL_EXPECTS(m_ranges.totalSize() <= PTRDIFF_MAX);
     }
 
     constexpr static_bounds() = default;
@@ -678,7 +678,7 @@ public:
         static_assert(std::is_integral<IntType>::value,
                       "Dimension parameter must be supplied as an integral type.");
         auto real_dim = narrow_cast<size_t>(dim);
-        Expects(real_dim < rank);
+        GSL_EXPECTS(real_dim < rank);
 
         return m_ranges.elementNum(real_dim);
     }
@@ -779,7 +779,7 @@ public:
     {
         size_type ret = 0;
         for (size_t i = 0; i < rank; i++) {
-            Expects(idx[i] < m_extents[i]); // index is out of bounds of the array
+            GSL_EXPECTS(idx[i] < m_extents[i]); // index is out of bounds of the array
             ret += idx[i] * m_strides[i];
         }
         return ret;
@@ -889,7 +889,7 @@ public:
         }
         // If we're here the preconditions were violated
         // "pre: there exists s such that r == ++s"
-        Expects(false);
+        GSL_EXPECTS(false);
         return *this;
     }
 
@@ -919,7 +919,7 @@ public:
             linear_idx = linear_idx % stride[i];
         }
         // index is out of bounds of the array
-        Expects(!less(curr_, index_type{}) && !less(boundary_, curr_));
+        GSL_EXPECTS(!less(curr_, index_type{}) && !less(boundary_, curr_));
         return *this;
     }
 
@@ -1044,7 +1044,7 @@ namespace details
                           BoundsSrc::static_size == dynamic_range ||
                           BoundsDest::static_size == BoundsSrc::static_size,
                       "The source bounds must have same size as dest bounds");
-        Expects(src.size() == dest.size());
+        GSL_EXPECTS(src.size() == dest.size());
     }
 
 } // namespace details
@@ -1110,13 +1110,13 @@ namespace details
     template <typename BoundsType>
     BoundsType newBoundsHelperImpl(std::ptrdiff_t totalSize, std::true_type) // dynamic size
     {
-        Expects(totalSize >= 0 && totalSize <= PTRDIFF_MAX);
+        GSL_EXPECTS(totalSize >= 0 && totalSize <= PTRDIFF_MAX);
         return BoundsType{totalSize};
     }
     template <typename BoundsType>
     BoundsType newBoundsHelperImpl(std::ptrdiff_t totalSize, std::false_type) // static size
     {
-        Expects(BoundsType::static_size <= totalSize);
+        GSL_EXPECTS(BoundsType::static_size <= totalSize);
         return {};
     }
     template <typename BoundsType>
@@ -1235,7 +1235,7 @@ public:
                           (bounds_type::dynamic_rank == 0 && bounds_type::static_size == 0),
                       "nullptr_t construction of span<T> only possible "
                       "for dynamic or fixed, zero-length spans.");
-        Expects(size == 0);
+        GSL_EXPECTS(size == 0);
     }
 
     // construct from a single element
@@ -1257,7 +1257,7 @@ public:
     constexpr span(pointer data, bounds_type bounds) noexcept : data_(data),
                                                                 bounds_(std::move(bounds))
     {
-        Expects((bounds_.size() > 0 && data != nullptr) || bounds_.size() == 0);
+        GSL_EXPECTS((bounds_.size() > 0 && data != nullptr) || bounds_.size() == 0);
     }
 
     // construct from begin,end pointer pair
@@ -1267,7 +1267,7 @@ public:
     constexpr span(pointer begin, Ptr end)
         : span(begin, details::newBoundsHelper<bounds_type>(static_cast<pointer>(end) - begin))
     {
-        Expects(begin != nullptr && end != nullptr && begin <= static_cast<pointer>(end));
+        GSL_EXPECTS(begin != nullptr && end != nullptr && begin <= static_cast<pointer>(end));
     }
 
     // construct from n-dimensions static array
@@ -1376,14 +1376,14 @@ public:
                           Count <= bounds_type::static_size,
                       "Count is out of bounds.");
 
-        Expects(bounds_type::static_size != dynamic_range || Count <= this->size());
+        GSL_EXPECTS(bounds_type::static_size != dynamic_range || Count <= this->size());
         return {this->data(), Count};
     }
 
     // first() - extract the first count elements into a new span
     constexpr span<ValueType, dynamic_range> first(size_type count) const noexcept
     {
-        Expects(count >= 0 && count <= this->size());
+        GSL_EXPECTS(count >= 0 && count <= this->size());
         return {this->data(), count};
     }
 
@@ -1396,14 +1396,14 @@ public:
                           Count <= bounds_type::static_size,
                       "Count is out of bounds.");
 
-        Expects(bounds_type::static_size != dynamic_range || Count <= this->size());
+        GSL_EXPECTS(bounds_type::static_size != dynamic_range || Count <= this->size());
         return {this->data() + this->size() - Count, Count};
     }
 
     // last() - extract the last count elements into a new span
     constexpr span<ValueType, dynamic_range> last(size_type count) const noexcept
     {
-        Expects(count >= 0 && count <= this->size());
+        GSL_EXPECTS(count >= 0 && count <= this->size());
         return {this->data() + this->size() - count, count};
     }
 
@@ -1418,7 +1418,7 @@ public:
                            Count <= bounds_type::static_size - Offset),
                       "You must describe a sub-range within bounds of the span.");
 
-        Expects(bounds_type::static_size != dynamic_range ||
+        GSL_EXPECTS(bounds_type::static_size != dynamic_range ||
                 (Offset <= this->size() && Count <= this->size() - Offset));
         return {this->data() + Offset, Count};
     }
@@ -1428,7 +1428,7 @@ public:
     constexpr span<ValueType, dynamic_range> subspan(size_type offset,
                                                      size_type count = dynamic_range) const noexcept
     {
-        Expects((offset >= 0 && offset <= this->size()) &&
+        GSL_EXPECTS((offset >= 0 && offset <= this->size()) &&
                 (count == dynamic_range || (count <= this->size() - offset)));
         return {this->data() + offset, count == dynamic_range ? this->length() - offset : count};
     }
@@ -1498,11 +1498,11 @@ public:
     template <bool Enabled = (Rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
     constexpr Ret operator[](size_type idx) const noexcept
     {
-        Expects(idx < bounds_.size()); // index is out of bounds of the array
+        GSL_EXPECTS(idx < bounds_.size()); // index is out of bounds of the array
         const size_type ridx = idx * bounds_.stride();
 
         // index is out of bounds of the underlying data
-        Expects(ridx < bounds_.total_size());
+        GSL_EXPECTS(ridx < bounds_.total_size());
         return Ret{data_ + ridx, bounds_.slice()};
     }
 
@@ -1645,7 +1645,7 @@ constexpr auto as_span(span<const byte, Dimensions...> s) noexcept
              ConstByteSpan::bounds_type::static_size % narrow_cast<std::ptrdiff_t>(sizeof(U)) == 0),
         "Target type must be a trivial type and its size must match the byte array size");
 
-    Expects((s.size_bytes() % sizeof(U)) == 0 && (s.size_bytes() / sizeof(U)) < PTRDIFF_MAX);
+    GSL_EXPECTS((s.size_bytes() % sizeof(U)) == 0 && (s.size_bytes() / sizeof(U)) < PTRDIFF_MAX);
     return {reinterpret_cast<const U*>(s.data()),
             s.size_bytes() / narrow_cast<std::ptrdiff_t>(sizeof(U))};
 }
@@ -1669,7 +1669,7 @@ constexpr auto as_span(span<byte, Dimensions...> s) noexcept -> span<
              ByteSpan::bounds_type::static_size % static_cast<std::size_t>(sizeof(U)) == 0),
         "Target type must be a trivial type and its size must match the byte array size");
 
-    Expects((s.size_bytes() % sizeof(U)) == 0);
+    GSL_EXPECTS((s.size_bytes() % sizeof(U)) == 0);
     return {reinterpret_cast<U*>(s.data()),
             s.size_bytes() / narrow_cast<std::ptrdiff_t>(sizeof(U))};
 }
@@ -1721,7 +1721,7 @@ constexpr auto as_span(Cont& arr) -> std::enable_if_t<
     !details::is_span<std::decay_t<Cont>>::value,
     span<std::remove_reference_t<decltype(arr.size(), *arr.data())>, dynamic_range>>
 {
-    Expects(arr.size() < PTRDIFF_MAX);
+    GSL_EXPECTS(arr.size() < PTRDIFF_MAX);
     return {arr.data(), narrow_cast<std::ptrdiff_t>(arr.size())};
 }
 
@@ -1735,7 +1735,7 @@ template <typename CharT, typename Traits, typename Allocator>
 constexpr auto as_span(std::basic_string<CharT, Traits, Allocator>& str)
     -> span<CharT, dynamic_range>
 {
-    Expects(str.size() < PTRDIFF_MAX);
+    GSL_EXPECTS(str.size() < PTRDIFF_MAX);
     return {&str[0], narrow_cast<std::ptrdiff_t>(str.size())};
 }
 
@@ -1774,9 +1774,9 @@ public:
     constexpr strided_span(pointer ptr, size_type size, bounds_type bounds)
         : data_(ptr), bounds_(std::move(bounds))
     {
-        Expects((bounds_.size() > 0 && ptr != nullptr) || bounds_.size() == 0);
+        GSL_EXPECTS((bounds_.size() > 0 && ptr != nullptr) || bounds_.size() == 0);
         // Bounds cross data boundaries
-        Expects(this->bounds().total_size() <= size);
+        GSL_EXPECTS(this->bounds().total_size() <= size);
         (void) size;
     }
 
@@ -1838,11 +1838,11 @@ public:
     template <bool Enabled = (Rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
     constexpr Ret operator[](size_type idx) const
     {
-        Expects(idx < bounds_.size()); // index is out of bounds of the array
+        GSL_EXPECTS(idx < bounds_.size()); // index is out of bounds of the array
         const size_type ridx = idx * bounds_.stride();
 
         // index is out of bounds of the underlying data
-        Expects(ridx < bounds_.total_size());
+        GSL_EXPECTS(ridx < bounds_.total_size());
         return {data_ + ridx, bounds_.slice().total_size(), bounds_.slice()};
     }
 
@@ -1937,7 +1937,7 @@ private:
     static index_type resize_extent(const index_type& extent, std::ptrdiff_t d)
     {
         // The last dimension of the array needs to contain a multiple of new type elements
-        Expects(extent[Rank - 1] >= d && (extent[Rank - 1] % d == 0));
+        GSL_EXPECTS(extent[Rank - 1] >= d && (extent[Rank - 1] % d == 0));
 
         index_type ret = extent;
         ret[Rank - 1] /= d;
@@ -1949,7 +1949,7 @@ private:
     static index_type resize_stride(const index_type& strides, std::ptrdiff_t, void* = 0)
     {
         // Only strided arrays with regular strides can be resized
-        Expects(strides[Rank - 1] == 1);
+        GSL_EXPECTS(strides[Rank - 1] == 1);
 
         return strides;
     }
@@ -1958,14 +1958,14 @@ private:
     static index_type resize_stride(const index_type& strides, std::ptrdiff_t d)
     {
         // Only strided arrays with regular strides can be resized
-        Expects(strides[Rank - 1] == 1);
+        GSL_EXPECTS(strides[Rank - 1] == 1);
         // The strides must have contiguous chunks of
         // memory that can contain a multiple of new type elements
-        Expects(strides[Rank - 2] >= d && (strides[Rank - 2] % d == 0));
+        GSL_EXPECTS(strides[Rank - 2] >= d && (strides[Rank - 2] % d == 0));
 
         for (size_t i = Rank - 1; i > 0; --i) {
             // Only strided arrays with regular strides can be resized
-            Expects((strides[i - 1] >= strides[i]) && (strides[i - 1] % strides[i] == 0));
+            GSL_EXPECTS((strides[i - 1] >= strides[i]) && (strides[i - 1] % strides[i] == 0));
         }
 
         index_type ret = strides / d;
@@ -1995,7 +1995,7 @@ private:
     void validateThis() const
     {
         // iterator is out of range of the array
-        Expects(data_ >= m_validator->data_ && data_ < m_validator->data_ + m_validator->size());
+        GSL_EXPECTS(data_ >= m_validator->data_ && data_ < m_validator->data_ + m_validator->size());
     }
     contiguous_span_iterator(const Span* container, bool isbegin)
         : data_(isbegin ? container->data_ : container->data_ + container->size())
@@ -2054,19 +2054,19 @@ public:
     contiguous_span_iterator& operator-=(difference_type n) noexcept { return * this += -n; }
     difference_type operator-(const contiguous_span_iterator& rhs) const noexcept
     {
-        Expects(m_validator == rhs.m_validator);
+        GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ - rhs.data_;
     }
     reference operator[](difference_type n) const noexcept { return *(*this + n); }
     bool operator==(const contiguous_span_iterator& rhs) const noexcept
     {
-        Expects(m_validator == rhs.m_validator);
+        GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ == rhs.data_;
     }
     bool operator!=(const contiguous_span_iterator& rhs) const noexcept { return !(*this == rhs); }
     bool operator<(const contiguous_span_iterator& rhs) const noexcept
     {
-        Expects(m_validator == rhs.m_validator);
+        GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ < rhs.data_;
     }
     bool operator<=(const contiguous_span_iterator& rhs) const noexcept { return !(rhs < *this); }
@@ -2153,7 +2153,7 @@ public:
     general_span_iterator& operator-=(difference_type n) noexcept { return * this += -n; }
     difference_type operator-(const general_span_iterator& rhs) const noexcept
     {
-        Expects(m_container == rhs.m_container);
+        GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr - rhs.m_itr;
     }
     value_type operator[](difference_type n) const noexcept
@@ -2163,13 +2163,13 @@ public:
     }
     bool operator==(const general_span_iterator& rhs) const noexcept
     {
-        Expects(m_container == rhs.m_container);
+        GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr == rhs.m_itr;
     }
     bool operator!=(const general_span_iterator& rhs) const noexcept { return !(*this == rhs); }
     bool operator<(const general_span_iterator& rhs) const noexcept
     {
-        Expects(m_container == rhs.m_container);
+        GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr < rhs.m_itr;
     }
     bool operator<=(const general_span_iterator& rhs) const noexcept { return !(rhs < *this); }

--- a/include/span.h
+++ b/include/span.h
@@ -35,6 +35,9 @@
 #include <type_traits>
 #include <utility>
 
+#define GSL_IMPL_CONSTEXPR constexpr
+#define GSL_IMPL_NOEXCEPT noexcept
+
 #ifdef _MSC_VER
 
 // turn off some warnings that are noisy about our GSL_EXPECTS statements
@@ -42,8 +45,8 @@
 #pragma warning(disable : 4127) // conditional expression is constant
 
 // No MSVC does constexpr fully yet
-#pragma push_macro("constexpr")
-#define constexpr
+#undef GSL_IMPL_CONSTEXPR
+#define GSL_IMPL_CONSTEXPR
 
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
@@ -53,8 +56,8 @@
 
 // noexcept is not understood 
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
-#pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#undef GSL_IMPL_NOEXCEPT
+#define GSL_IMPL_NOEXCEPT /* nothing */
 #endif
 
 // turn off some misguided warnings
@@ -68,11 +71,8 @@
 
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
 
-#ifdef _MSC_VER
-#pragma push_macro("noexcept")
-#endif
-
-#define noexcept /* nothing */
+#undef GSL_IMPL_NOEXCEPT
+#define GSL_IMPL_NOEXCEPT /* nothing */
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
@@ -118,9 +118,9 @@ public:
     using reference = std::add_lvalue_reference_t<value_type>;
     using const_reference = std::add_lvalue_reference_t<std::add_const_t<value_type>>;
 
-    constexpr index() noexcept {}
+    GSL_IMPL_CONSTEXPR index() GSL_IMPL_NOEXCEPT {}
 
-    constexpr index(const value_type (&values)[Rank]) noexcept
+    GSL_IMPL_CONSTEXPR index(const value_type (&values)[Rank]) GSL_IMPL_NOEXCEPT
     {
         std::copy(values, values + Rank, elems);
     }
@@ -130,105 +130,105 @@ public:
         typename T, typename... Ts,
         typename = std::enable_if_t<((sizeof...(Ts) + 1) == Rank) && std::is_integral<T>::value &&
                                     details::are_integral<Ts...>::value>>
-    constexpr index(T t, Ts... ds)
+    GSL_IMPL_CONSTEXPR index(T t, Ts... ds)
         : index({narrow_cast<value_type>(t), narrow_cast<value_type>(ds)...})
     {
     }
 #else
     template <typename... Ts, typename = std::enable_if_t<(sizeof...(Ts) == Rank) &&
                                                           details::are_integral<Ts...>::value>>
-    constexpr index(Ts... ds) noexcept : elems{narrow_cast<value_type>(ds)...}
+    GSL_IMPL_CONSTEXPR index(Ts... ds) GSL_IMPL_NOEXCEPT : elems{narrow_cast<value_type>(ds)...}
     {
     }
 #endif
 
-    constexpr index(const index& other) noexcept = default;
+    GSL_IMPL_CONSTEXPR index(const index& other) GSL_IMPL_NOEXCEPT = default;
 
-    constexpr index& operator=(const index& rhs) noexcept = default;
+    GSL_IMPL_CONSTEXPR index& operator=(const index& rhs) GSL_IMPL_NOEXCEPT = default;
 
     // Preconditions: component_idx < rank
-    constexpr reference operator[](size_t component_idx)
+    GSL_IMPL_CONSTEXPR reference operator[](size_t component_idx)
     {
         GSL_EXPECTS(component_idx < Rank); // Component index must be less than rank
         return elems[component_idx];
     }
 
     // Preconditions: component_idx < rank
-    constexpr const_reference operator[](size_t component_idx) const noexcept
+    GSL_IMPL_CONSTEXPR const_reference operator[](size_t component_idx) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(component_idx < Rank); // Component index must be less than rank
         return elems[component_idx];
     }
 
-    constexpr bool operator==(const index& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(const index& rhs) const GSL_IMPL_NOEXCEPT
     {
         return std::equal(elems, elems + rank, rhs.elems);
     }
 
-    constexpr bool operator!=(const index& rhs) const noexcept { return !(this == rhs); }
+    GSL_IMPL_CONSTEXPR bool operator!=(const index& rhs) const GSL_IMPL_NOEXCEPT { return !(this == rhs); }
 
-    constexpr index operator+() const noexcept { return *this; }
+    GSL_IMPL_CONSTEXPR index operator+() const GSL_IMPL_NOEXCEPT { return *this; }
 
-    constexpr index operator-() const noexcept
+    GSL_IMPL_CONSTEXPR index operator-() const GSL_IMPL_NOEXCEPT
     {
         index ret = *this;
         std::transform(ret, ret + rank, ret, std::negate<value_type>{});
         return ret;
     }
 
-    constexpr index operator+(const index& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR index operator+(const index& rhs) const GSL_IMPL_NOEXCEPT
     {
         index ret = *this;
         ret += rhs;
         return ret;
     }
 
-    constexpr index operator-(const index& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR index operator-(const index& rhs) const GSL_IMPL_NOEXCEPT
     {
         index ret = *this;
         ret -= rhs;
         return ret;
     }
 
-    constexpr index& operator+=(const index& rhs) noexcept
+    GSL_IMPL_CONSTEXPR index& operator+=(const index& rhs) GSL_IMPL_NOEXCEPT
     {
         std::transform(elems, elems + rank, rhs.elems, elems, std::plus<value_type>{});
         return *this;
     }
 
-    constexpr index& operator-=(const index& rhs) noexcept
+    GSL_IMPL_CONSTEXPR index& operator-=(const index& rhs) GSL_IMPL_NOEXCEPT
     {
         std::transform(elems, elems + rank, rhs.elems, elems, std::minus<value_type>{});
         return *this;
     }
 
-    constexpr index operator*(value_type v) const noexcept
+    GSL_IMPL_CONSTEXPR index operator*(value_type v) const GSL_IMPL_NOEXCEPT
     {
         index ret = *this;
         ret *= v;
         return ret;
     }
 
-    constexpr index operator/(value_type v) const noexcept
+    GSL_IMPL_CONSTEXPR index operator/(value_type v) const GSL_IMPL_NOEXCEPT
     {
         index ret = *this;
         ret /= v;
         return ret;
     }
 
-    friend constexpr index operator*(value_type v, const index& rhs) noexcept
+    friend GSL_IMPL_CONSTEXPR index operator*(value_type v, const index& rhs) GSL_IMPL_NOEXCEPT
     {
         return rhs * v;
     }
 
-    constexpr index& operator*=(value_type v) noexcept
+    GSL_IMPL_CONSTEXPR index& operator*=(value_type v) GSL_IMPL_NOEXCEPT
     {
         std::transform(elems, elems + rank, elems,
                        [v](value_type x) { return std::multiplies<value_type>{}(x, v); });
         return *this;
     }
 
-    constexpr index& operator/=(value_type v) noexcept
+    GSL_IMPL_CONSTEXPR index& operator/=(value_type v) GSL_IMPL_NOEXCEPT
     {
         std::transform(elems, elems + rank, elems,
                        [v](value_type x) { return std::divides<value_type>{}(x, v); });
@@ -244,37 +244,37 @@ private:
 struct static_bounds_dynamic_range_t
 {
     template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
-    constexpr operator T() const noexcept
+    GSL_IMPL_CONSTEXPR operator T() const GSL_IMPL_NOEXCEPT
     {
         return narrow_cast<T>(-1);
     }
 
     template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
-    constexpr bool operator==(T other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(T other) const GSL_IMPL_NOEXCEPT
     {
         return narrow_cast<T>(-1) == other;
     }
 
     template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
-    constexpr bool operator!=(T other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator!=(T other) const GSL_IMPL_NOEXCEPT
     {
         return narrow_cast<T>(-1) != other;
     }
 };
 
 template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
-constexpr bool operator==(T left, static_bounds_dynamic_range_t right) noexcept
+GSL_IMPL_CONSTEXPR bool operator==(T left, static_bounds_dynamic_range_t right) GSL_IMPL_NOEXCEPT
 {
     return right == left;
 }
 
 template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
-constexpr bool operator!=(T left, static_bounds_dynamic_range_t right) noexcept
+GSL_IMPL_CONSTEXPR bool operator!=(T left, static_bounds_dynamic_range_t right) GSL_IMPL_NOEXCEPT
 {
     return right != left;
 }
 
-constexpr static_bounds_dynamic_range_t dynamic_range{};
+GSL_IMPL_CONSTEXPR static_bounds_dynamic_range_t dynamic_range{};
 #else
 const std::ptrdiff_t dynamic_range = -1;
 #endif
@@ -332,11 +332,11 @@ namespace details
             return -1;
         }
 
-        size_type elementNum(size_t) const noexcept { return 0; }
+        size_type elementNum(size_t) const GSL_IMPL_NOEXCEPT { return 0; }
 
-        size_type totalSize() const noexcept { return TotalSize; }
+        size_type totalSize() const GSL_IMPL_NOEXCEPT { return TotalSize; }
 
-        bool operator==(const BoundsRanges&) const noexcept { return true; }
+        bool operator==(const BoundsRanges&) const GSL_IMPL_NOEXCEPT { return true; }
     };
 
     template <std::ptrdiff_t... RestRanges>
@@ -392,11 +392,11 @@ namespace details
             return cur < m_bound ? cur + last : -1;
         }
 
-        size_type totalSize() const noexcept { return m_bound; }
+        size_type totalSize() const GSL_IMPL_NOEXCEPT { return m_bound; }
 
-        size_type elementNum() const noexcept { return totalSize() / this->Base::totalSize(); }
+        size_type elementNum() const GSL_IMPL_NOEXCEPT { return totalSize() / this->Base::totalSize(); }
 
-        size_type elementNum(size_t dim) const noexcept
+        size_type elementNum(size_t dim) const GSL_IMPL_NOEXCEPT
         {
             if (dim > 0)
                 return this->Base::elementNum(dim - 1);
@@ -404,7 +404,7 @@ namespace details
                 return elementNum();
         }
 
-        bool operator==(const BoundsRanges& rhs) const noexcept
+        bool operator==(const BoundsRanges& rhs) const GSL_IMPL_NOEXCEPT
         {
             return m_bound == rhs.m_bound &&
                    static_cast<const Base&>(*this) == static_cast<const Base&>(rhs);
@@ -459,11 +459,11 @@ namespace details
             return this->Base::totalSize() * arr[Dim] + last;
         }
 
-        size_type totalSize() const noexcept { return CurrentRange * this->Base::totalSize(); }
+        size_type totalSize() const GSL_IMPL_NOEXCEPT { return CurrentRange * this->Base::totalSize(); }
 
-        size_type elementNum() const noexcept { return CurrentRange; }
+        size_type elementNum() const GSL_IMPL_NOEXCEPT { return CurrentRange; }
 
-        size_type elementNum(size_t dim) const noexcept
+        size_type elementNum(size_t dim) const GSL_IMPL_NOEXCEPT
         {
             if (dim > 0)
                 return this->Base::elementNum(dim - 1);
@@ -471,7 +471,7 @@ namespace details
                 return elementNum();
         }
 
-        bool operator==(const BoundsRanges& rhs) const noexcept
+        bool operator==(const BoundsRanges& rhs) const GSL_IMPL_NOEXCEPT
         {
             return static_cast<const Base&>(*this) == static_cast<const Base&>(rhs);
         }
@@ -520,7 +520,7 @@ namespace details
 
     template <size_t Rank, bool Enabled = (Rank > 1),
               typename Ret = std::enable_if_t<Enabled, index<Rank - 1>>>
-    constexpr Ret shift_left(const index<Rank>& other) noexcept
+    GSL_IMPL_CONSTEXPR Ret shift_left(const index<Rank>& other) GSL_IMPL_NOEXCEPT
     {
         Ret ret{};
         for (size_t i = 0; i < Rank - 1; ++i) {
@@ -546,7 +546,7 @@ class static_bounds<FirstRange, RestRanges...>
     using MyRanges = details::BoundsRanges<FirstRange, RestRanges...>;
 
     MyRanges m_ranges;
-    constexpr static_bounds(const MyRanges& range) : m_ranges(range) {}
+    GSL_IMPL_CONSTEXPR static_bounds(const MyRanges& range) : m_ranges(range) {}
 
     template <std::ptrdiff_t... OtherRanges>
     friend class static_bounds;
@@ -565,7 +565,7 @@ public:
     using sliced_type = static_bounds<RestRanges...>;
     using mapping_type = contiguous_mapping_tag;
 
-    constexpr static_bounds(const static_bounds&) = default;
+    GSL_IMPL_CONSTEXPR static_bounds(const static_bounds&) = default;
 
     template <typename SourceType, typename TargetType, size_t Rank>
     struct BoundsRangeConvertible2;
@@ -617,13 +617,13 @@ public:
               typename = std::enable_if_t<details::BoundsRangeConvertible<
                   details::BoundsRanges<Ranges...>,
                   details::BoundsRanges<FirstRange, RestRanges...>>::value>>
-    constexpr static_bounds(const static_bounds<Ranges...>& other) : m_ranges(other.m_ranges)
+    GSL_IMPL_CONSTEXPR static_bounds(const static_bounds<Ranges...>& other) : m_ranges(other.m_ranges)
     {
         GSL_EXPECTS((MyRanges::DynamicNum == 0 && details::BoundsRanges<Ranges...>::DynamicNum == 0) ||
                 MyRanges::DynamicNum > 0 || other.m_ranges.totalSize() >= m_ranges.totalSize());
     }
 
-    constexpr static_bounds(std::initializer_list<size_type> il)
+    GSL_IMPL_CONSTEXPR static_bounds(std::initializer_list<size_type> il)
         : m_ranges(static_cast<const std::ptrdiff_t*>(il.begin()))
     {
         // Size of the initializer list must match the rank of the array
@@ -633,39 +633,39 @@ public:
         GSL_EXPECTS(m_ranges.totalSize() <= PTRDIFF_MAX);
     }
 
-    constexpr static_bounds() = default;
+    GSL_IMPL_CONSTEXPR static_bounds() = default;
 
-    constexpr static_bounds& operator=(const static_bounds& otherBounds)
+    GSL_IMPL_CONSTEXPR static_bounds& operator=(const static_bounds& otherBounds)
     {
         new (&m_ranges) MyRanges(otherBounds.m_ranges);
         return *this;
     }
 
-    constexpr sliced_type slice() const noexcept
+    GSL_IMPL_CONSTEXPR sliced_type slice() const GSL_IMPL_NOEXCEPT
     {
         return sliced_type{static_cast<const details::BoundsRanges<RestRanges...>&>(m_ranges)};
     }
 
-    constexpr size_type stride() const noexcept { return rank > 1 ? slice().size() : 1; }
+    GSL_IMPL_CONSTEXPR size_type stride() const GSL_IMPL_NOEXCEPT { return rank > 1 ? slice().size() : 1; }
 
-    constexpr size_type size() const noexcept { return m_ranges.totalSize(); }
+    GSL_IMPL_CONSTEXPR size_type size() const GSL_IMPL_NOEXCEPT { return m_ranges.totalSize(); }
 
-    constexpr size_type total_size() const noexcept { return m_ranges.totalSize(); }
+    GSL_IMPL_CONSTEXPR size_type total_size() const GSL_IMPL_NOEXCEPT { return m_ranges.totalSize(); }
 
-    constexpr size_type linearize(const index_type& idx) const { return m_ranges.linearize(idx); }
+    GSL_IMPL_CONSTEXPR size_type linearize(const index_type& idx) const { return m_ranges.linearize(idx); }
 
-    constexpr bool contains(const index_type& idx) const noexcept
+    GSL_IMPL_CONSTEXPR bool contains(const index_type& idx) const GSL_IMPL_NOEXCEPT
     {
         return m_ranges.contains(idx) != -1;
     }
 
-    constexpr size_type operator[](size_t index) const noexcept
+    GSL_IMPL_CONSTEXPR size_type operator[](size_t index) const GSL_IMPL_NOEXCEPT
     {
         return m_ranges.elementNum(index);
     }
 
     template <size_t Dim = 0>
-    constexpr size_type extent() const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Dim < rank,
                       "dimension should be less than rank (dimension count starts from 0)");
@@ -673,7 +673,7 @@ public:
     }
 
     template <typename IntType>
-    constexpr size_type extent(IntType dim) const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent(IntType dim) const GSL_IMPL_NOEXCEPT
     {
         static_assert(std::is_integral<IntType>::value,
                       "Dimension parameter must be supplied as an integral type.");
@@ -683,7 +683,7 @@ public:
         return m_ranges.elementNum(real_dim);
     }
 
-    constexpr index_type index_bounds() const noexcept
+    GSL_IMPL_CONSTEXPR index_type index_bounds() const GSL_IMPL_NOEXCEPT
     {
         size_type extents[rank] = {};
         m_ranges.serialize(extents);
@@ -691,20 +691,20 @@ public:
     }
 
     template <std::ptrdiff_t... Ranges>
-    constexpr bool operator==(const static_bounds<Ranges...>& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(const static_bounds<Ranges...>& rhs) const GSL_IMPL_NOEXCEPT
     {
         return this->size() == rhs.size();
     }
 
     template <std::ptrdiff_t... Ranges>
-    constexpr bool operator!=(const static_bounds<Ranges...>& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator!=(const static_bounds<Ranges...>& rhs) const GSL_IMPL_NOEXCEPT
     {
         return !(*this == rhs);
     }
 
-    constexpr const_iterator begin() const noexcept { return const_iterator(*this, index_type{}); }
+    GSL_IMPL_CONSTEXPR const_iterator begin() const GSL_IMPL_NOEXCEPT { return const_iterator(*this, index_type{}); }
 
-    constexpr const_iterator end() const noexcept
+    GSL_IMPL_CONSTEXPR const_iterator end() const GSL_IMPL_NOEXCEPT
     {
         return const_iterator(*this, this->index_bounds());
     }
@@ -732,24 +732,24 @@ public:
     using sliced_type = std::conditional_t<rank != 0, strided_bounds<rank - 1>, void>;
     using mapping_type = generalized_mapping_tag;
 
-    constexpr strided_bounds(const strided_bounds&) noexcept = default;
+    GSL_IMPL_CONSTEXPR strided_bounds(const strided_bounds&) GSL_IMPL_NOEXCEPT = default;
 
-    constexpr strided_bounds& operator=(const strided_bounds&) noexcept = default;
+    GSL_IMPL_CONSTEXPR strided_bounds& operator=(const strided_bounds&) GSL_IMPL_NOEXCEPT = default;
 
-    constexpr strided_bounds(const value_type (&values)[rank], index_type strides)
+    GSL_IMPL_CONSTEXPR strided_bounds(const value_type (&values)[rank], index_type strides)
         : m_extents(values), m_strides(std::move(strides))
     {
     }
 
-    constexpr strided_bounds(const index_type& extents, const index_type& strides) noexcept
+    GSL_IMPL_CONSTEXPR strided_bounds(const index_type& extents, const index_type& strides) GSL_IMPL_NOEXCEPT
         : m_extents(extents),
           m_strides(strides)
     {
     }
 
-    constexpr index_type strides() const noexcept { return m_strides; }
+    GSL_IMPL_CONSTEXPR index_type strides() const GSL_IMPL_NOEXCEPT { return m_strides; }
 
-    constexpr size_type total_size() const noexcept
+    GSL_IMPL_CONSTEXPR size_type total_size() const GSL_IMPL_NOEXCEPT
     {
         size_type ret = 0;
         for (size_t i = 0; i < rank; ++i) {
@@ -758,7 +758,7 @@ public:
         return ret + 1;
     }
 
-    constexpr size_type size() const noexcept
+    GSL_IMPL_CONSTEXPR size_type size() const GSL_IMPL_NOEXCEPT
     {
         size_type ret = 1;
         for (size_t i = 0; i < rank; ++i) {
@@ -767,7 +767,7 @@ public:
         return ret;
     }
 
-    constexpr bool contains(const index_type& idx) const noexcept
+    GSL_IMPL_CONSTEXPR bool contains(const index_type& idx) const GSL_IMPL_NOEXCEPT
     {
         for (size_t i = 0; i < rank; ++i) {
             if (idx[i] < 0 || idx[i] >= m_extents[i]) return false;
@@ -775,7 +775,7 @@ public:
         return true;
     }
 
-    constexpr size_type linearize(const index_type& idx) const noexcept
+    GSL_IMPL_CONSTEXPR size_type linearize(const index_type& idx) const GSL_IMPL_NOEXCEPT
     {
         size_type ret = 0;
         for (size_t i = 0; i < rank; i++) {
@@ -785,26 +785,26 @@ public:
         return ret;
     }
 
-    constexpr size_type stride() const noexcept { return m_strides[0]; }
+    GSL_IMPL_CONSTEXPR size_type stride() const GSL_IMPL_NOEXCEPT { return m_strides[0]; }
 
     template <bool Enabled = (rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
-    constexpr sliced_type slice() const
+    GSL_IMPL_CONSTEXPR sliced_type slice() const
     {
         return {details::shift_left(m_extents), details::shift_left(m_strides)};
     }
 
     template <size_t Dim = 0>
-    constexpr size_type extent() const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Dim < Rank,
                       "dimension should be less than rank (dimension count starts from 0)");
         return m_extents[Dim];
     }
 
-    constexpr index_type index_bounds() const noexcept { return m_extents; }
-    constexpr const_iterator begin() const noexcept { return const_iterator{*this, index_type{}}; }
+    GSL_IMPL_CONSTEXPR index_type index_bounds() const GSL_IMPL_NOEXCEPT { return m_extents; }
+    GSL_IMPL_CONSTEXPR const_iterator begin() const GSL_IMPL_NOEXCEPT { return const_iterator{*this, index_type{}}; }
 
-    constexpr const_iterator end() const noexcept { return const_iterator{*this, index_bounds()}; }
+    GSL_IMPL_CONSTEXPR const_iterator end() const GSL_IMPL_NOEXCEPT { return const_iterator{*this, index_bounds()}; }
 
 private:
     index_type m_extents;
@@ -839,18 +839,18 @@ public:
     using index_type = value_type;
     using index_size_type = typename IndexType::value_type;
     template <typename Bounds>
-    explicit bounds_iterator(const Bounds& bnd, value_type curr) noexcept
+    explicit bounds_iterator(const Bounds& bnd, value_type curr) GSL_IMPL_NOEXCEPT
         : boundary_(bnd.index_bounds()),
           curr_(std::move(curr))
     {
         static_assert(is_bounds<Bounds>::value, "Bounds type must be provided");
     }
 
-    constexpr reference operator*() const noexcept { return curr_; }
+    GSL_IMPL_CONSTEXPR reference operator*() const GSL_IMPL_NOEXCEPT { return curr_; }
 
-    constexpr pointer operator->() const noexcept { return &curr_; }
+    GSL_IMPL_CONSTEXPR pointer operator->() const GSL_IMPL_NOEXCEPT { return &curr_; }
 
-    constexpr bounds_iterator& operator++() noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator& operator++() GSL_IMPL_NOEXCEPT
     {
         for (size_t i = rank; i-- > 0;) {
             if (curr_[i] < boundary_[i] - 1) {
@@ -864,14 +864,14 @@ public:
         return *this;
     }
 
-    constexpr bounds_iterator operator++(int) noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator operator++(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         ++(*this);
         return ret;
     }
 
-    constexpr bounds_iterator& operator--() noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator& operator--() GSL_IMPL_NOEXCEPT
     {
         if (!less(curr_, boundary_)) {
             // if at the past-the-end, set to last element
@@ -893,20 +893,20 @@ public:
         return *this;
     }
 
-    constexpr bounds_iterator operator--(int) noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator operator--(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         --(*this);
         return ret;
     }
 
-    constexpr bounds_iterator operator+(difference_type n) const noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator operator+(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         bounds_iterator ret{*this};
         return ret += n;
     }
 
-    constexpr bounds_iterator& operator+=(difference_type n) noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator& operator+=(difference_type n) GSL_IMPL_NOEXCEPT
     {
         auto linear_idx = linearize(curr_) + n;
         std::remove_const_t<value_type> stride = 0;
@@ -923,47 +923,47 @@ public:
         return *this;
     }
 
-    constexpr bounds_iterator operator-(difference_type n) const noexcept
+    GSL_IMPL_CONSTEXPR bounds_iterator operator-(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         bounds_iterator ret{*this};
         return ret -= n;
     }
 
-    constexpr bounds_iterator& operator-=(difference_type n) noexcept { return * this += -n; }
+    GSL_IMPL_CONSTEXPR bounds_iterator& operator-=(difference_type n) GSL_IMPL_NOEXCEPT { return * this += -n; }
 
-    constexpr difference_type operator-(const bounds_iterator& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR difference_type operator-(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         return linearize(curr_) - linearize(rhs.curr_);
     }
 
-    constexpr value_type operator[](difference_type n) const noexcept { return *(*this + n); }
+    GSL_IMPL_CONSTEXPR value_type operator[](difference_type n) const GSL_IMPL_NOEXCEPT { return *(*this + n); }
 
-    constexpr bool operator==(const bounds_iterator& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         return curr_ == rhs.curr_;
     }
 
-    constexpr bool operator!=(const bounds_iterator& rhs) const noexcept { return !(*this == rhs); }
+    GSL_IMPL_CONSTEXPR bool operator!=(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(*this == rhs); }
 
-    constexpr bool operator<(const bounds_iterator& rhs) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator<(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         return less(curr_, rhs.curr_);
     }
 
-    constexpr bool operator<=(const bounds_iterator& rhs) const noexcept { return !(rhs < *this); }
+    GSL_IMPL_CONSTEXPR bool operator<=(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs < *this); }
 
-    constexpr bool operator>(const bounds_iterator& rhs) const noexcept { return rhs < *this; }
+    GSL_IMPL_CONSTEXPR bool operator>(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT { return rhs < *this; }
 
-    constexpr bool operator>=(const bounds_iterator& rhs) const noexcept { return !(rhs > *this); }
+    GSL_IMPL_CONSTEXPR bool operator>=(const bounds_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs > *this); }
 
-    void swap(bounds_iterator& rhs) noexcept
+    void swap(bounds_iterator& rhs) GSL_IMPL_NOEXCEPT
     {
         std::swap(boundary_, rhs.boundary_);
         std::swap(curr_, rhs.curr_);
     }
 
 private:
-    constexpr bool less(index_type& one, index_type& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool less(index_type& one, index_type& other) const GSL_IMPL_NOEXCEPT
     {
         for (size_t i = 0; i < rank; ++i) {
             if (one[i] < other[i]) return true;
@@ -971,7 +971,7 @@ private:
         return false;
     }
 
-    constexpr index_size_type linearize(const value_type& idx) const noexcept
+    GSL_IMPL_CONSTEXPR index_size_type linearize(const value_type& idx) const GSL_IMPL_NOEXCEPT
     {
         // TODO: Smarter impl.
         // Check if past-the-end
@@ -1000,7 +1000,7 @@ private:
 
 template <typename IndexType>
 bounds_iterator<IndexType> operator+(typename bounds_iterator<IndexType>::difference_type n,
-                                     const bounds_iterator<IndexType>& rhs) noexcept
+                                     const bounds_iterator<IndexType>& rhs) GSL_IMPL_NOEXCEPT
 {
     return rhs + n;
 }
@@ -1008,20 +1008,20 @@ bounds_iterator<IndexType> operator+(typename bounds_iterator<IndexType>::differ
 namespace details
 {
     template <typename Bounds>
-    constexpr std::enable_if_t<
+    GSL_IMPL_CONSTEXPR std::enable_if_t<
         std::is_same<typename Bounds::mapping_type, generalized_mapping_tag>::value,
         typename Bounds::index_type>
-    make_stride(const Bounds& bnd) noexcept
+    make_stride(const Bounds& bnd) GSL_IMPL_NOEXCEPT
     {
         return bnd.strides();
     }
 
     // Make a stride vector from bounds, assuming contiguous memory.
     template <typename Bounds>
-    constexpr std::enable_if_t<
+    GSL_IMPL_CONSTEXPR std::enable_if_t<
         std::is_same<typename Bounds::mapping_type, contiguous_mapping_tag>::value,
         typename Bounds::index_type>
-    make_stride(const Bounds& bnd) noexcept
+    make_stride(const Bounds& bnd) GSL_IMPL_NOEXCEPT
     {
         auto extents = bnd.index_bounds();
         typename Bounds::size_type stride[Bounds::rank] = {};
@@ -1210,7 +1210,7 @@ private:
 
 public:
     // default constructor - same as constructing from nullptr_t
-    constexpr span() noexcept : span(nullptr, bounds_type{})
+    GSL_IMPL_CONSTEXPR span() GSL_IMPL_NOEXCEPT : span(nullptr, bounds_type{})
     {
         static_assert(bounds_type::dynamic_rank != 0 ||
                           (bounds_type::dynamic_rank == 0 && bounds_type::static_size == 0),
@@ -1219,7 +1219,7 @@ public:
     }
 
     // construct from nullptr - get an empty span
-    constexpr span(std::nullptr_t) noexcept : span(nullptr, bounds_type{})
+    GSL_IMPL_CONSTEXPR span(std::nullptr_t) GSL_IMPL_NOEXCEPT : span(nullptr, bounds_type{})
     {
         static_assert(bounds_type::dynamic_rank != 0 ||
                           (bounds_type::dynamic_rank == 0 && bounds_type::static_size == 0),
@@ -1229,7 +1229,7 @@ public:
 
     // construct from nullptr with size of 0 (helps with template function calls)
     template <class IntType, typename = std::enable_if_t<std::is_integral<IntType>::value>>
-    constexpr span(std::nullptr_t, IntType size) noexcept : span(nullptr, bounds_type{})
+    GSL_IMPL_CONSTEXPR span(std::nullptr_t, IntType size) GSL_IMPL_NOEXCEPT : span(nullptr, bounds_type{})
     {
         static_assert(bounds_type::dynamic_rank != 0 ||
                           (bounds_type::dynamic_rank == 0 && bounds_type::static_size == 0),
@@ -1239,7 +1239,7 @@ public:
     }
 
     // construct from a single element
-    constexpr span(reference data) noexcept : span(&data, bounds_type{1})
+    GSL_IMPL_CONSTEXPR span(reference data) GSL_IMPL_NOEXCEPT : span(&data, bounds_type{1})
     {
         static_assert(bounds_type::dynamic_rank > 0 || bounds_type::static_size == 0 ||
                           bounds_type::static_size == 1,
@@ -1248,13 +1248,13 @@ public:
     }
 
     // prevent constructing from temporaries for single-elements
-    constexpr span(value_type&&) = delete;
+    GSL_IMPL_CONSTEXPR span(value_type&&) = delete;
 
     // construct from pointer + length
-    constexpr span(pointer ptr, size_type size) noexcept : span(ptr, bounds_type{size}) {}
+    GSL_IMPL_CONSTEXPR span(pointer ptr, size_type size) GSL_IMPL_NOEXCEPT : span(ptr, bounds_type{size}) {}
 
     // construct from pointer + length - multidimensional
-    constexpr span(pointer data, bounds_type bounds) noexcept : data_(data),
+    GSL_IMPL_CONSTEXPR span(pointer data, bounds_type bounds) GSL_IMPL_NOEXCEPT : data_(data),
                                                                 bounds_(std::move(bounds))
     {
         GSL_EXPECTS((bounds_.size() > 0 && data != nullptr) || bounds_.size() == 0);
@@ -1264,7 +1264,7 @@ public:
     template <typename Ptr,
               typename = std::enable_if_t<std::is_convertible<Ptr, pointer>::value &&
                                           details::LessThan<bounds_type::dynamic_rank, 2>::value>>
-    constexpr span(pointer begin, Ptr end)
+    GSL_IMPL_CONSTEXPR span(pointer begin, Ptr end)
         : span(begin, details::newBoundsHelper<bounds_type>(static_cast<pointer>(end) - begin))
     {
         GSL_EXPECTS(begin != nullptr && end != nullptr && begin <= static_cast<pointer>(end));
@@ -1272,7 +1272,7 @@ public:
 
     // construct from n-dimensions static array
     template <typename T, size_t N, typename Helper = details::SpanArrayTraits<T, N>>
-    constexpr span(T (&arr)[N])
+    GSL_IMPL_CONSTEXPR span(T (&arr)[N])
         : span(reinterpret_cast<pointer>(arr), bounds_type{typename Helper::bounds_type{}})
     {
         static_assert(
@@ -1285,7 +1285,7 @@ public:
     // construct from n-dimensions dynamic array (e.g. new int[m][4])
     // (precedence will be lower than the 1-dimension pointer)
     template <typename T, typename Helper = details::SpanArrayTraits<T, dynamic_range>>
-    constexpr span(T* const& data, size_type size)
+    GSL_IMPL_CONSTEXPR span(T* const& data, size_type size)
         : span(reinterpret_cast<pointer>(data), typename Helper::bounds_type{size})
     {
         static_assert(
@@ -1295,7 +1295,7 @@ public:
 
     // construct from std::array
     template <typename T, size_t N>
-    constexpr span(std::array<T, N>& arr) : span(arr.data(), bounds_type{static_bounds<N>{}})
+    GSL_IMPL_CONSTEXPR span(std::array<T, N>& arr) : span(arr.data(), bounds_type{static_bounds<N>{}})
     {
         static_assert(
             std::is_convertible<T(*) [], typename std::remove_const_t<value_type>(*) []>::value,
@@ -1306,7 +1306,7 @@ public:
 
     // construct from const std::array
     template <typename T, size_t N>
-    constexpr span(const std::array<std::remove_const_t<value_type>, N>& arr)
+    GSL_IMPL_CONSTEXPR span(const std::array<std::remove_const_t<value_type>, N>& arr)
         : span(arr.data(), static_bounds<N>())
     {
         static_assert(std::is_convertible<T(*) [], std::remove_const_t<value_type>>::value,
@@ -1317,7 +1317,7 @@ public:
 
     // prevent constructing from temporary std::array
     template <typename T, size_t N>
-    constexpr span(std::array<T, N>&& arr) = delete;
+    GSL_IMPL_CONSTEXPR span(std::array<T, N>&& arr) = delete;
 
     // construct from containers
     // future: could use contiguous_iterator_traits to identify only contiguous containers
@@ -1329,7 +1329,7 @@ public:
                   std::is_same<std::decay_t<decltype(std::declval<Cont>().size(),
                                                      *std::declval<Cont>().data())>,
                                DataType>::value>>
-    constexpr span(Cont& cont)
+    GSL_IMPL_CONSTEXPR span(Cont& cont)
         : span(static_cast<pointer>(cont.data()),
                details::newBoundsHelper<bounds_type>(narrow_cast<size_type>(cont.size())))
     {
@@ -1343,33 +1343,33 @@ public:
                   std::is_same<std::decay_t<decltype(std::declval<Cont>().size(),
                                                      *std::declval<Cont>().data())>,
                                DataType>::value>>
-    explicit constexpr span(Cont&& cont) = delete;
+    explicit GSL_IMPL_CONSTEXPR span(Cont&& cont) = delete;
 
     // construct from a convertible span
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename OtherBounds = static_bounds<OtherDimensions...>,
               typename = std::enable_if_t<std::is_convertible<OtherValueType, ValueType>::value &&
                                           std::is_convertible<OtherBounds, bounds_type>::value>>
-    constexpr span(span<OtherValueType, OtherDimensions...> other) noexcept : data_(other.data_),
+    GSL_IMPL_CONSTEXPR span(span<OtherValueType, OtherDimensions...> other) GSL_IMPL_NOEXCEPT : data_(other.data_),
                                                                               bounds_(other.bounds_)
     {
     }
 
 // trivial copy and move
 #ifndef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-    constexpr span(span&&) = default;
+    GSL_IMPL_CONSTEXPR span(span&&) = default;
 #endif
-    constexpr span(const span&) = default;
+    GSL_IMPL_CONSTEXPR span(const span&) = default;
 
 // trivial assignment
 #ifndef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-    constexpr span& operator=(span&&) = default;
+    GSL_IMPL_CONSTEXPR span& operator=(span&&) = default;
 #endif
-    constexpr span& operator=(const span&) = default;
+    GSL_IMPL_CONSTEXPR span& operator=(const span&) = default;
 
     // first() - extract the first Count elements into a new span
     template <std::ptrdiff_t Count>
-    constexpr span<ValueType, Count> first() const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, Count> first() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Count >= 0, "Count must be >= 0.");
         static_assert(bounds_type::static_size == dynamic_range ||
@@ -1381,7 +1381,7 @@ public:
     }
 
     // first() - extract the first count elements into a new span
-    constexpr span<ValueType, dynamic_range> first(size_type count) const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, dynamic_range> first(size_type count) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(count >= 0 && count <= this->size());
         return {this->data(), count};
@@ -1389,7 +1389,7 @@ public:
 
     // last() - extract the last Count elements into a new span
     template <std::ptrdiff_t Count>
-    constexpr span<ValueType, Count> last() const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, Count> last() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Count >= 0, "Count must be >= 0.");
         static_assert(bounds_type::static_size == dynamic_range ||
@@ -1401,7 +1401,7 @@ public:
     }
 
     // last() - extract the last count elements into a new span
-    constexpr span<ValueType, dynamic_range> last(size_type count) const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, dynamic_range> last(size_type count) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(count >= 0 && count <= this->size());
         return {this->data() + this->size() - count, count};
@@ -1409,7 +1409,7 @@ public:
 
     // subspan() - create a subview of Count elements starting at Offset
     template <std::ptrdiff_t Offset, std::ptrdiff_t Count>
-    constexpr span<ValueType, Count> subspan() const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, Count> subspan() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Count >= 0, "Count must be >= 0.");
         static_assert(Offset >= 0, "Offset must be >= 0.");
@@ -1425,8 +1425,8 @@ public:
 
     // subspan() - create a subview of count elements starting at offset
     // supplying dynamic_range for count will consume all available elements from offset
-    constexpr span<ValueType, dynamic_range> subspan(size_type offset,
-                                                     size_type count = dynamic_range) const noexcept
+    GSL_IMPL_CONSTEXPR span<ValueType, dynamic_range> subspan(size_type offset,
+                                                     size_type count = dynamic_range) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS((offset >= 0 && offset <= this->size()) &&
                 (count == dynamic_range || (count <= this->size() - offset)));
@@ -1434,8 +1434,8 @@ public:
     }
 
     // section - creates a non-contiguous, strided span from a contiguous one
-    constexpr strided_span<ValueType, Rank> section(index_type origin, index_type extents) const
-        noexcept
+    GSL_IMPL_CONSTEXPR strided_span<ValueType, Rank> section(index_type origin, index_type extents) const
+        GSL_IMPL_NOEXCEPT
     {
         size_type size = this->bounds().total_size() - this->bounds().linearize(origin);
         return {&this->operator[](origin), size,
@@ -1443,23 +1443,23 @@ public:
     }
 
     // length of the span in elements
-    constexpr size_type size() const noexcept { return bounds_.size(); }
+    GSL_IMPL_CONSTEXPR size_type size() const GSL_IMPL_NOEXCEPT { return bounds_.size(); }
 
     // length of the span in elements
-    constexpr size_type length() const noexcept { return this->size(); }
+    GSL_IMPL_CONSTEXPR size_type length() const GSL_IMPL_NOEXCEPT { return this->size(); }
 
     // length of the span in bytes
-    constexpr size_type size_bytes() const noexcept { return sizeof(value_type) * this->size(); }
+    GSL_IMPL_CONSTEXPR size_type size_bytes() const GSL_IMPL_NOEXCEPT { return sizeof(value_type) * this->size(); }
 
     // length of the span in bytes
-    constexpr size_type length_bytes() const noexcept { return this->size_bytes(); }
+    GSL_IMPL_CONSTEXPR size_type length_bytes() const GSL_IMPL_NOEXCEPT { return this->size_bytes(); }
 
-    constexpr bool empty() const noexcept { return this->size() == 0; }
+    GSL_IMPL_CONSTEXPR bool empty() const GSL_IMPL_NOEXCEPT { return this->size() == 0; }
 
-    static constexpr std::size_t rank() { return Rank; }
+    static GSL_IMPL_CONSTEXPR std::size_t rank() { return Rank; }
 
     template <size_t Dim = 0>
-    constexpr size_type extent() const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Dim < Rank,
                       "Dimension should be less than rank (dimension count starts from 0).");
@@ -1467,36 +1467,36 @@ public:
     }
 
     template <typename IntType>
-    constexpr size_type extent(IntType dim) const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent(IntType dim) const GSL_IMPL_NOEXCEPT
     {
         return bounds_.extent(dim);
     }
 
-    constexpr bounds_type bounds() const noexcept { return bounds_; }
+    GSL_IMPL_CONSTEXPR bounds_type bounds() const GSL_IMPL_NOEXCEPT { return bounds_; }
 
-    constexpr pointer data() const noexcept { return data_; }
+    GSL_IMPL_CONSTEXPR pointer data() const GSL_IMPL_NOEXCEPT { return data_; }
 
     template <typename FirstIndex>
-    constexpr reference operator()(FirstIndex index)
+    GSL_IMPL_CONSTEXPR reference operator()(FirstIndex index)
     {
         return this->operator[](narrow_cast<std::ptrdiff_t>(index));
     }
 
     template <typename FirstIndex, typename... OtherIndices>
-    constexpr reference operator()(FirstIndex index, OtherIndices... indices)
+    GSL_IMPL_CONSTEXPR reference operator()(FirstIndex index, OtherIndices... indices)
     {
         index_type idx = {narrow_cast<std::ptrdiff_t>(index),
                           narrow_cast<std::ptrdiff_t>(indices...)};
         return this->operator[](idx);
     }
 
-    constexpr reference operator[](const index_type& idx) const noexcept
+    GSL_IMPL_CONSTEXPR reference operator[](const index_type& idx) const GSL_IMPL_NOEXCEPT
     {
         return data_[bounds_.linearize(idx)];
     }
 
     template <bool Enabled = (Rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
-    constexpr Ret operator[](size_type idx) const noexcept
+    GSL_IMPL_CONSTEXPR Ret operator[](size_type idx) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(idx < bounds_.size()); // index is out of bounds of the array
         const size_type ridx = idx * bounds_.stride();
@@ -1506,30 +1506,30 @@ public:
         return Ret{data_ + ridx, bounds_.slice()};
     }
 
-    constexpr iterator begin() const noexcept { return iterator{this, true}; }
+    GSL_IMPL_CONSTEXPR iterator begin() const GSL_IMPL_NOEXCEPT { return iterator{this, true}; }
 
-    constexpr iterator end() const noexcept { return iterator{this, false}; }
+    GSL_IMPL_CONSTEXPR iterator end() const GSL_IMPL_NOEXCEPT { return iterator{this, false}; }
 
-    constexpr const_iterator cbegin() const noexcept
+    GSL_IMPL_CONSTEXPR const_iterator cbegin() const GSL_IMPL_NOEXCEPT
     {
         return const_iterator{reinterpret_cast<const const_span*>(this), true};
     }
 
-    constexpr const_iterator cend() const noexcept
+    GSL_IMPL_CONSTEXPR const_iterator cend() const GSL_IMPL_NOEXCEPT
     {
         return const_iterator{reinterpret_cast<const const_span*>(this), false};
     }
 
-    constexpr reverse_iterator rbegin() const noexcept { return reverse_iterator{end()}; }
+    GSL_IMPL_CONSTEXPR reverse_iterator rbegin() const GSL_IMPL_NOEXCEPT { return reverse_iterator{end()}; }
 
-    constexpr reverse_iterator rend() const noexcept { return reverse_iterator{begin()}; }
+    GSL_IMPL_CONSTEXPR reverse_iterator rend() const GSL_IMPL_NOEXCEPT { return reverse_iterator{begin()}; }
 
-    constexpr const_reverse_iterator crbegin() const noexcept
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crbegin() const GSL_IMPL_NOEXCEPT
     {
         return const_reverse_iterator{cend()};
     }
 
-    constexpr const_reverse_iterator crend() const noexcept
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crend() const GSL_IMPL_NOEXCEPT
     {
         return const_reverse_iterator{cbegin()};
     }
@@ -1537,7 +1537,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator==(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return bounds_.size() == other.bounds_.size() &&
                (data_ == other.data_ || std::equal(this->begin(), this->end(), other.begin()));
@@ -1546,7 +1546,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator!=(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator!=(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(*this == other);
     }
@@ -1554,7 +1554,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator<(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return std::lexicographical_compare(this->begin(), this->end(), other.begin(), other.end());
     }
@@ -1562,7 +1562,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<=(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator<=(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(other < *this);
     }
@@ -1570,7 +1570,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator>(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return (other < *this);
     }
@@ -1578,7 +1578,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>=(const span<OtherValueType, OtherDimensions...>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator>=(const span<OtherValueType, OtherDimensions...>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(*this < other);
     }
@@ -1592,7 +1592,7 @@ public:
 // DimCount and Enabled here are workarounds for a bug in MSVC 2015
 template <typename SpanType, typename... Dimensions2, size_t DimCount = sizeof...(Dimensions2),
           bool Enabled = (DimCount > 0), typename = std::enable_if_t<Enabled>>
-constexpr span<typename SpanType::value_type, Dimensions2::value...> as_span(SpanType s,
+GSL_IMPL_CONSTEXPR span<typename SpanType::value_type, Dimensions2::value...> as_span(SpanType s,
                                                                              Dimensions2... dims)
 {
     static_assert(details::is_span<SpanType>::value,
@@ -1606,7 +1606,7 @@ constexpr span<typename SpanType::value_type, Dimensions2::value...> as_span(Spa
 
 // convert a span<T> to a span<const byte>
 template <typename U, std::ptrdiff_t... Dimensions>
-span<const byte, dynamic_range> as_bytes(span<U, Dimensions...> s) noexcept
+span<const byte, dynamic_range> as_bytes(span<U, Dimensions...> s) GSL_IMPL_NOEXCEPT
 {
     static_assert(std::is_trivial<std::decay_t<U>>::value,
                   "The value_type of span must be a trivial type.");
@@ -1618,7 +1618,7 @@ span<const byte, dynamic_range> as_bytes(span<U, Dimensions...> s) noexcept
 // on all implementations. It should be considered an experimental extension
 // to the standard GSL interface.
 template <typename U, std::ptrdiff_t... Dimensions>
-span<byte> as_writeable_bytes(span<U, Dimensions...> s) noexcept
+span<byte> as_writeable_bytes(span<U, Dimensions...> s) GSL_IMPL_NOEXCEPT
 {
     static_assert(std::is_trivial<std::decay_t<U>>::value,
                   "The value_type of span must be a trivial type.");
@@ -1630,7 +1630,7 @@ span<byte> as_writeable_bytes(span<U, Dimensions...> s) noexcept
 // on all implementations. It should be considered an experimental extension
 // to the standard GSL interface.
 template <typename U, std::ptrdiff_t... Dimensions>
-constexpr auto as_span(span<const byte, Dimensions...> s) noexcept
+GSL_IMPL_CONSTEXPR auto as_span(span<const byte, Dimensions...> s) GSL_IMPL_NOEXCEPT
     -> span<const U, static_cast<std::ptrdiff_t>(
                          span<const byte, Dimensions...>::bounds_type::static_size != dynamic_range
                              ? (static_cast<size_t>(
@@ -1655,7 +1655,7 @@ constexpr auto as_span(span<const byte, Dimensions...> s) noexcept
 // on all implementations. It should be considered an experimental extension
 // to the standard GSL interface.
 template <typename U, std::ptrdiff_t... Dimensions>
-constexpr auto as_span(span<byte, Dimensions...> s) noexcept -> span<
+GSL_IMPL_CONSTEXPR auto as_span(span<byte, Dimensions...> s) GSL_IMPL_NOEXCEPT -> span<
     U, narrow_cast<std::ptrdiff_t>(
            span<byte, Dimensions...>::bounds_type::static_size != dynamic_range
                ? static_cast<std::size_t>(span<byte, Dimensions...>::bounds_type::static_size) /
@@ -1675,7 +1675,7 @@ constexpr auto as_span(span<byte, Dimensions...> s) noexcept -> span<
 }
 
 template <typename T, std::ptrdiff_t... Dimensions>
-constexpr auto as_span(T* const& ptr, dim<Dimensions>... args)
+GSL_IMPL_CONSTEXPR auto as_span(T* const& ptr, dim<Dimensions>... args)
     -> span<std::remove_all_extents_t<T>, Dimensions...>
 {
     return {reinterpret_cast<std::remove_all_extents_t<T>*>(ptr),
@@ -1683,41 +1683,41 @@ constexpr auto as_span(T* const& ptr, dim<Dimensions>... args)
 }
 
 template <typename T>
-constexpr auto as_span(T* arr, std::ptrdiff_t len) ->
+GSL_IMPL_CONSTEXPR auto as_span(T* arr, std::ptrdiff_t len) ->
     typename details::SpanArrayTraits<T, dynamic_range>::type
 {
     return {reinterpret_cast<std::remove_all_extents_t<T>*>(arr), len};
 }
 
 template <typename T, size_t N>
-constexpr auto as_span(T (&arr)[N]) -> typename details::SpanArrayTraits<T, N>::type
+GSL_IMPL_CONSTEXPR auto as_span(T (&arr)[N]) -> typename details::SpanArrayTraits<T, N>::type
 {
     return {arr};
 }
 
 template <typename T, size_t N>
-constexpr span<const T, N> as_span(const std::array<T, N>& arr)
+GSL_IMPL_CONSTEXPR span<const T, N> as_span(const std::array<T, N>& arr)
 {
     return {arr};
 }
 
 template <typename T, size_t N>
-constexpr span<const T, N> as_span(const std::array<T, N>&&) = delete;
+GSL_IMPL_CONSTEXPR span<const T, N> as_span(const std::array<T, N>&&) = delete;
 
 template <typename T, size_t N>
-constexpr span<T, N> as_span(std::array<T, N>& arr)
+GSL_IMPL_CONSTEXPR span<T, N> as_span(std::array<T, N>& arr)
 {
     return {arr};
 }
 
 template <typename T>
-constexpr span<T, dynamic_range> as_span(T* begin, T* end)
+GSL_IMPL_CONSTEXPR span<T, dynamic_range> as_span(T* begin, T* end)
 {
     return {begin, end};
 }
 
 template <typename Cont>
-constexpr auto as_span(Cont& arr) -> std::enable_if_t<
+GSL_IMPL_CONSTEXPR auto as_span(Cont& arr) -> std::enable_if_t<
     !details::is_span<std::decay_t<Cont>>::value,
     span<std::remove_reference_t<decltype(arr.size(), *arr.data())>, dynamic_range>>
 {
@@ -1726,13 +1726,13 @@ constexpr auto as_span(Cont& arr) -> std::enable_if_t<
 }
 
 template <typename Cont>
-constexpr auto as_span(Cont&& arr) -> std::enable_if_t<
+GSL_IMPL_CONSTEXPR auto as_span(Cont&& arr) -> std::enable_if_t<
     !details::is_span<std::decay_t<Cont>>::value,
     span<std::remove_reference_t<decltype(arr.size(), *arr.data())>, dynamic_range>> = delete;
 
 // from basic_string which doesn't have nonconst .data() member like other contiguous containers
 template <typename CharT, typename Traits, typename Allocator>
-constexpr auto as_span(std::basic_string<CharT, Traits, Allocator>& str)
+GSL_IMPL_CONSTEXPR auto as_span(std::basic_string<CharT, Traits, Allocator>& str)
     -> span<CharT, dynamic_range>
 {
     GSL_EXPECTS(str.size() < PTRDIFF_MAX);
@@ -1771,7 +1771,7 @@ private:
 
 public:
     // from raw data
-    constexpr strided_span(pointer ptr, size_type size, bounds_type bounds)
+    GSL_IMPL_CONSTEXPR strided_span(pointer ptr, size_type size, bounds_type bounds)
         : data_(ptr), bounds_(std::move(bounds))
     {
         GSL_EXPECTS((bounds_.size() > 0 && ptr != nullptr) || bounds_.size() == 0);
@@ -1782,7 +1782,7 @@ public:
 
     // from static array of size N
     template <size_type N>
-    constexpr strided_span(value_type (&values)[N], bounds_type bounds)
+    GSL_IMPL_CONSTEXPR strided_span(value_type (&values)[N], bounds_type bounds)
         : strided_span(values, N, std::move(bounds))
     {
     }
@@ -1792,7 +1792,7 @@ public:
               bool Enabled1 = (sizeof...(Dimensions) == Rank),
               bool Enabled2 = std::is_convertible<OtherValueType*, ValueType*>::value,
               typename Dummy = std::enable_if_t<Enabled1 && Enabled2>>
-    constexpr strided_span(span<OtherValueType, Dimensions...> av, bounds_type bounds)
+    GSL_IMPL_CONSTEXPR strided_span(span<OtherValueType, Dimensions...> av, bounds_type bounds)
         : strided_span(av.data(), av.bounds().total_size(), std::move(bounds))
     {
     }
@@ -1800,14 +1800,14 @@ public:
     // convertible
     template <typename OtherValueType, typename Dummy = std::enable_if_t<std::is_convertible<
                                            OtherValueType (*)[], value_type (*)[]>::value>>
-    constexpr strided_span(const strided_span<OtherValueType, Rank>& other)
+    GSL_IMPL_CONSTEXPR strided_span(const strided_span<OtherValueType, Rank>& other)
         : data_(other.data_), bounds_(other.bounds_)
     {
     }
 
     // convert from bytes
     template <typename OtherValueType>
-    constexpr strided_span<
+    GSL_IMPL_CONSTEXPR strided_span<
         typename std::enable_if<std::is_same<value_type, const byte>::value, OtherValueType>::type,
         Rank>
     as_strided_span() const
@@ -1823,20 +1823,20 @@ public:
                             resize_stride(this->bounds().strides(), d)}};
     }
 
-    constexpr strided_span section(index_type origin, index_type extents) const
+    GSL_IMPL_CONSTEXPR strided_span section(index_type origin, index_type extents) const
     {
         size_type size = this->bounds().total_size() - this->bounds().linearize(origin);
         return {&this->operator[](origin), size,
                 bounds_type{extents, details::make_stride(bounds())}};
     }
 
-    constexpr reference operator[](const index_type& idx) const
+    GSL_IMPL_CONSTEXPR reference operator[](const index_type& idx) const
     {
         return data_[bounds_.linearize(idx)];
     }
 
     template <bool Enabled = (Rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
-    constexpr Ret operator[](size_type idx) const
+    GSL_IMPL_CONSTEXPR Ret operator[](size_type idx) const
     {
         GSL_EXPECTS(idx < bounds_.size()); // index is out of bounds of the array
         const size_type ridx = idx * bounds_.stride();
@@ -1846,48 +1846,48 @@ public:
         return {data_ + ridx, bounds_.slice().total_size(), bounds_.slice()};
     }
 
-    constexpr bounds_type bounds() const noexcept { return bounds_; }
+    GSL_IMPL_CONSTEXPR bounds_type bounds() const GSL_IMPL_NOEXCEPT { return bounds_; }
 
     template <size_t Dim = 0>
-    constexpr size_type extent() const noexcept
+    GSL_IMPL_CONSTEXPR size_type extent() const GSL_IMPL_NOEXCEPT
     {
         static_assert(Dim < Rank,
                       "dimension should be less than Rank (dimension count starts from 0)");
         return bounds_.template extent<Dim>();
     }
 
-    constexpr size_type size() const noexcept { return bounds_.size(); }
+    GSL_IMPL_CONSTEXPR size_type size() const GSL_IMPL_NOEXCEPT { return bounds_.size(); }
 
-    constexpr pointer data() const noexcept { return data_; }
+    GSL_IMPL_CONSTEXPR pointer data() const GSL_IMPL_NOEXCEPT { return data_; }
 
-    constexpr explicit operator bool() const noexcept { return data_ != nullptr; }
+    GSL_IMPL_CONSTEXPR explicit operator bool() const GSL_IMPL_NOEXCEPT { return data_ != nullptr; }
 
-    constexpr iterator begin() const { return iterator{this, true}; }
+    GSL_IMPL_CONSTEXPR iterator begin() const { return iterator{this, true}; }
 
-    constexpr iterator end() const { return iterator{this, false}; }
+    GSL_IMPL_CONSTEXPR iterator end() const { return iterator{this, false}; }
 
-    constexpr const_iterator cbegin() const
+    GSL_IMPL_CONSTEXPR const_iterator cbegin() const
     {
         return const_iterator{reinterpret_cast<const const_strided_span*>(this), true};
     }
 
-    constexpr const_iterator cend() const
+    GSL_IMPL_CONSTEXPR const_iterator cend() const
     {
         return const_iterator{reinterpret_cast<const const_strided_span*>(this), false};
     }
 
-    constexpr reverse_iterator rbegin() const { return reverse_iterator{end()}; }
+    GSL_IMPL_CONSTEXPR reverse_iterator rbegin() const { return reverse_iterator{end()}; }
 
-    constexpr reverse_iterator rend() const { return reverse_iterator{begin()}; }
+    GSL_IMPL_CONSTEXPR reverse_iterator rend() const { return reverse_iterator{begin()}; }
 
-    constexpr const_reverse_iterator crbegin() const { return const_reverse_iterator{cend()}; }
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crbegin() const { return const_reverse_iterator{cend()}; }
 
-    constexpr const_reverse_iterator crend() const { return const_reverse_iterator{cbegin()}; }
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crend() const { return const_reverse_iterator{cbegin()}; }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator==(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator==(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return bounds_.size() == other.bounds_.size() &&
                (data_ == other.data_ || std::equal(this->begin(), this->end(), other.begin()));
@@ -1896,7 +1896,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator!=(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator!=(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(*this == other);
     }
@@ -1904,7 +1904,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator<(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return std::lexicographical_compare(this->begin(), this->end(), other.begin(), other.end());
     }
@@ -1912,7 +1912,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<=(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator<=(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(other < *this);
     }
@@ -1920,7 +1920,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator>(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return (other < *this);
     }
@@ -1928,7 +1928,7 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>=(const strided_span<OtherValueType, OtherRank>& other) const noexcept
+    GSL_IMPL_CONSTEXPR bool operator>=(const strided_span<OtherValueType, OtherRank>& other) const GSL_IMPL_NOEXCEPT
     {
         return !(*this < other);
     }
@@ -2004,75 +2004,75 @@ private:
     }
 
 public:
-    reference operator*() const noexcept
+    reference operator*() const GSL_IMPL_NOEXCEPT
     {
         validateThis();
         return *data_;
     }
-    pointer operator->() const noexcept
+    pointer operator->() const GSL_IMPL_NOEXCEPT
     {
         validateThis();
         return data_;
     }
-    contiguous_span_iterator& operator++() noexcept
+    contiguous_span_iterator& operator++() GSL_IMPL_NOEXCEPT
     {
         ++data_;
         return *this;
     }
-    contiguous_span_iterator operator++(int) noexcept
+    contiguous_span_iterator operator++(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         ++(*this);
         return ret;
     }
-    contiguous_span_iterator& operator--() noexcept
+    contiguous_span_iterator& operator--() GSL_IMPL_NOEXCEPT
     {
         --data_;
         return *this;
     }
-    contiguous_span_iterator operator--(int) noexcept
+    contiguous_span_iterator operator--(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         --(*this);
         return ret;
     }
-    contiguous_span_iterator operator+(difference_type n) const noexcept
+    contiguous_span_iterator operator+(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         contiguous_span_iterator ret{*this};
         return ret += n;
     }
-    contiguous_span_iterator& operator+=(difference_type n) noexcept
+    contiguous_span_iterator& operator+=(difference_type n) GSL_IMPL_NOEXCEPT
     {
         data_ += n;
         return *this;
     }
-    contiguous_span_iterator operator-(difference_type n) const noexcept
+    contiguous_span_iterator operator-(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         contiguous_span_iterator ret{*this};
         return ret -= n;
     }
-    contiguous_span_iterator& operator-=(difference_type n) noexcept { return * this += -n; }
-    difference_type operator-(const contiguous_span_iterator& rhs) const noexcept
+    contiguous_span_iterator& operator-=(difference_type n) GSL_IMPL_NOEXCEPT { return * this += -n; }
+    difference_type operator-(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ - rhs.data_;
     }
-    reference operator[](difference_type n) const noexcept { return *(*this + n); }
-    bool operator==(const contiguous_span_iterator& rhs) const noexcept
+    reference operator[](difference_type n) const GSL_IMPL_NOEXCEPT { return *(*this + n); }
+    bool operator==(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ == rhs.data_;
     }
-    bool operator!=(const contiguous_span_iterator& rhs) const noexcept { return !(*this == rhs); }
-    bool operator<(const contiguous_span_iterator& rhs) const noexcept
+    bool operator!=(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(*this == rhs); }
+    bool operator<(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_validator == rhs.m_validator);
         return data_ < rhs.data_;
     }
-    bool operator<=(const contiguous_span_iterator& rhs) const noexcept { return !(rhs < *this); }
-    bool operator>(const contiguous_span_iterator& rhs) const noexcept { return rhs < *this; }
-    bool operator>=(const contiguous_span_iterator& rhs) const noexcept { return !(rhs > *this); }
-    void swap(contiguous_span_iterator& rhs) noexcept
+    bool operator<=(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs < *this); }
+    bool operator>(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return rhs < *this; }
+    bool operator>=(const contiguous_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs > *this); }
+    void swap(contiguous_span_iterator& rhs) GSL_IMPL_NOEXCEPT
     {
         std::swap(data_, rhs.data_);
         std::swap(m_validator, rhs.m_validator);
@@ -2081,7 +2081,7 @@ public:
 
 template <typename Span>
 contiguous_span_iterator<Span> operator+(typename contiguous_span_iterator<Span>::difference_type n,
-                                         const contiguous_span_iterator<Span>& rhs) noexcept
+                                         const contiguous_span_iterator<Span>& rhs) GSL_IMPL_NOEXCEPT
 {
     return rhs + n;
 }
@@ -2111,71 +2111,71 @@ private:
     }
 
 public:
-    reference operator*() noexcept { return (*m_container)[*m_itr]; }
-    pointer operator->() noexcept { return &(*m_container)[*m_itr]; }
-    general_span_iterator& operator++() noexcept
+    reference operator*() GSL_IMPL_NOEXCEPT { return (*m_container)[*m_itr]; }
+    pointer operator->() GSL_IMPL_NOEXCEPT { return &(*m_container)[*m_itr]; }
+    general_span_iterator& operator++() GSL_IMPL_NOEXCEPT
     {
         ++m_itr;
         return *this;
     }
-    general_span_iterator operator++(int) noexcept
+    general_span_iterator operator++(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         ++(*this);
         return ret;
     }
-    general_span_iterator& operator--() noexcept
+    general_span_iterator& operator--() GSL_IMPL_NOEXCEPT
     {
         --m_itr;
         return *this;
     }
-    general_span_iterator operator--(int) noexcept
+    general_span_iterator operator--(int) GSL_IMPL_NOEXCEPT
     {
         auto ret = *this;
         --(*this);
         return ret;
     }
-    general_span_iterator operator+(difference_type n) const noexcept
+    general_span_iterator operator+(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         general_span_iterator ret{*this};
         return ret += n;
     }
-    general_span_iterator& operator+=(difference_type n) noexcept
+    general_span_iterator& operator+=(difference_type n) GSL_IMPL_NOEXCEPT
     {
         m_itr += n;
         return *this;
     }
-    general_span_iterator operator-(difference_type n) const noexcept
+    general_span_iterator operator-(difference_type n) const GSL_IMPL_NOEXCEPT
     {
         general_span_iterator ret{*this};
         return ret -= n;
     }
-    general_span_iterator& operator-=(difference_type n) noexcept { return * this += -n; }
-    difference_type operator-(const general_span_iterator& rhs) const noexcept
+    general_span_iterator& operator-=(difference_type n) GSL_IMPL_NOEXCEPT { return * this += -n; }
+    difference_type operator-(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr - rhs.m_itr;
     }
-    value_type operator[](difference_type n) const noexcept
+    value_type operator[](difference_type n) const GSL_IMPL_NOEXCEPT
     {
         return (*m_container)[m_itr[n]];
         ;
     }
-    bool operator==(const general_span_iterator& rhs) const noexcept
+    bool operator==(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr == rhs.m_itr;
     }
-    bool operator!=(const general_span_iterator& rhs) const noexcept { return !(*this == rhs); }
-    bool operator<(const general_span_iterator& rhs) const noexcept
+    bool operator!=(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(*this == rhs); }
+    bool operator<(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT
     {
         GSL_EXPECTS(m_container == rhs.m_container);
         return m_itr < rhs.m_itr;
     }
-    bool operator<=(const general_span_iterator& rhs) const noexcept { return !(rhs < *this); }
-    bool operator>(const general_span_iterator& rhs) const noexcept { return rhs < *this; }
-    bool operator>=(const general_span_iterator& rhs) const noexcept { return !(rhs > *this); }
-    void swap(general_span_iterator& rhs) noexcept
+    bool operator<=(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs < *this); }
+    bool operator>(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return rhs < *this; }
+    bool operator>=(const general_span_iterator& rhs) const GSL_IMPL_NOEXCEPT { return !(rhs > *this); }
+    void swap(general_span_iterator& rhs) GSL_IMPL_NOEXCEPT
     {
         std::swap(m_itr, rhs.m_itr);
         std::swap(m_container, rhs.m_container);
@@ -2184,41 +2184,29 @@ public:
 
 template <typename Span>
 general_span_iterator<Span> operator+(typename general_span_iterator<Span>::difference_type n,
-                                      const general_span_iterator<Span>& rhs) noexcept
+                                      const general_span_iterator<Span>& rhs) GSL_IMPL_NOEXCEPT
 {
     return rhs + n;
 }
 
 } // namespace gsl
 
-#ifdef _MSC_VER
+#undef GSL_IMPL_CONSTEXPR
+#undef GSL_IMPL_NOEXCEPT
 
-#undef constexpr
-#pragma pop_macro("constexpr")
+
+#ifdef _MSC_VER
 
 #if _MSC_VER <= 1800
 #pragma warning(pop)
-
-#ifndef GSL_THROW_ON_CONTRACT_VIOLATION
-#undef noexcept
-#pragma pop_macro("noexcept")
-#endif // GSL_THROW_ON_CONTRACT_VIOLATION
-
 #undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-
 #endif // _MSC_VER <= 1800
 
-#endif // _MSC_VER
 
 #if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
-
-#undef noexcept
-
-#ifdef _MSC_VER
 #pragma warning(pop)
-#pragma pop_macro("noexcept")
-#endif
-
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
+
+#endif // _MSC_VER
 
 #endif // GSL_SPAN_H

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -100,7 +100,7 @@ span<T, dynamic_range> ensure_sentinel(T* seq, std::ptrdiff_t max = PTRDIFF_MAX)
 {
     auto cur = seq;
     while ((cur - seq) < max && *cur != Sentinel) ++cur;
-    Ensures(*cur == Sentinel);
+    GSL_ENSURES(*cur == Sentinel);
     return{ seq, cur - seq };
 }
 
@@ -120,28 +120,28 @@ inline span<T, dynamic_range> ensure_z(T* const & sz, std::ptrdiff_t max = PTRDI
 inline span<char, dynamic_range> ensure_z(char* const& sz, std::ptrdiff_t max)
 {
     auto len = strnlen(sz, narrow_cast<size_t>(max));
-    Ensures(sz[len] == 0);
+    GSL_ENSURES(sz[len] == 0);
     return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
 inline span<const char, dynamic_range> ensure_z(const char* const& sz, std::ptrdiff_t max)
 {
     auto len = strnlen(sz, narrow_cast<size_t>(max));
-    Ensures(sz[len] == 0);
+    GSL_ENSURES(sz[len] == 0);
     return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
 inline span<wchar_t, dynamic_range> ensure_z(wchar_t* const& sz, std::ptrdiff_t max)
 {
     auto len = wcsnlen(sz, narrow_cast<size_t>(max));
-    Ensures(sz[len] == 0);
+    GSL_ENSURES(sz[len] == 0);
     return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
 inline span<const wchar_t, dynamic_range> ensure_z(const wchar_t* const& sz, std::ptrdiff_t max)
 {
     auto len = wcsnlen(sz, narrow_cast<size_t>(max));
-    Ensures(sz[len] == 0);
+    GSL_ENSURES(sz[len] == 0);
     return{ sz, static_cast<std::ptrdiff_t>(len) };
 }
 
@@ -547,7 +547,7 @@ public:
         : span_(span)
     {
         // expects a zero-terminated span
-        Expects(span[span.size() - 1] == '\0');
+        GSL_EXPECTS(span[span.size() - 1] == '\0');
     }
 
     // copy

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -25,11 +25,14 @@
 #include <cstring>
 #include <string>
 
+#define GSL_IMPL_CONSTEXPR constexpr
+#define GSL_IMPL_NOEXCEPT noexcept
+
 #ifdef _MSC_VER
 
 // No MSVC does constexpr fully yet
-#pragma push_macro("constexpr")
-#define constexpr /* nothing */
+#undef GSL_IMPL_CONSTEXPR
+#define GSL_IMPL_CONSTEXPR /* nothing */
 
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
@@ -41,8 +44,8 @@
 
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
-#pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#undef GSL_IMPL_NOEXCEPT
+#define GSL_IMPL_NOEXCEPT /* nothing */
 #endif
 
 #endif // _MSC_VER <= 1800
@@ -51,11 +54,8 @@
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
 
-#ifdef _MSC_VER
-#pragma push_macro("noexcept")
-#endif
-
-#define noexcept /* nothing */
+#undef GSL_IMPL_NOEXCEPT
+#define GSL_IMPL_NOEXCEPT /* nothing */
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
@@ -178,7 +178,7 @@ namespace details
     template <>
     struct length_func<char>
     {
-        std::ptrdiff_t operator()(char* const ptr, std::ptrdiff_t length) noexcept
+        std::ptrdiff_t operator()(char* const ptr, std::ptrdiff_t length) GSL_IMPL_NOEXCEPT
         {
             return narrow_cast<std::ptrdiff_t>(strnlen(ptr, narrow_cast<size_t>(length)));
         }
@@ -187,7 +187,7 @@ namespace details
     template <>
     struct length_func<wchar_t>
     {
-        std::ptrdiff_t operator()(wchar_t* const ptr, std::ptrdiff_t length) noexcept
+        std::ptrdiff_t operator()(wchar_t* const ptr, std::ptrdiff_t length) GSL_IMPL_NOEXCEPT
         {
             return narrow_cast<std::ptrdiff_t>(wcsnlen(ptr, narrow_cast<size_t>(length)));
         }
@@ -196,7 +196,7 @@ namespace details
     template <>
     struct length_func<const char>
     {
-        std::ptrdiff_t operator()(const char* const ptr, std::ptrdiff_t length) noexcept
+        std::ptrdiff_t operator()(const char* const ptr, std::ptrdiff_t length) GSL_IMPL_NOEXCEPT
         {
             return narrow_cast<std::ptrdiff_t>(strnlen(ptr, narrow_cast<size_t>(length)));
         }
@@ -205,7 +205,7 @@ namespace details
     template <>
     struct length_func<const wchar_t>
     {
-        std::ptrdiff_t operator()(const wchar_t* const ptr, std::ptrdiff_t length) noexcept
+        std::ptrdiff_t operator()(const wchar_t* const ptr, std::ptrdiff_t length) GSL_IMPL_NOEXCEPT
         {
             return narrow_cast<std::ptrdiff_t>(wcsnlen(ptr, narrow_cast<size_t>(length)));
         }
@@ -237,28 +237,28 @@ public:
     using const_reverse_iterator = typename impl_type::const_reverse_iterator;
 
     // default (empty)
-    constexpr basic_string_span() = default;
+    GSL_IMPL_CONSTEXPR basic_string_span() = default;
 
     // copy
-    constexpr basic_string_span(const basic_string_span& other) = default;
+    GSL_IMPL_CONSTEXPR basic_string_span(const basic_string_span& other) = default;
 
     // move
 #ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-    constexpr basic_string_span(basic_string_span&& other) = default;
+    GSL_IMPL_CONSTEXPR basic_string_span(basic_string_span&& other) = default;
 #else
-    constexpr basic_string_span(basic_string_span&& other)
+    GSL_IMPL_CONSTEXPR basic_string_span(basic_string_span&& other)
     	: span_(std::move(other.span_))
     {}
 #endif
 
     // assign
-    constexpr basic_string_span& operator=(const basic_string_span& other) = default;
+    GSL_IMPL_CONSTEXPR basic_string_span& operator=(const basic_string_span& other) = default;
 
     // move assign
 #ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-    constexpr basic_string_span& operator=(basic_string_span&& other) = default;
+    GSL_IMPL_CONSTEXPR basic_string_span& operator=(basic_string_span&& other) = default;
 #else
-    constexpr basic_string_span& operator=(basic_string_span&& other)
+    GSL_IMPL_CONSTEXPR basic_string_span& operator=(basic_string_span&& other)
     {
         span_ = std::move(other.span_);
         return *this;
@@ -266,12 +266,12 @@ public:
 #endif
 
     // from nullptr
-    constexpr basic_string_span(std::nullptr_t ptr) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(std::nullptr_t ptr) GSL_IMPL_NOEXCEPT
         : span_(ptr)
     {}
 
     // from nullptr and length
-    constexpr basic_string_span(std::nullptr_t ptr, size_type length) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(std::nullptr_t ptr, size_type length) GSL_IMPL_NOEXCEPT
         : span_(ptr, length)
     {}
 
@@ -279,19 +279,19 @@ public:
 
     // from static arrays and string literals
     template<size_t N>
-    constexpr basic_string_span(value_type(&arr)[N]) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(value_type(&arr)[N]) GSL_IMPL_NOEXCEPT
         : span_(remove_z(arr))
     {}
 
     // Those allow 0s within the length, so we do not remove them
 
     // from raw data and length
-    constexpr basic_string_span(pointer ptr, size_type length) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(pointer ptr, size_type length) GSL_IMPL_NOEXCEPT
         : span_(ptr, length)
     {}
 
     // from string
-    constexpr basic_string_span(std::string& s) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(std::string& s) GSL_IMPL_NOEXCEPT
         : span_(const_cast<pointer>(s.data()), narrow_cast<std::ptrdiff_t>(s.length()))
     {}
 
@@ -303,7 +303,7 @@ public:
         && std::is_convertible<DataType*, value_type*>::value
         && std::is_same<std::decay_t<decltype(std::declval<Cont>().size(), *std::declval<Cont>().data())>, DataType>::value>
     >
-    constexpr basic_string_span(Cont& cont)
+    GSL_IMPL_CONSTEXPR basic_string_span(Cont& cont)
         : span_(cont.data(), cont.size())
     {}
 
@@ -323,17 +323,17 @@ public:
         std::is_convertible<OtherValueType*, value_type*>::value
         && std::is_convertible<static_bounds<OtherExtent>, bounds_type>::value>
     >
-    constexpr basic_string_span(span<OtherValueType, OtherExtent> other) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(span<OtherValueType, OtherExtent> other) GSL_IMPL_NOEXCEPT
         : span_(other)
     {}
 #else
     // from span
-    constexpr basic_string_span(span<value_type, Extent> other) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(span<value_type, Extent> other) GSL_IMPL_NOEXCEPT
         : span_(other)
     {}
         
     template <typename Dummy = std::enable_if_t<!std::is_same<std::remove_const_t<value_type>, value_type>::value>>
-    constexpr basic_string_span(span<std::remove_const_t<value_type>, Extent> other) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(span<std::remove_const_t<value_type>, Extent> other) GSL_IMPL_NOEXCEPT
         : span_(other)
     {}
 #endif
@@ -343,134 +343,134 @@ public:
         typename OtherBounds = static_bounds<OtherExtent>,
         typename Dummy = std::enable_if_t<std::is_convertible<OtherValueType*, value_type*>::value && std::is_convertible<OtherBounds, bounds_type>::value>
     >
-    constexpr basic_string_span(basic_string_span<OtherValueType, OtherExtent> other) noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span(basic_string_span<OtherValueType, OtherExtent> other) GSL_IMPL_NOEXCEPT
         : span_(other.data(), other.length())
     {}
 
-    constexpr bool empty() const noexcept
+    GSL_IMPL_CONSTEXPR bool empty() const GSL_IMPL_NOEXCEPT
     {
         return length() == 0;
     }
 
     // first Count elements
     template<size_type Count>
-    constexpr basic_string_span<value_type, Count> first() const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, Count> first() const GSL_IMPL_NOEXCEPT
     {
         return{ span_.template first<Count>() };
     }
 
-    constexpr basic_string_span<value_type, dynamic_range> first(size_type count) const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, dynamic_range> first(size_type count) const GSL_IMPL_NOEXCEPT
     {
         return{ span_.first(count) };
     }
 
     // last Count elements
     template<size_type Count>
-    constexpr basic_string_span<value_type, Count> last() const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, Count> last() const GSL_IMPL_NOEXCEPT
     {
         return{ span_.template last<Count>() };
     }
 
-    constexpr basic_string_span<value_type, dynamic_range> last(size_type count) const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, dynamic_range> last(size_type count) const GSL_IMPL_NOEXCEPT
     {
         return{ span_.last(count) };
     }
 
     // create a subview of Count elements starting from Offset
     template<size_type Offset, size_type Count>
-    constexpr basic_string_span<value_type, Count> subspan() const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, Count> subspan() const GSL_IMPL_NOEXCEPT
     {
         return{ span_.template subspan<Offset, Count>() };
     }
 
-    constexpr basic_string_span<value_type, dynamic_range> subspan(size_type offset, size_type count = dynamic_range) const noexcept
+    GSL_IMPL_CONSTEXPR basic_string_span<value_type, dynamic_range> subspan(size_type offset, size_type count = dynamic_range) const GSL_IMPL_NOEXCEPT
     {
         return{ span_.subspan(offset, count) };
     }
 
-    constexpr reference operator[](size_type idx) const noexcept
+    GSL_IMPL_CONSTEXPR reference operator[](size_type idx) const GSL_IMPL_NOEXCEPT
     {
         return span_[idx];
     }
 
-    constexpr pointer data() const noexcept
+    GSL_IMPL_CONSTEXPR pointer data() const GSL_IMPL_NOEXCEPT
     {
         return span_.data();
     }
 
     // length of the span in elements
-    constexpr size_type length() const noexcept
+    GSL_IMPL_CONSTEXPR size_type length() const GSL_IMPL_NOEXCEPT
     {
         return span_.size();
     }
 
     // length of the span in elements
-    constexpr size_type size() const noexcept
+    GSL_IMPL_CONSTEXPR size_type size() const GSL_IMPL_NOEXCEPT
     {
         return span_.size();
     }
 
     // length of the span in bytes
-    constexpr size_type size_bytes() const noexcept
+    GSL_IMPL_CONSTEXPR size_type size_bytes() const GSL_IMPL_NOEXCEPT
     {
         return span_.size_bytes();
     }
 
     // length of the span in bytes
-    constexpr size_type length_bytes() const noexcept
+    GSL_IMPL_CONSTEXPR size_type length_bytes() const GSL_IMPL_NOEXCEPT
     {
         return span_.length_bytes();
     }
 
-    constexpr iterator begin() const noexcept
+    GSL_IMPL_CONSTEXPR iterator begin() const GSL_IMPL_NOEXCEPT
     {
         return span_.begin();
     }
 
-    constexpr iterator end() const noexcept
+    GSL_IMPL_CONSTEXPR iterator end() const GSL_IMPL_NOEXCEPT
     {
         return span_.end();
     }
 
-    constexpr const_iterator cbegin() const noexcept
+    GSL_IMPL_CONSTEXPR const_iterator cbegin() const GSL_IMPL_NOEXCEPT
     {
         return span_.cbegin();
     }
 
-    constexpr const_iterator cend() const noexcept
+    GSL_IMPL_CONSTEXPR const_iterator cend() const GSL_IMPL_NOEXCEPT
     {
         return span_.cend();
     }
 
-    constexpr reverse_iterator rbegin() const noexcept
+    GSL_IMPL_CONSTEXPR reverse_iterator rbegin() const GSL_IMPL_NOEXCEPT
     {
         return span_.rbegin();
     }
 
-    constexpr reverse_iterator rend() const noexcept
+    GSL_IMPL_CONSTEXPR reverse_iterator rend() const GSL_IMPL_NOEXCEPT
     {
         return span_.rend();
     }
 
-    constexpr const_reverse_iterator crbegin() const noexcept
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crbegin() const GSL_IMPL_NOEXCEPT
     {
         return span_.crbegin();
     }
 
-    constexpr const_reverse_iterator crend() const noexcept
+    GSL_IMPL_CONSTEXPR const_reverse_iterator crend() const GSL_IMPL_NOEXCEPT
     {
         return span_.crend();
     }
 
 private:
 
-    static impl_type remove_z(pointer const& sz, std::ptrdiff_t max) noexcept
+    static impl_type remove_z(pointer const& sz, std::ptrdiff_t max) GSL_IMPL_NOEXCEPT
     {
         return{ sz, details::length_func<value_type>()(sz, max)};
     }
 
     template<size_t N>
-    static impl_type remove_z(value_type(&sz)[N]) noexcept
+    static impl_type remove_z(value_type(&sz)[N]) GSL_IMPL_NOEXCEPT
     {
         return remove_z(&sz[0], narrow_cast<std::ptrdiff_t>(N));
     }
@@ -543,7 +543,7 @@ public:
     using impl_type = span<value_type, Extent>;
     using string_span_type = basic_string_span<value_type, Extent>;
 
-    constexpr basic_zstring_span(impl_type span) noexcept
+    GSL_IMPL_CONSTEXPR basic_zstring_span(impl_type span) GSL_IMPL_NOEXCEPT
         : span_(span)
     {
         // expects a zero-terminated span
@@ -551,38 +551,38 @@ public:
     }
 
     // copy
-    constexpr basic_zstring_span(const basic_zstring_span& other) = default;
+    GSL_IMPL_CONSTEXPR basic_zstring_span(const basic_zstring_span& other) = default;
 
     // move
 #ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-    constexpr basic_zstring_span(basic_zstring_span&& other) = default;
+    GSL_IMPL_CONSTEXPR basic_zstring_span(basic_zstring_span&& other) = default;
 #else
-    constexpr basic_zstring_span(basic_zstring_span&& other)
+    GSL_IMPL_CONSTEXPR basic_zstring_span(basic_zstring_span&& other)
         : span_(std::move(other.span_))
     {}
 #endif
 
     // assign
-    constexpr basic_zstring_span& operator=(const basic_zstring_span& other) = default;
+    GSL_IMPL_CONSTEXPR basic_zstring_span& operator=(const basic_zstring_span& other) = default;
 
     // move assign
 #ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-    constexpr basic_zstring_span& operator=(basic_zstring_span&& other) = default;
+    GSL_IMPL_CONSTEXPR basic_zstring_span& operator=(basic_zstring_span&& other) = default;
 #else
-    constexpr basic_zstring_span& operator=(basic_zstring_span&& other)
+    GSL_IMPL_CONSTEXPR basic_zstring_span& operator=(basic_zstring_span&& other)
     {
         span_ = std::move(other.span_);
         return *this;
     }
 #endif
 
-    constexpr bool empty() const noexcept { return span_.size() == 0; }
+    GSL_IMPL_CONSTEXPR bool empty() const GSL_IMPL_NOEXCEPT { return span_.size() == 0; }
 
-    constexpr string_span_type as_string_span() const noexcept { return span_.first(span_.size()-1); }
+    GSL_IMPL_CONSTEXPR string_span_type as_string_span() const GSL_IMPL_NOEXCEPT { return span_.first(span_.size()-1); }
 
-    constexpr string_span_type ensure_z() const noexcept { return gsl::ensure_z(span_); }
+    GSL_IMPL_CONSTEXPR string_span_type ensure_z() const GSL_IMPL_NOEXCEPT { return gsl::ensure_z(span_); }
 
-    constexpr const_zstring_type assume_z() const noexcept { return span_.data(); }
+    GSL_IMPL_CONSTEXPR const_zstring_type assume_z() const GSL_IMPL_NOEXCEPT { return span_.data(); }
 
 private:
     impl_type span_;
@@ -607,7 +607,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator==(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator==(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
 #ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
@@ -622,7 +622,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator==(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator==(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(one);
 #ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
@@ -645,7 +645,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator==(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator==(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
     return std::equal(one.begin(), one.end(), tmp.begin(), tmp.end());
@@ -659,7 +659,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator==(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator==(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(one);
     return std::equal(tmp.begin(), tmp.end(), other.begin(), other.end());
@@ -671,7 +671,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator!=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator!=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(one == other);
 }
@@ -681,7 +681,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator!=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator!=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(one == other);
 }
@@ -699,7 +699,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator!=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator!=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(one == other);
 }
@@ -712,7 +712,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator!=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator!=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(one == other);
 }
@@ -723,7 +723,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
     return std::lexicographical_compare(one.begin(), one.end(), tmp.begin(), tmp.end());
@@ -734,7 +734,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(one);
     return std::lexicographical_compare(tmp.begin(), tmp.end(), other.begin(), other.end());
@@ -753,7 +753,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
     return std::lexicographical_compare(one.begin(), one.end(), tmp.begin(), tmp.end());
@@ -767,7 +767,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(one);
     return std::lexicographical_compare(tmp.begin(), tmp.end(), other.begin(), other.end());
@@ -779,7 +779,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(other < one);
 }
@@ -789,7 +789,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(other < one);
 }
@@ -807,7 +807,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(other < one);
 }
@@ -820,7 +820,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(other < one);
 }
@@ -831,7 +831,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return other < one;
 }
@@ -841,7 +841,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return other < one;
 }
@@ -859,7 +859,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return other < one;
 }
@@ -872,7 +872,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return other < one;
 }
@@ -883,7 +883,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     typename = std::enable_if_t<
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>
 >
-bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(one < other);
 }
@@ -893,7 +893,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value
     && !gsl::details::is_basic_string_span<T>::value>
 >
-bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(one < other);
 }
@@ -911,7 +911,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) noexcept
+bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_IMPL_NOEXCEPT
 {
     return !(one < other);
 }
@@ -924,24 +924,17 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_range, typename T
     && std::is_convertible<DataType*, CharT*>::value
     && std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>, DataType>::value>
 >
-bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexcept
+bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_IMPL_NOEXCEPT
 {
     return !(one < other);
 }
 #endif
 
+#undef GSL_IMPL_NOEXCEPT
+#undef GSL_IMPL_CONSTEXPR
+
 // VS 2013 workarounds
-#ifdef _MSC_VER
-
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#if _MSC_VER <= 1800
-
-#ifndef GSL_THROW_ON_CONTRACT_VIOLATION
-#undef noexcept
-#pragma pop_macro("noexcept")
-#endif // GSL_THROW_ON_CONTRACT_VIOLATION
+#if defined(_MSC_VER) and (_MSC_VER <= 1800)
 
 #undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
 #undef GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
@@ -949,15 +942,5 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexc
 #undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
 
 #endif // _MSC_VER <= 1800
-#endif // _MSC_VER
 
-#if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
-
-#undef noexcept
-
-#ifdef _MSC_VER
-#pragma pop_macro("noexcept")
-#endif
-
-#endif // GSL_THROW_ON_CONTRACT_VIOLATION
 #endif // GSL_STRING_SPAN_H

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -23,7 +23,7 @@ SUITE(assertion_tests)
 {
     int f(int i)
     {
-        Expects(i > 0 && i < 10);
+        GSL_EXPECTS(i > 0 && i < 10);
         return i;
     }
 
@@ -36,7 +36,7 @@ SUITE(assertion_tests)
     int g(int i)
     {        
         i++;
-        Ensures(i > 0 && i < 10);
+        GSL_ENSURES(i > 0 && i < 10);
         return i;
     }
 

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -833,7 +833,7 @@ SUITE(string_span_tests)
 
     czstring_span<> CreateTempName(string_span<> span)
     {
-        Expects(span.size() > 1);
+        GSL_EXPECTS(span.size() > 1);
 
         int last = 0;
         if (span.size() > 4)
@@ -890,7 +890,7 @@ SUITE(string_span_tests)
 
     cwzstring_span<> CreateTempNameW(wstring_span<> span)
     {
-        Expects(span.size() > 1);
+        GSL_EXPECTS(span.size() > 1);
 
         int last = 0;
         if (span.size() > 4)


### PR DESCRIPTION
According to the standard, it is undefined behavior to re-`#define` keywords. The first part of this pull request fixes that.

[According to the Core-Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-ALL_CAPS), macros should always be in `ALL_CAPS`. Since `Expects` and `Ensures` are macros, this commit renames them accordingly:

* By default, their new names are `GSL_EXPECTS` and `GSL_ENSURES`, thereby also not polluting the global macro-namespace.
* if `GSL_USE_UNPREFIXED_CONTRACTS` is defined, `EXPECTS` and `ENSURES` will defined as aliases
* if `GSL_USE_UNPREFIXED_AND_LOWERCASE_CONTRACTS` is defined, `Expects` and `Ensures` will be defined as aliases
* The two-alias-options are independent of each other.

I've compiled and tested the code under x86_64 Debian GNU/Linux with GCC 5.3 and Clang 3.6 and could not observe problems. Since most of the changes of the first part will however only affect VS, it would be very wise to test that as well.