### PR TITLE
Make GSL easier consumed by another project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(GSL CXX)
 
@@ -12,9 +12,9 @@ set(GSL_HEADERS
     "gsl/string_span"
 )
 
-include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(FILES ${GSL_HEADERS}
     DESTINATION include/gsl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 function(add_gsl_test name)
     add_executable(${name} ${name}.cpp ../gsl/gsl ../gsl/gsl_assert ../gsl/gsl_util ../gsl/multi_span ../gsl/span ../gsl/string_span)
-    target_link_libraries(${name} UnitTest++)
+    target_link_libraries(${name} UnitTest++ GSL)
     install(TARGETS ${name}
         RUNTIME DESTINATION bin
     )


### PR DESCRIPTION
This PR is related to this issue: [#363](https://github.com/Microsoft/GSL/issues/363)

Changes:
- Switched old include_directories function for the newer target_include_directories.
- Added GSL as a INTERFACE library
- Added GSL project to the tests CMakeLists.txt so It can include it automatically.
