### PR TITLE
Don't install tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,9 +35,6 @@ endif()
 function(add_gsl_test name)
     add_executable(${name} ${name}.cpp ../gsl/gsl ../gsl/gsl_assert ../gsl/gsl_util ../gsl/multi_span ../gsl/span ../gsl/string_span)
     target_link_libraries(${name} UnitTest++)
-    install(TARGETS ${name}
-        RUNTIME DESTINATION bin
-    )
     add_test(
       ${name}
       ${name}


### PR DESCRIPTION
'make install' should install the GSL library (ie. the headers),
not the tests.

It still installs the UnitTest++ headers, but that will be more
complex to fix, as GSL just imports UnitTest++ as a git submodule,
and the install command propagates down to UnitTest++'s
CMakeLists.txt.