### PR TITLE
Specialize gsl::at for span

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -653,6 +653,14 @@ as_writeable_bytes(span<ElementType, Extent> s) noexcept
     return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
 }
 
+// Specialization of gsl::at for span
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr ElementType& at(const span<ElementType ,Extent>& s, size_t index)
+{
+    // No bounds checking here because it is done in span::operator[] called below
+    return s[index];
+}
+
 } // namespace gsl
 
 #ifdef _MSC_VER

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1354,6 +1354,13 @@ SUITE(span_tests)
         CHECK(match[0].first == f_it);
         CHECK(match[0].second == (f_it + 1));
     }
+
+    TEST(interop_with_gsl_at)
+    {
+        int arr[5] = {1, 2, 3, 4, 5};
+        span<int> s{arr};
+        CHECK(at(s,0) == 1 && at(s,1) == 2);
+    }
 }
 
 int main(int, const char* []) { return UnitTest::RunAllTests(); }


### PR DESCRIPTION
span being a view and not a container, the generic version of gsl::at is not valid any more for span.
This commits adds a specialization of gsl::at for span