### PR TITLE
fix use of gsl::at with span (broken by PR #309)

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -377,6 +377,8 @@ public:
     using index_type = std::ptrdiff_t;
     using pointer = element_type*;
     using reference = element_type&;
+    
+    using value_type = ElementType;
 
     using iterator = details::span_iterator<span<ElementType, Extent>, false>;
     using const_iterator = details::span_iterator<span<ElementType, Extent>, true>;

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1354,6 +1354,13 @@ SUITE(span_tests)
         CHECK(match[0].first == f_it);
         CHECK(match[0].second == (f_it + 1));
     }
+
+    TEST(interop_with_gsl_at)
+    {
+        int arr[5] = {1, 2, 3, 4, 5};
+        span<int> s{arr};
+        CHECK(at(s,0) == 1 && at(s,1) == 2);
+    }
 }
 
 int main(int, const char* []) { return UnitTest::RunAllTests(); }


### PR DESCRIPTION
PR #309 removed `using value_type = ValueType;` from span class, which broke the use of gsl::at with a span argument. This PR re-enables it.