### PR TITLE
Suppressed CppCoreCheck warnings.

### DIFF
--- a/include/gsl_util.h
+++ b/include/gsl_util.h
@@ -31,6 +31,9 @@
 #pragma push_macro("constexpr")
 #define constexpr
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant
+
 // MSVC 2013 workarounds
 #if _MSC_VER <= 1800
 // noexcept is not understood
@@ -40,7 +43,6 @@
 // turn off some misguided warnings
 #pragma warning(push)
 #pragma warning(disable: 4351) // warns about newly introduced aggregate initializer behavior
-#pragma warning(disable: 4127) // conditional expression is constant
 
 #endif // _MSC_VER <= 1800
 
@@ -130,6 +132,8 @@ constexpr typename Cont::value_type& at(Cont& cont, size_t index)
 
 
 #ifdef _MSC_VER
+
+#pragma warning(pop)
 
 #undef constexpr
 #pragma pop_macro("constexpr")

--- a/include/span.h
+++ b/include/span.h
@@ -37,9 +37,15 @@
 
 #ifdef _MSC_VER
 
-// turn off some warnings that are noisy about our Expects statements
 #pragma warning(push)
+
+// turn off some warnings that are noisy about our Expects statements
 #pragma warning(disable : 4127) // conditional expression is constant
+
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable: 26481 26482 26483 26485 26490 26491 26492 26493 26495)
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")

--- a/include/string_span.h
+++ b/include/string_span.h
@@ -31,6 +31,14 @@
 #pragma push_macro("constexpr")
 #define constexpr /* nothing */
 
+#pragma warning(push)
+
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable: 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+
+
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
 
@@ -930,12 +938,14 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) noexc
 }
 #endif
 
-// VS 2013 workarounds
 #ifdef _MSC_VER
+
+#pragma warning(pop)
 
 #undef constexpr
 #pragma pop_macro("constexpr")
 
+// VS 2013 workarounds
 #if _MSC_VER <= 1800
 
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION


### PR DESCRIPTION
This will prevent warnings about the GSL implementation from needlessly annoying users of CppCoreCheck. A more targeted set of suppressions will go into a future revision of the GSL.