### PR TITLE
register GSL as a system header

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -19,7 +19,9 @@
 #ifndef GSL_GSL_H
 #define GSL_GSL_H
 
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC system_header
+#endif
 
 #include <gsl/gsl_assert>  // Ensures/Expects
 #include <gsl/gsl_util>    // finally()/narrow()/narrow_cast()...

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -19,6 +19,8 @@
 #ifndef GSL_GSL_H
 #define GSL_GSL_H
 
+#pragma GCC system_header
+
 #include <gsl/gsl_assert>  // Ensures/Expects
 #include <gsl/gsl_util>    // finally()/narrow()/narrow_cast()...
 #include <gsl/multi_span>  // multi_span, strided_span...


### PR DESCRIPTION
GSL currently causes Clang Tidy to go nuts for several reasons: 
1) there are several checks that fail because of UnitTest++ 
2) there are several checks that fail simply because we need to clean up some issues 
3) the Core Guideline checks clearly fail since we are implementing the GSL

Adding this macro prevents Clang Tidy and other tools (like coverage tools) from registering the GSL as code that belongs to the project.