### PR TITLE
Add size_type, difference_type to span

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -347,6 +347,8 @@ public:
     using index_type = std::ptrdiff_t;
     using pointer = element_type*;
     using reference = element_type&;
+    using size_type = index_type;
+    using difference_type = index_type;
 
     using iterator = details::span_iterator<span<ElementType, Extent>, false>;
     using const_iterator = details::span_iterator<span<ElementType, Extent>, true>;


### PR DESCRIPTION
Currently you can't use span generically as a replacement for std containers because it lacks size_type and difference_type, unlike std containers.  