### PR TITLE
gsl::at overload for initializer_list

### DIFF
--- a/include/gsl_util.h
+++ b/include/gsl_util.h
@@ -128,6 +128,10 @@ template <class Cont>
 constexpr typename Cont::value_type& at(Cont& cont, size_t index)
 { Expects(index < cont.size()); return cont[index]; }
 
+template <class T>
+constexpr const T& at(std::initializer_list<T> cont, size_t index)
+{ Expects(index < cont.size()); return *(cont.begin() + index); }
+
 } // namespace gsl
 
 

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -17,6 +17,7 @@
 #include <UnitTest++/UnitTest++.h> 
 #include <gsl.h>
 #include <vector>
+#include <initializer_list>
 
 using namespace std;
 using namespace gsl;
@@ -46,6 +47,16 @@ SUITE(at_tests)
     TEST(StdVector)
     {
         std::vector<int> a = { 1, 2, 3, 4 };
+
+        for (int i = 0; i < 4; ++i)
+            CHECK(at(a, i) == i+1);
+
+        CHECK_THROW(at(a, 4), fail_fast);
+    }
+
+    TEST(InitializerList)
+    {
+        std::initializer_list<int> a = { 1, 2, 3, 4 };
 
         for (int i = 0; i < 4; ++i)
             CHECK(at(a, i) == i+1);


### PR DESCRIPTION
initializer_list do not have subscript operator, so the generic container overload of gsl::at fails to compile.
This commits adds an overload of gsl::at for initializer_lists, using *(initializer_list::begin()+index) instead of subscript operator, and associated test