### PR TITLE
Fix #388 Deprecated implicit copy assignment operator for span_iterat…

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -163,6 +163,8 @@ namespace details
         {
         }
 
+        constexpr span_iterator<Span, IsConst>& operator=(const span_iterator<Span, IsConst>&) noexcept = default;
+
         constexpr reference operator*() const
         {
             Expects(span_);


### PR DESCRIPTION
Fix #388 by explicit default.  Unlike the copy constructor this does not perform an extra Expects check.  I can redo the pr to explicitly do that if requested because check for invalid iterator is desired on operator=.  