### PR TITLE
gsl::copy returns remaining range

### DIFF
--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -37,9 +37,21 @@
 namespace gsl
 {
 
-template <class SrcElementType, std::ptrdiff_t SrcExtent,
+namespace details_copy
+{
+    template <class T, std::ptrdiff_t src, std::ptrdiff_t dest>
+    struct return_type
+    {
+        using type = span<T, (src == dynamic_extent || dest == dynamic_extent) ? dynamic_extent : dest - src>;
+    };
+
+    template <class T, std::ptrdiff_t src, std::ptrdiff_t dest>
+    using return_t = typename return_type<T, src, dest>::type;
+}
+
+template <class SrcElementType,  std::ptrdiff_t SrcExtent,
           class DestElementType, std::ptrdiff_t DestExtent>
-void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent> dest)
+auto copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent> dest) -> details_copy::return_t<DestElementType, SrcExtent, DestExtent>
 {
     static_assert(std::is_assignable<decltype(*dest.data()), decltype(*src.data())>::value,
                   "Elements of source span can not be assigned to elements of destination span");
@@ -48,6 +60,7 @@ void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent>
 
     Expects(dest.size() >= src.size());
     std::copy_n(src.data(), src.size(), dest.data());
+    return dest.subspan(src.size());
 }
 
 } // namespace gsl

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -25,147 +25,165 @@ using namespace gsl;
 SUITE(copy_tests)
 {
 
-    TEST(same_type)
+    // dynamic source and destination span
+    TEST(same_type_dd)
     {
-        // dynamic source and destination span
-        {
-            std::array<int, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
+        std::array<int, 5> src{1, 2, 3, 4, 5};
+        std::array<int, 10> dst{};
 
-            span<int> src_span(src);
-            span<int> dst_span(dst);
+        span<int> src_span(src);
+        span<int> dst_span(dst);
 
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
+        dst_span = copy(src_span, dst_span);
+        dst_span = copy(src_span, dst_span);
+        CHECK_THROW(copy(src_span, dst_span), fail_fast);
 
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // static source and dynamic destination span
-        {
-            std::array<int, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<int, 5> src_span(src);
-            span<int> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // dynamic source and static destination span
-        {
-            std::array<int, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<int> src_span(src);
-            span<int, 10> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // static source and destination span
-        {
-            std::array<int, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<int, 5> src_span(src);
-            span<int, 10> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
         }
     }
 
-    TEST(compatible_type)
+    // static source and dynamic destination span
+    TEST(same_type_sd)
     {
-        // dynamic source and destination span
-        {
-            std::array<short, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
+        std::array<int, 5> src{1, 2, 3, 4, 5};
+        std::array<int, 10> dst{};
 
-            span<short> src_span(src);
-            span<int> dst_span(dst);
+        span<int, 5> src_span(src);
+        span<int> dst_span(dst);
 
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
+        dst_span = copy(src_span, dst_span);
+        dst_span = copy(src_span, dst_span);
+        CHECK_THROW(copy(src_span, dst_span), fail_fast);
 
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // static source and dynamic destination span
-        {
-            std::array<short, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<short, 5> src_span(src);
-            span<int> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // dynamic source and static destination span
-        {
-            std::array<short, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<short> src_span(src);
-            span<int, 10> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
-        }
-
-        // static source and destination span
-        {
-            std::array<short, 5> src{1, 2, 3, 4, 5};
-            std::array<int, 10> dst{};
-
-            span<short, 5> src_span(src);
-            span<int, 10> dst_span(dst);
-
-            copy(src_span, dst_span);
-            copy(src_span, dst_span.subspan(src_span.size()));
-
-            for (std::size_t i = 0; i < src.size(); ++i) {
-                CHECK(dst[i] == src[i]);
-                CHECK(dst[i + src.size()] == src[i]);
-            }
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
         }
     }
+
+    // dynamic source and static destination span
+    TEST(same_type_ds)
+    {
+        std::array<int, 5> src{1, 2, 3, 4, 5};
+        std::array<int, 10> dst{};
+
+        span<int> src_span(src);
+        span<int, 10> dst_span(dst);
+
+        auto dst_span2 = copy(src_span, dst_span);
+             dst_span2 = copy(src_span, dst_span2);
+        CHECK_THROW(copy(src_span, dst_span2), fail_fast);
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
+    // static source and destination span
+    TEST(same_type_ss)
+    {
+        std::array<int, 5> src{1, 2, 3, 4, 5};
+        std::array<int, 10> dst{};
+
+        span<int, 5> src_span(src);
+        span<int, 10> dst_span(dst);
+
+        auto dst_span2 = copy(src_span, dst_span);
+        auto dst_span3 = copy(src_span, dst_span2);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        CHECK_THROW(copy(src_span, dst_span3), fail_fast);
+#endif
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
+    // dynamic source and destination span
+    TEST(compatible_type_dd)
+    {
+        // dynamic source and destination span
+        std::array<short, 5> src{1, 2, 3, 4, 5};
+        std::array<int, 10> dst{};
+
+        span<short> src_span(src);
+        span<int> dst_span(dst);
+
+        dst_span = copy(src_span, dst_span);
+        dst_span = copy(src_span, dst_span);
+        CHECK_THROW(copy(src_span, dst_span), fail_fast);
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
+    // static source and dynamic destination span
+    TEST(compatible_type_sd)
+    {
+        std::array<short, 5> src{ 1, 2, 3, 4, 5 };
+        std::array<int, 10> dst{};
+
+        span<short, 5> src_span(src);
+        span<int> dst_span(dst);
+
+
+        dst_span = copy(src_span, dst_span);
+        dst_span = copy(src_span, dst_span);
+        CHECK_THROW(copy(src_span, dst_span), fail_fast);
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
+    // dynamic source and static destination span
+    TEST(compatible_type_ds)
+    {
+        std::array<short, 5> src{ 1, 2, 3, 4, 5 };
+        std::array<int, 10> dst{};
+
+        span<short> src_span(src);
+        span<int, 10> dst_span(dst);
+
+        auto dst_span2 = copy(src_span, dst_span);
+             dst_span2 = copy(src_span, dst_span2);
+        CHECK_THROW(copy(src_span, dst_span2), fail_fast);
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
+    // static source and destination span
+    TEST(compatible_type_ss)
+    {
+        std::array<short, 5> src{ 1, 2, 3, 4, 5 };
+        std::array<int, 10> dst{};
+
+        span<short, 5> src_span(src);
+        span<int, 10> dst_span(dst);
+
+        auto dst_span2 = copy(src_span, dst_span);
+        auto dst_span3 = copy(src_span, dst_span2);
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        CHECK_THROW(copy(src_span, dst_span3), fail_fast);
+#endif
+
+        for (std::size_t i = 0; i < src.size(); ++i) {
+            CHECK(dst[i] == src[i]);
+            CHECK(dst[i + src.size()] == src[i]);
+        }
+    }
+
 
 #ifdef CONFIRM_COMPILATION_ERRORS
     TEST(incompatible_type)


### PR DESCRIPTION
As originally planned for #344, `gsl::copy` now returns the remaining destination range. 

If both source and destination span have a static extent, the result is a new span of static extent. Otherwise a span of dynamic extent is returned.

Additionally, the unit tests are now more fine granular than before. Due to the resulting indentation change I'd recommend viewing the diff of  `tests/algorithm_tests.cpp`  with the `-w` flag.