### PR TITLE
Negative indices to multi_span are not flagged with neither exception nor abort.

### DIFF
--- a/gsl/multi_span
+++ b/gsl/multi_span
@@ -443,7 +443,7 @@ namespace details
         template <typename T, size_t Dim = 0>
         size_type linearize(const T& arr) const
         {
-            Expects(arr[Dim] < CurrentRange); // Index is out of range
+            Expects(arr[Dim] >= 0 && arr[Dim] < CurrentRange); // Index is out of range
             return this->Base::totalSize() * arr[Dim] +
                    this->Base::template linearize<T, Dim + 1>(arr);
         }
@@ -1510,7 +1510,7 @@ public:
     template <bool Enabled = (Rank > 1), typename Ret = std::enable_if_t<Enabled, sliced_type>>
     constexpr Ret operator[](size_type idx) const noexcept
     {
-        Expects(idx < bounds_.size()); // index is out of bounds of the array
+        Expects(idx >= 0 && idx < bounds_.size()); // index is out of bounds of the array
         const size_type ridx = idx * bounds_.stride();
 
         // index is out of bounds of the underlying data

--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -1084,6 +1084,12 @@ SUITE(multi_span_tests)
 
         CHECK_THROW(av[10][2], fail_fast);
         CHECK_THROW((av[{10, 2}]), fail_fast);
+
+        CHECK_THROW(av[-1][0], fail_fast);
+        CHECK_THROW((av[{-1, 0}]), fail_fast);
+
+        CHECK_THROW(av[0][-1], fail_fast);
+        CHECK_THROW((av[{0, -1}]), fail_fast);
     }
 
     void overloaded_func(multi_span<const int, dynamic_range, 3, 5> exp, int expected_value)


### PR DESCRIPTION
I augmented the tests of multi_span to show that you can pass negative indices and they are not detected properly. The second commit to my branch fixes the `Expects()` checks that cause the problem, so that the new checks pass.

```
    TEST(bounds_checks)
    {
        int arr[10][2];
        auto av = as_multi_span(arr);

        fill(begin(av), end(av), 0);

        // ...

        CHECK_THROW(av[-1][0], fail_fast); // ... does not throw before the fix
        CHECK_THROW((av[{-1, 0}]), fail_fast);  // ... does not throw before the fix
}
```
