### PR TITLE
For span, fix size_t to index_type conversion warning 

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -392,7 +392,7 @@ public:
                   std::is_convertible<typename Container::pointer, pointer>::value &&
                   std::is_convertible<typename Container::pointer,
                                       decltype(std::declval<Container>().data())>::value>>
-    constexpr span(Container& cont) : span(cont.data(), cont.size())
+    constexpr span(Container& cont) : span(cont.data(), narrow<index_type>(cont.size()))
     {
     }
 
@@ -402,7 +402,7 @@ public:
                   std::is_convertible<typename Container::pointer, pointer>::value &&
                   std::is_convertible<typename Container::pointer,
                                       decltype(std::declval<Container>().data())>::value>>
-    constexpr span(const Container& cont) : span(cont.data(), cont.size())
+    constexpr span(const Container& cont) : span(cont.data(), narrow<index_type>(cont.size()))
     {
     }
 


### PR DESCRIPTION
Standard containers return size_t which is signed.  Therefore implicit conversion to index_type throws a warning which causes compiler errors on -Wall.  This static casts to avoid this.  

Passes tests on gcc version 6.2.0 20160914 (Ubuntu 6.2.0-3ubuntu15) 