### PR TITLE
add gsl::not_null operator<<

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -109,6 +109,13 @@ private:
     T ptr_;
 };
 
+template <class T>
+std::ostream& operator<<(std::ostream& os, const not_null<T>& val)
+{
+    os << val.get();
+    return os;
+}
+
 // more unwanted operators
 template <class T, class U>
 std::ptrdiff_t operator-(const not_null<T>&, const not_null<U>&) = delete;

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -25,6 +25,7 @@
 #include <gsl/span>        // span
 #include <gsl/string_span> // zstring, string_span, zstring_builder...
 #include <memory>
+#include <iostream>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
  #pragma push_macro("constexpr")


### PR DESCRIPTION
Hippomocks, which is a popular mocking engine for C++ uses operator<< on pointers and gets confused about gsl::not_null not having this operator.