### PR TITLE
Add std::unique_ptr support to gsl::span

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -29,6 +29,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+#include <memory>
 
 #ifdef _MSC_VER
 
@@ -385,6 +386,12 @@ public:
         : storage_(&arr[0], details::extent_type<N>())
     {
     }
+
+    template<class ArrayElementType = std::add_pointer<element_type>>
+    constexpr span(const std::unique_ptr<ArrayElementType>& ptr, index_type count) : storage_(ptr.get(), count) {}
+
+    constexpr span(const std::unique_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0) {}
+    constexpr span(const std::shared_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0) {}
 
     // NB: the SFINAE here uses .data() as a incomplete/imperfect proxy for the requirement
     // on Container to be a contiguous sequence container.

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -483,6 +483,72 @@ SUITE(span_tests)
 #endif
     }
 
+    TEST(from_unique_pointer_construction)
+    {
+        {
+            auto ptr = std::make_unique<int>(4);
+
+            {
+                span<int> s{ptr};
+                CHECK(s.length() == 1 && s.data() == ptr.get());
+                CHECK(s[0] == 4);
+            }
+        }
+
+        {
+            auto ptr = std::unique_ptr<int>{nullptr};
+
+            {
+                span<int> s{ptr};
+                CHECK(s.length() == 0 && s.data() == nullptr);
+            }
+        }
+
+        {
+            auto arr = std::make_unique<int[]>(4);
+
+            for (auto i = 0; i < 4; i++)
+                arr[i] = i + 1;
+
+            {
+                span<int> s{arr, 4};
+                CHECK(s.length() == 4 && s.data() == arr.get());
+                CHECK(s[0] == 1 && s[1] == 2);
+            }
+        }
+
+        {
+            auto ptr = std::unique_ptr<int[]>{nullptr};
+
+            {
+                span<int> s{ptr, 0};
+                CHECK(s.length() == 0 && s.data() == nullptr);
+            }
+        }
+    }
+
+    TEST(from_shared_pointer_construction)
+    {
+        {
+            auto ptr = std::make_shared<int>(4);
+
+            {
+                span<int> s{ptr};
+                CHECK(s.length() == 1 && s.data() == ptr.get());
+                CHECK(s[0] == 4);
+            }
+        }
+
+        {
+            auto ptr = std::shared_ptr<int>{nullptr};
+
+            {
+                span<int> s{ptr};
+                CHECK(s.length() == 0 && s.data() == nullptr);
+            }
+        }
+    }
+
     TEST(from_container_constructor)
     {
         std::vector<int> v = {1, 2, 3};


### PR DESCRIPTION
This patch adds support for std::unique_ptr to the gsl::span
class instead of having to manually grab the pointer from
a std::unique_ptr.

It was suggestd that we also add support for std::shared_ptr,
but no array syntax exists for this class, and the element
types don't match. Until the following is accepted, I suggest
support for std::shared_ptr is left out:

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4077.html

For reference, this is part of the following issue:
https://github.com/Microsoft/GSL/issues/402

Signed-off-by: “Rian <“rianquinn@gmail.com”>
