### PR TITLE
Revert change to the definition of constexpr macro in gsl_byte from #446

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -31,7 +31,7 @@
  #if _MSC_VER <= 1800
   // constexpr is not understood
   #pragma push_macro("constexpr")
-  #define constexpr inline
+  #define constexpr /*constexpr*/
 
   // noexcept is not understood
   #pragma push_macro("noexcept")


### PR DESCRIPTION
I apparently lied when I said I had reverted all of these changes to the `constexpr` macros. Causes warning spew when building with VS2013.