### PR TITLE
Mark headers as C++ code with vim filetype

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -144,3 +144,5 @@ struct hash<gsl::not_null<T>>
 #endif // defined(_MSC_VER) && _MSC_VER < 1910
 
 #endif // GSL_GSL_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -57,3 +57,5 @@ void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent>
 #endif // _MSC_VER
 
 #endif // GSL_ALGORITHM_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -83,3 +83,5 @@ struct fail_fast : public std::runtime_error
 #endif
 
 #endif // GSL_CONTRACTS_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -153,3 +153,5 @@ inline constexpr byte to_byte() noexcept
 #endif // _MSC_VER
 
 #endif // GSL_BYTE_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -173,3 +173,5 @@ inline constexpr const T& at(std::initializer_list<T> cont, std::ptrdiff_t index
 #endif // _MSC_VER
 
 #endif // GSL_UTIL_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -2219,3 +2219,5 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 #endif // _MSC_VER
 
 #endif // GSL_MULTI_SPAN_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -699,3 +699,5 @@ inline constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdif
 #endif // _MSC_VER
 
 #endif // GSL_SPAN_H
+
+// vim: set filetype=cpp:

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -850,3 +850,5 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 #endif // _MSC_VER
 
 #endif // GSL_STRING_SPAN_H
+
+// vim: set filetype=cpp:


### PR DESCRIPTION
This adds syntax highlighting to the Github file browser and might add auto highlighting to some editors, namely vim and derivatives.

Example before: https://github.com/Microsoft/GSL/blob/3819df6e378ffccf0e29465afe99c3b324c2aa70/include/gsl/gsl
Example after: https://github.com/ranisalt/GSL/blob/28d6fd1d50dc9b1e09cdac42301860b481a26315/include/gsl/gsl

As it's not code changes, I didn't open an issue before, but I can do.