### PR TITLE
Fix MSVC warning

### DIFF
--- a/gsl/multi_span
+++ b/gsl/multi_span
@@ -87,7 +87,7 @@ namespace details
     template <typename SizeType>
     struct SizeTypeTraits
     {
-        static const SizeType max_value = std::numeric_limits<SizeType>::max();
+        static const SizeType max_value = (std::numeric_limits<SizeType>::max)();
     };
 
     template <typename... Ts>


### PR DESCRIPTION
Inhibit macro expansion for call to numeric_limits<T>::max in SizeTypeTraits. Resolves warning C4003 which is generated under MSVC in some circumstances.