### PR TITLE
Differentiating exception type for Expects and Ensures for option [GSL_THROW_ON_CONTRACT_VIOLATION]

### DIFF
--- a/include/gsl_assert.h
+++ b/include/gsl_assert.h
@@ -22,6 +22,18 @@
 #include <exception>
 #include <stdexcept>
 
+#ifdef _MSC_VER
+
+// MSVC 2013 workarounds
+#if _MSC_VER <= 1800
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept
+
+#endif // _MSC_VER <= 1800
+
+#endif // _MSC_VER
+
 //
 // There are three configuration options for this GSL implementation's behavior
 // when pre/post conditions on the GSL types are violated:
@@ -85,6 +97,18 @@ namespace details
 #define Ensures(cond)           
 
 #endif 
+
+
+#ifdef _MSC_VER
+
+#if _MSC_VER <= 1800
+
+#undef noexcept
+#pragma pop_macro("noexcept")
+
+#endif // _MSC_VER <= 1800
+
+#endif // _MSC_VER
 
 
 #endif // GSL_CONTRACTS_H

--- a/include/gsl_assert.h
+++ b/include/gsl_assert.h
@@ -47,7 +47,7 @@ namespace gsl
 {
 struct fail_fast
 {
-    virtual char const* what() const = 0;
+    virtual char const* what() const noexcept = 0;
 };
 
 namespace details
@@ -56,7 +56,7 @@ namespace details
     struct contract_violation : public E, public fail_fast
     {
         explicit contract_violation(char const* const message) : E(message) {}
-        virtual char const* what() const override
+        virtual char const* what() const noexcept override
         {
             return E::what();
         }

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -31,6 +31,19 @@ SUITE(assertion_tests)
     {
         CHECK(f(2) == 2);
         CHECK_THROW(f(10), fail_fast);
+        try { f(10); }
+        catch (fail_fast const& e) {
+            cstring_span<> prefix = ensure_z("GSL: Precondition failure");
+            cstring_span<> what = ensure_z(e.what()).first(prefix.length());
+            CHECK(prefix == what);
+        }
+        CHECK_THROW(f(10), std::logic_error);
+        try { f(10); }
+        catch (std::logic_error const& e) {
+            cstring_span<> prefix = ensure_z("GSL: Precondition failure");
+            cstring_span<> what = ensure_z(e.what()).first(prefix.length());
+            CHECK(prefix == what);
+        }
     }
 
     int g(int i)
@@ -44,7 +57,20 @@ SUITE(assertion_tests)
     {
         CHECK(g(2) == 3);
         CHECK_THROW(g(9), fail_fast);
-    }
+        try { g(9); }
+        catch (fail_fast const& e) {
+            cstring_span<> prefix = ensure_z("GSL: Postcondition failure");
+            cstring_span<> what = ensure_z(e.what()).first(prefix.length());
+            CHECK(prefix == what);
+        }
+        CHECK_THROW(g(9), std::runtime_error);
+        try { g(9); }
+        catch (std::runtime_error const& e) {
+            cstring_span<> prefix = ensure_z("GSL: Postcondition failure");
+            cstring_span<> what = ensure_z(e.what()).first(prefix.length());
+            CHECK(prefix == what);
+        }
+   }
 }
 
 int main(int, const char *[])


### PR DESCRIPTION
Expects now throws std::logic_error when Ensures throws std::runtime_error (issue #298).
Uses multiple inheritance so that the exception thrown is both the standard and the gsl::fail_fast to limit the risks of breaking existing code.
