### PR TITLE
Fix gsl_byte in clang 3.9.1

### DIFF
--- a/gsl/gsl_byte
+++ b/gsl/gsl_byte
@@ -19,6 +19,8 @@
 #ifndef GSL_BYTE_H
 #define GSL_BYTE_H
 
+#include <type_traits>
+
 #ifdef _MSC_VER
 
 #pragma warning(push)


### PR DESCRIPTION
type_traits are needed for gsl_byte to be used in clang 3.9.1