### PR TITLE
Maybe PR: basic_string_span: test for std::array; ctor for std::array not called

### DIFF
--- a/gsl/string_span
+++ b/gsl/string_span
@@ -326,6 +326,8 @@ public:
     template <size_t N, class ArrayElementType = std::remove_const_t<element_type>>
     constexpr basic_string_span(const std::array<ArrayElementType, N>& arr) noexcept : span_(arr)
     {
+        // never called, Container version below takes precedence
+        std::terminate();
     }
 
     // Container signature should work for basic_string after C++17 version exists
@@ -501,7 +503,7 @@ std::basic_string<CharT, Traits, Allocator> to_basic_string(basic_string_span<gC
 {
   return {view.data(), static_cast<size_t>(view.length())};
 }
-  
+
 // zero-terminated string span, used to convert
 // zero-terminated spans to legacy strings
 template <typename CharT, std::ptrdiff_t Extent = dynamic_extent>

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -44,11 +44,36 @@ SUITE(string_span_tests)
         CHECK(v.length() == static_cast<cstring_span<>::index_type>(s.length()));
     }
 
+    TEST(TestConstructFromStdArray)
+    {
+        {
+            std::array<char, 5> arr{'h', 'e', 'l', 'l', 'o'};
+            string_span<> v {arr};
+            CHECK(v.length() == static_cast<string_span<>::index_type>(arr.size()));
+        }
+
+        // Note: with std::array trailing terminator is NOT stripped:
+        {
+            std::array<char, 6> arr{'h', 'e', 'l', 'l', 'o', '\0'};
+            string_span<> v {arr};
+            CHECK(v.length() == static_cast<string_span<>::index_type>(arr.size()));
+        }
+    }
+
     TEST(TestConstructFromStdVector)
     {
-        std::vector<char> vec(5, 'h');
-        string_span<> v {vec};
-        CHECK(v.length() == static_cast<string_span<>::index_type>(vec.size()));
+        {
+            std::vector<char> vec(5, 'h');
+            string_span<> v {vec};
+            CHECK(v.length() == static_cast<string_span<>::index_type>(vec.size()));
+        }
+
+        // Note: with std::vector trailing terminator is NOT stripped:
+        {
+            std::vector<char> vec{'h', 'e', 'l', 'l', 'o', '\0'};
+            string_span<> v {vec};
+            CHECK(v.length() == static_cast<string_span<>::index_type>(vec.size()));
+        }
     }
 
     TEST(TestStackArrayConstruction)
@@ -125,7 +150,7 @@ SUITE(string_span_tests)
         CHECK(static_cast<cstring_span<>::index_type>(s2.length()) == v.length());
         CHECK(s2.length() == 5);
     }
-    
+
     TEST(EqualityAndImplicitConstructors)
     {
         {
@@ -134,7 +159,7 @@ SUITE(string_span_tests)
 
             // comparison to empty span
             CHECK(span1 != span);
-            CHECK(span != span1);      
+            CHECK(span != span1);
         }
 
         {
@@ -291,7 +316,7 @@ SUITE(string_span_tests)
             string_span<> _span{ _ptr, 5 };
 
             // non-const span, non-const other type
-            
+
             CHECK(_span == _ar);
             CHECK(_span == _ar1);
             CHECK(_span == _ar2);


### PR DESCRIPTION
This PR adds a test for the `std::array` constructor of `basic_string_span`.

The test shows that constructing a `basic_string_span` from a `std::array` (or `std::vector`) that includes a terminating `'\0'` does include that `'\0'` in the `basic_string_span` . Note that for `std::array` this behavior differs from what `basic_string_span` proposal [p0123r2](http://wg21.link/p0123) suggests.

In *gsl lite* I'm [leaning to follow the proposal](https://github.com/martinmoene/gsl-lite/blob/5c64f98e1ef394abadc8b1186ae72ed8f5c42367/include/gsl/gsl-lite.h#L1566) and use `remove_z( arr )` for the `std::array` case.

This PR also adds `std::terminate()` (!) to `basic_string_span`'s constructor for `std::array` to show it is not called. Instead the `Container` version takes precedence as std::array is not excluded for this constructor as specified in the `basic_string_span` proposal [p0123r2](http://wg21.link/p0123) (see *gsl lite* [here](https://github.com/martinmoene/gsl-lite/blob/5c64f98e1ef394abadc8b1186ae72ed8f5c42367/include/gsl/gsl-lite.h#L1583)).