### PR TITLE
Added to_byte method for issue #329

### DIFF
--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -106,14 +106,15 @@ constexpr IntegerType to_integer(byte b) noexcept
     return {b};
 }
 
-template<bool, typename T>
+template<bool E, typename T>
 constexpr byte to_byte_impl(T t) noexcept
 {
     static_assert(
-        false, 
+        E,
         "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
         "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version."
-    )
+    );
+    return static_cast<byte>(t);
 }
 template<>
 constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept

--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -106,11 +106,33 @@ constexpr IntegerType to_integer(byte b) noexcept
     return {b};
 }
 
-constexpr byte to_byte(unsigned char i) noexcept
+template<bool, typename T>
+constexpr byte to_byte_impl(T t) noexcept
 {
-    return static_cast<byte>(i);
+    static_assert(
+        false, 
+        "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
+        "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version."
+    )
+}
+template<>
+constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept
+{
+     return byte(t);
 }
 
+template<typename T>
+constexpr byte to_byte(T t) noexcept
+{
+     return to_byte_impl<std::is_same<T, unsigned char>::value, T>(t);
+}
+
+template <int I>
+constexpr byte to_byte() noexcept
+{
+    static_assert(I >= 0 && I <= 255, "gsl::byte only has 8 bits of storage, values must be in range 0-255");
+    return static_cast<byte>(I);
+}
 
 } // namespace gsl
 

--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -106,6 +106,12 @@ constexpr IntegerType to_integer(byte b) noexcept
     return {b};
 }
 
+constexpr byte to_byte(unsigned char i) noexcept
+{
+    return static_cast<byte>(i);
+}
+
+
 } // namespace gsl
 
 #ifdef _MSC_VER

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -43,6 +43,11 @@ SUITE(byte_tests)
             byte b = byte(12);
             CHECK(static_cast<unsigned char>(b) == 12);
         }
+        
+        {
+            byte b = to_byte(12);
+            CHECK(static_cast<unsigned char>(b) == 12);
+        }
 
         // waiting for C++17 enum class direct initializer support
         //{
@@ -53,38 +58,38 @@ SUITE(byte_tests)
 
     TEST(bitwise_operations)
     {
-        byte b = byte(0xFF);
+        byte b = to_byte(0xFF);
 
-        byte a = byte(0x00);
-        CHECK((b | a) == byte(0xFF));
-        CHECK(a == byte(0x00));
+        byte a = to_byte(0x00);
+        CHECK((b | a) == to_byte(0xFF));
+        CHECK(a == to_byte(0x00));
 
         a |= b;
-        CHECK(a == byte(0xFF));
+        CHECK(a == to_byte(0xFF));
 
-        a = byte(0x01);
-        CHECK((b & a) == byte(0x01));
+        a = to_byte(0x01);
+        CHECK((b & a) == to_byte(0x01));
 
         a &= b;
-        CHECK(a == byte(0x01));
+        CHECK(a == to_byte(0x01));
 
-        CHECK((b ^ a) == byte(0xFE));
+        CHECK((b ^ a) == to_byte(0xFE));
         
-        CHECK(a == byte(0x01));
+        CHECK(a == to_byte(0x01));
         a ^= b;
-        CHECK(a == byte(0xFE));
+        CHECK(a == to_byte(0xFE));
 
-        a = byte(0x01);
-        CHECK(~a == byte(0xFE));
+        a = to_byte(0x01);
+        CHECK(~a == to_byte(0xFE));
 
-        a = byte(0xFF);
-        CHECK((a << 4) == byte(0xF0));
-        CHECK((a >> 4) == byte(0x0F));
+        a = to_byte(0xFF);
+        CHECK((a << 4) == to_byte(0xF0));
+        CHECK((a >> 4) == to_byte(0x0F));
 
         a <<= 4;
-        CHECK(a == byte(0xF0));
+        CHECK(a == to_byte(0xF0));
         a >>= 4;
-        CHECK(a == byte(0x0F));
+        CHECK(a == to_byte(0x0F));
     }
 }
 

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -45,7 +45,12 @@ SUITE(byte_tests)
         }
         
         {
-            byte b = to_byte(12);
+            byte b = to_byte<12>();
+            CHECK(static_cast<unsigned char>(b) == 12);
+        }
+        {
+            unsigned char uc = 12;
+            byte b = to_byte(uc);
             CHECK(static_cast<unsigned char>(b) == 12);
         }
 
@@ -58,38 +63,38 @@ SUITE(byte_tests)
 
     TEST(bitwise_operations)
     {
-        byte b = to_byte(0xFF);
+        byte b = to_byte<0xFF>();
 
-        byte a = to_byte(0x00);
-        CHECK((b | a) == to_byte(0xFF));
-        CHECK(a == to_byte(0x00));
+        byte a = to_byte<0x00>();
+        CHECK((b | a) == to_byte<0xFF>());
+        CHECK(a == to_byte<0x00>());
 
         a |= b;
-        CHECK(a == to_byte(0xFF));
+        CHECK(a == to_byte<0xFF>());
 
-        a = to_byte(0x01);
-        CHECK((b & a) == to_byte(0x01));
+        a = to_byte<0x01>();
+        CHECK((b & a) == to_byte<0x01>());
 
         a &= b;
-        CHECK(a == to_byte(0x01));
+        CHECK(a == to_byte<0x01>());
 
-        CHECK((b ^ a) == to_byte(0xFE));
+        CHECK((b ^ a) == to_byte<0xFE>());
         
-        CHECK(a == to_byte(0x01));
+        CHECK(a == to_byte<0x01>());
         a ^= b;
-        CHECK(a == to_byte(0xFE));
+        CHECK(a == to_byte<0xFE>());
 
-        a = to_byte(0x01);
-        CHECK(~a == to_byte(0xFE));
+        a = to_byte<0x01>();
+        CHECK(~a == to_byte<0xFE>());
 
-        a = to_byte(0xFF);
-        CHECK((a << 4) == to_byte(0xF0));
-        CHECK((a >> 4) == to_byte(0x0F));
+        a = to_byte<0xFF>();
+        CHECK((a << 4) == to_byte<0xF0>());
+        CHECK((a >> 4) == to_byte<0x0F>());
 
         a <<= 4;
-        CHECK(a == to_byte(0xF0));
+        CHECK(a == to_byte<0xF0>());
         a >>= 4;
-        CHECK(a == to_byte(0x0F));
+        CHECK(a == to_byte<0x0F>());
     }
 }
 


### PR DESCRIPTION
I have added the to_byte method and updated the unit tests.

This gives slightly nicer syntax than static_cast, is better than the
c-style cast used in the unit test.

See: https://github.com/Microsoft/GSL/issues/329#issuecomment-240588515

I have tested my change on:
* VS2013
* VS2015
* Apple LLVM version 7.3.0 (clang-703.0.31)

Hopefully everything passes