### PR TITLE
Define constexpr as /*constexpr*/ when unavailable (also noexcept)

### DIFF
--- a/gsl/gsl
+++ b/gsl/gsl
@@ -30,13 +30,13 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // MSVC 2013 workarounds
 #if _MSC_VER <= 1800
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 // turn off some misguided warnings
 #pragma warning(push)

--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -26,11 +26,11 @@
 
 // constexpr is not understood
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 #endif // _MSC_VER <= 1800
 

--- a/gsl/gsl_util
+++ b/gsl/gsl_util
@@ -29,7 +29,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
@@ -38,7 +38,7 @@
 #if _MSC_VER <= 1800
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 // turn off some misguided warnings
 #pragma warning(push)

--- a/gsl/multi_span
+++ b/gsl/multi_span
@@ -44,7 +44,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
@@ -55,7 +55,7 @@
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 #endif
 
 // turn off some misguided warnings
@@ -73,7 +73,7 @@
 #pragma push_macro("noexcept")
 #endif
 
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 

--- a/gsl/span
+++ b/gsl/span
@@ -44,7 +44,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
@@ -56,7 +56,7 @@
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 #endif
 
 #pragma push_macro("alignof")
@@ -77,7 +77,7 @@
 #pragma push_macro("noexcept")
 #endif
 
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 

--- a/gsl/string_span
+++ b/gsl/string_span
@@ -30,7 +30,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr /* nothing */
+#define constexpr /*constexpr*/
 
 #pragma warning(push)
 
@@ -50,7 +50,7 @@
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 #endif
 
 #endif // _MSC_VER <= 1800
@@ -67,7 +67,7 @@
 #pragma push_macro("noexcept")
 #endif
 
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 


### PR DESCRIPTION
This PR resolves issue #340.

To give the commented-out `constexpr` the appearance of a single element, there's no whitespace between `constexpr` and `/*`, `*/` .