### PR TITLE
Making unittest-cpp a submodule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tests/unittest-cpp
 CMakeFiles
 tests/CMakeFiles
 tests/Debug

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/unittest-cpp"]
+	path = tests/unittest-cpp
+	url = https://github.com/Microsoft/unittest-cpp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ install:
 
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
-  - git clone --depth 1 https://github.com/Microsoft/unittest-cpp tests/unittest-cpp
   - cmake -H. -Bb -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_INSTALL_PREFIX=$PWD/o -DCMAKE_BUILD_TYPE=$BUILD_TYPE
   - cmake --build b
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.7)
 
 project(GSLTests CXX)
 
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unittest-cpp/tests)
+    execute_process(COMMAND git submodule update --init WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
 add_subdirectory(unittest-cpp)
 
 include_directories(
@@ -26,10 +30,6 @@ else()
     else()
       message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
     endif()
-endif()
-
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unittest-cpp/tests)
-    execute_process(COMMAND git submodule update --init --recursive WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 function(add_gsl_test name)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,8 +28,8 @@ else()
     endif()
 endif()
 
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unittest-cpp)
-  message(FATAL_ERROR "Could not find unittest-cpp enlistment. Please run 'git clone https://github.com/Microsoft/unittest-cpp.git unittest-cpp' in the tests directory")
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unittest-cpp/tests)
+    execute_process(COMMAND git submodule update --init --recursive WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 function(add_gsl_test name)


### PR DESCRIPTION
This should address the following issue: https://github.com/Microsoft/GSL/issues/47
Note that I invoke git within cmake to automatically initialize the submodule. This assumes that git is in the path.