### PR TITLE
Add branch prediction to Ensures / Expects

### DIFF
--- a/gsl/gsl_assert
+++ b/gsl/gsl_assert
@@ -38,6 +38,14 @@
 #define GSL_STRINGIFY_DETAIL(x) #x
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)
 
+#if defined(__clang__) || defined(__GNUC__)
+#define GSL_LIKELY(x)    __builtin_expect (!!(x), 1)
+#define GSL_UNLIKELY(x)  __builtin_expect (!!(x), 0)
+#else
+#define GSL_LIKELY(x)
+#define GSL_UNLIKELY(x)
+#endif
+
 //
 // GSL.assert: assertions
 //
@@ -53,19 +61,19 @@ struct fail_fast : public std::runtime_error
 #if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
 
 #define Expects(cond)                                                                              \
-    if (!(cond))                                                                                   \
+    if (GSL_UNLIKELY(!(cond)))                                                                     \
         throw gsl::fail_fast("GSL: Precondition failure at " __FILE__ ": " GSL_STRINGIFY(__LINE__));
 #define Ensures(cond)                                                                              \
-    if (!(cond))                                                                                   \
+    if (GSL_UNLIKELY(!(cond)))                                                                     \
         throw gsl::fail_fast("GSL: Postcondition failure at " __FILE__                             \
                              ": " GSL_STRINGIFY(__LINE__));
 
 #elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
 #define Expects(cond)                                                                              \
-    if (!(cond)) std::terminate();
+    if (GSL_UNLIKELY(!(cond))) std::terminate();
 #define Ensures(cond)                                                                              \
-    if (!(cond)) std::terminate();
+    if (GSL_UNLIKELY(!(cond))) std::terminate();
 
 #elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
 

--- a/gsl/gsl_assert
+++ b/gsl/gsl_assert
@@ -39,11 +39,11 @@
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)
 
 #if defined(__clang__) || defined(__GNUC__)
-#define GSL_LIKELY(x)    __builtin_expect (!!(x), 1)
-#define GSL_UNLIKELY(x)  __builtin_expect (!!(x), 0)
+#define GSL_LIKELY(x) __builtin_expect (!!(x), 1)
+#define GSL_UNLIKELY(x) __builtin_expect (!!(x), 0)
 #else
-#define GSL_LIKELY(x)
-#define GSL_UNLIKELY(x)
+#define GSL_LIKELY(x) (x)
+#define GSL_UNLIKELY(x) (x)
 #endif
 
 //


### PR DESCRIPTION
We should be using branch prediction on asserts as these conditions are known to be unlikely, therefore we should be optimizing the likely case. These macros are similar to what the Linux kernel uses. Not really sure what Visual Studio does so at the moment these are disabled for VS.