### PR TITLE
Update narrow_cast to use std::forward

### DIFF
--- a/gsl/gsl_util
+++ b/gsl/gsl_util
@@ -93,11 +93,19 @@ inline final_act<F> finally(F&& f) noexcept
 }
 
 // narrow_cast(): a searchable way to do narrowing casts of values
+#if _MSC_VER <= 1800
+template <class T, class U>
+inline constexpr T narrow_cast(U u) noexcept
+{
+    return static_cast<T>(u);
+}
+#else
 template <class T, class U>
 inline constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
+#endif
 
 struct narrowing_error : public std::exception
 {

--- a/gsl/gsl_util
+++ b/gsl/gsl_util
@@ -94,9 +94,9 @@ inline final_act<F> finally(F&& f) noexcept
 
 // narrow_cast(): a searchable way to do narrowing casts of values
 template <class T, class U>
-inline constexpr T narrow_cast(U u) noexcept
+inline constexpr T narrow_cast(U&& u) noexcept
 {
-    return static_cast<T>(u);
+    return static_cast<T>(std::forward<U>(u));
 }
 
 struct narrowing_error : public std::exception


### PR DESCRIPTION
Based on [F19](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f19-for-forward-parameters-pass-by-tp-and-only-stdforward-the-parameter), I believe `gsl::narrow_cast` should be implemented using forward semantics.