### PR TITLE
[span] Fix UB hack in static_bounds::operator=(const static_bounds&)

### DIFF
--- a/gsl/multi_span
+++ b/gsl/multi_span
@@ -308,8 +308,6 @@ namespace details
         {
         }
 
-        BoundsRanges(const BoundsRanges&) = default;
-        BoundsRanges& operator=(const BoundsRanges&) = default;
         BoundsRanges(const std::ptrdiff_t* const) {}
         BoundsRanges() = default;
 
@@ -346,9 +344,9 @@ namespace details
         static const size_t DynamicNum = Base::DynamicNum + 1;
         static const size_type CurrentRange = dynamic_range;
         static const size_type TotalSize = dynamic_range;
-        const size_type m_bound;
-
-        BoundsRanges(const BoundsRanges&) = default;
+    private:
+        size_type m_bound;
+    public:
 
         BoundsRanges(const std::ptrdiff_t* const arr)
             : Base(arr + 1), m_bound(*arr * this->Base::totalSize())
@@ -419,8 +417,6 @@ namespace details
         static const size_type CurrentRange = CurRange;
         static const size_type TotalSize =
             Base::TotalSize == dynamic_range ? dynamic_range : CurrentRange * Base::TotalSize;
-
-        BoundsRanges(const BoundsRanges&) = default;
 
         BoundsRanges(const std::ptrdiff_t* const arr) : Base(arr) {}
         BoundsRanges() = default;
@@ -632,12 +628,6 @@ public:
     }
 
     constexpr static_bounds() = default;
-
-    constexpr static_bounds& operator=(const static_bounds& otherBounds)
-    {
-        new (&m_ranges) MyRanges(otherBounds.m_ranges);
-        return *this;
-    }
 
     constexpr sliced_type slice() const noexcept
     {


### PR DESCRIPTION
* Make `BoundsRanges<dynamic_range, ...>::m_bound` non-`const` and private
* Remove various defaulted copy constructor/assignment declarations from `BoundsRanges` specializations whose only effect is to needlessly suppress the generation of moves
* Remove the hackish `static_bounds::operator=(const static_bounds&)`. The implicitly generated default is now sufficient.

Technically, the `new` expression itself:
```c++
new (&m_ranges) MyRanges(otherBounds.m_ranges); 
```
has defined behavior. The problem is that any access to the new object created atop `m_ranges` through the name of or pointers to the object that previously existed there does result in UB per [basic.life]/7.3.