### PR TITLE
Make GSL a CMake consumable header-only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,17 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.0.0)
 
 project(GSL CXX)
 
-install(
-    DIRECTORY include/gsl
-    DESTINATION include
-)
+add_library(cppgsl INTERFACE)
+target_include_directories(cppgsl INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+install(TARGETS cppgsl EXPORT cppgslConfig)
+install(DIRECTORY include/gsl DESTINATION include)
+
+export(EXPORT cppgslConfig)
+install(EXPORT cppgslConfig DESTINATION cmake)
 
 enable_testing()
 add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unittest-cpp/tests)
     execute_process(COMMAND git submodule update --init WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
-add_subdirectory(unittest-cpp)
+add_subdirectory(unittest-cpp EXCLUDE_FROM_ALL)
 
 include_directories(
     ../include

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 function(add_gsl_test name)
     add_executable(${name} ${name}.cpp)
-    target_link_libraries(${name} UnitTest++)
+    target_link_libraries(${name} UnitTest++ cppgsl)
     add_test(
       ${name}
       ${name}


### PR DESCRIPTION
Supersedes #370:
- Uses correct CMake version.
- Can be used in CMake without requiring it to be a sub-project.
- Can be used in CMake after installation without a local fork.

The library has been named as suggested [here](https://github.com/Microsoft/GSL/issues/363#issuecomment-276821586) to prevent collision with GNU's GSL. FYI, I had name clashes with it.