### PR TITLE
Fix compiler warning

### DIFF
--- a/gsl/string_span
+++ b/gsl/string_span
@@ -554,7 +554,8 @@ public:
 
     constexpr string_span_type as_string_span() const noexcept
     {
-        return span_.first(span_.size() - 1);
+        auto sz = span_.size();
+        return span_.first(sz <= 0 ? 0 : sz - 1);
     }
 
     constexpr string_span_type ensure_z() const noexcept { return gsl::ensure_z(span_); }


### PR DESCRIPTION
When building with GCC 5.4, the compiler spits out a warning about
the following:

warning: assuming signed overflow does not occur when assuming
that (X - c) > X is always false [-Wstrict-overflow]

This patch fixes this issue.

Signed-off-by: “Rian <“rianquinn@gmail.com”>