### PR TITLE
fix wrong types in multi_span_test (<comparison_operators>)

### DIFF
--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -959,8 +959,8 @@ SUITE(multi_span_tests)
         }
 
         {
-            auto s1 = nullptr;
-            auto s2 = nullptr;
+            multi_span<int> s1 = nullptr;
+            multi_span<int> s2 = nullptr;
             CHECK(s1 == s2);
             CHECK(!(s1 != s2));
             CHECK(!(s1 < s2));


### PR DESCRIPTION
I assume those checks where meant to compare `multi_span` variables that where initialized with `nullptr`, not `nullptr_t` variables.