### PR TITLE
Adds gsl::span::at()

### DIFF
--- a/gsl/span
+++ b/gsl/span
@@ -503,6 +503,8 @@ public:
         Expects(idx >= 0 && idx < storage_.size());
         return data()[idx];
     }
+
+    constexpr reference at(index_type idx) const { return this->operator[](idx); }
     constexpr reference operator()(index_type idx) const { return this->operator[](idx); }
     constexpr pointer data() const noexcept { return storage_.data(); }
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -769,6 +769,25 @@ SUITE(span_tests)
         }
     }
 
+    TEST(at_call)
+    {
+        int arr[4] = {1, 2, 3, 4};
+
+        {
+            span<int> s = arr;
+            CHECK(s.at(0) == 1);
+            CHECK_THROW(s.at(5), fail_fast);
+        }
+
+        {
+            int arr2d[2] = {1, 6};
+            span<int, 2> s = arr2d;
+            CHECK(s.at(0) == 1);
+            CHECK(s.at(1) == 6);
+            CHECK_THROW(s.at(2) ,fail_fast);
+        }
+    }
+
     TEST(operator_function_call)
     {
         int arr[4] = {1, 2, 3, 4};


### PR DESCRIPTION
As per this discussion:
https://github.com/Microsoft/GSL/issues/402

This patch adds support for at() to gsl::span

Signed-off-by: “Rian <“rianquinn@gmail.com”>