### PR TITLE
Added inline to fix compilation warnings on msvc 2013

### DIFF
--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -26,7 +26,7 @@
 
 // constexpr is not understood
 #pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
+#define constexpr /*constexpr*/ 
 
 // noexcept is not understood
 #pragma push_macro("noexcept")
@@ -68,37 +68,37 @@ constexpr byte operator>>(byte b, IntegerType shift) noexcept
     return byte(static_cast<unsigned char>(b) >> shift);
 }
 
-constexpr byte& operator|=(byte& l, byte r) noexcept
+inline constexpr byte& operator|=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) | static_cast<unsigned char>(r));
 }
 
-constexpr byte operator|(byte l, byte r) noexcept
+inline constexpr byte operator|(byte l, byte r) noexcept
 {
     return byte(static_cast<unsigned char>(l) | static_cast<unsigned char>(r));
 }
 
-constexpr byte& operator&=(byte& l, byte r) noexcept
+inline constexpr byte& operator&=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) & static_cast<unsigned char>(r));
 }
 
-constexpr byte operator&(byte l, byte r) noexcept
+inline constexpr byte operator&(byte l, byte r) noexcept
 {
     return byte(static_cast<unsigned char>(l) & static_cast<unsigned char>(r));
 }
 
-constexpr byte& operator^=(byte& l, byte r) noexcept
+inline constexpr byte& operator^=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) ^ static_cast<unsigned char>(r));
 }
 
-constexpr byte operator^(byte l, byte r) noexcept
+inline constexpr byte operator^(byte l, byte r) noexcept
 {
     return byte(static_cast<unsigned char>(l) ^ static_cast<unsigned char>(r));
 }
 
-constexpr byte operator~(byte b) noexcept { return byte(~static_cast<unsigned char>(b)); }
+inline constexpr byte operator~(byte b) noexcept { return byte(~static_cast<unsigned char>(b)); }
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
 constexpr IntegerType to_integer(byte b) noexcept


### PR DESCRIPTION
Added inlines to avoid these compilation warnings on msvc13 where constexpr is not available

warning LNK4006: "enum gsl::byte & __cdecl gsl::operator|=(enum gsl::byte &,enum gsl::byte)" (??_5gsl@@YAAEAW4byte@0@AEAW410@W410@@Z) already defined in Algorithm.obj; second definition ignored