### PR TITLE
Fix some corechecker warnings

### DIFF
--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -577,7 +577,7 @@ template <class CharT, std::ptrdiff_t Extent, class T,
               std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>>>::value>>
 bool operator==(const gsl::basic_string_span<CharT, Extent>& one, const T& other) GSL_NOEXCEPT
 {
-    gsl::basic_string_span<std::add_const_t<CharT>> tmp(other);
+    const gsl::basic_string_span<std::add_const_t<CharT>> tmp(other);
 #ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
     return (one.size() == tmp.size()) && std::equal(one.begin(), one.end(), tmp.begin());
 #else
@@ -624,7 +624,7 @@ template <typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename 
               T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value>>
 bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_NOEXCEPT
 {
-    gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
+    const gsl::basic_string_span<std::add_const_t<CharT>, Extent> tmp(other);
     return std::lexicographical_compare(one.begin(), one.end(), tmp.begin(), tmp.end());
 }
 

--- a/tests/bounds_tests.cpp
+++ b/tests/bounds_tests.cpp
@@ -45,7 +45,7 @@ SUITE(bounds_test)
 	TEST(bounds_basic)
 	{
 		static_bounds<3, 4, 5> b;
-		auto a = b.slice();
+		const auto a = b.slice();
 		(void)a;
 		static_bounds<4, dynamic_range, 2> x{ 4 };
 		x.slice().slice();
@@ -55,7 +55,7 @@ SUITE(bounds_test)
 	{
 		static_bounds<4, dynamic_range, 2> bounds{ 3 };
 
-		auto itr = bounds.begin();
+		const auto itr = bounds.begin();
 		(void)itr;
 #ifdef CONFIRM_COMPILATION_ERRORS
 		multi_span<int, 4, dynamic_range, 2> av(nullptr, bounds);

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -35,22 +35,22 @@ SUITE(byte_tests)
     TEST(construction)
     {
         {
-            byte b = static_cast<byte>(4);
+            const byte b = static_cast<byte>(4);
             CHECK(static_cast<unsigned char>(b) == 4);
         }
 
         {
-            byte b = byte(12);
+            const byte b = byte(12);
             CHECK(static_cast<unsigned char>(b) == 12);
         }
 
         {
-            byte b = to_byte<12>();
+            const byte b = to_byte<12>();
             CHECK(static_cast<unsigned char>(b) == 12);
         }
         {
-            unsigned char uc = 12;
-            byte b = to_byte(uc);
+            const unsigned char uc = 12;
+            const byte b = to_byte(uc);
             CHECK(static_cast<unsigned char>(b) == 12);
         }
 
@@ -63,7 +63,7 @@ SUITE(byte_tests)
 
     TEST(bitwise_operations)
     {
-        byte b = to_byte<0xFF>();
+        const byte b = to_byte<0xFF>();
 
         byte a = to_byte<0x00>();
         CHECK((b | a) == to_byte<0xFF>());
@@ -79,7 +79,7 @@ SUITE(byte_tests)
         CHECK(a == to_byte<0x01>());
 
         CHECK((b ^ a) == to_byte<0xFE>());
-        
+
         CHECK(a == to_byte<0x01>());
         a ^= b;
         CHECK(a == to_byte<0xFE>());
@@ -99,7 +99,7 @@ SUITE(byte_tests)
 
     TEST(to_integer)
     {
-        byte b = to_byte<0x12>();
+        const byte b = to_byte<0x12>();
 
         CHECK(0x12 == gsl::to_integer<char>(b));
         CHECK(0x12 == gsl::to_integer<short>(b));
@@ -125,7 +125,7 @@ SUITE(byte_tests)
     TEST(aliasing)
     {
         int i{ 0 };
-        int res = modify_both(reinterpret_cast<byte&>(i), i);
+        const int res = modify_both(reinterpret_cast<byte&>(i), i);
         CHECK(res == i);
     }
 }

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -930,7 +930,7 @@ SUITE(span_tests)
             CHECK(av.subspan(4).length() == 1);
             CHECK(av.subspan(5).length() == 0);
             CHECK_THROW(av.subspan(6).length(), fail_fast);
-            auto av2 = av.subspan(1);
+            const auto av2 = av.subspan(1);
             for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
         }
 
@@ -941,7 +941,7 @@ SUITE(span_tests)
             CHECK(av.subspan(4).length() == 1);
             CHECK(av.subspan(5).length() == 0);
             CHECK_THROW(av.subspan(6).length(), fail_fast);
-            auto av2 = av.subspan(1);
+            const auto av2 = av.subspan(1);
             for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
         }
     }
@@ -1117,7 +1117,7 @@ SUITE(span_tests)
             CHECK(it == beyond);
             CHECK(it - beyond == 0);
 
-            for (auto& n : s)
+            for (const auto& n : s)
             {
                 CHECK(n == 5);
             }
@@ -1214,7 +1214,7 @@ SUITE(span_tests)
             CHECK(it == beyond);
             CHECK(it - beyond == 0);
 
-            for (auto& n : s)
+            for (const auto& n : s)
             {
                 CHECK(n == 5);
             }
@@ -1386,16 +1386,16 @@ SUITE(span_tests)
         int a[] = {1, 2, 3, 4};
 
         {
-            span<const int> s = a;
+            const span<const int> s = a;
             CHECK(s.length() == 4);
-            span<const byte> bs = as_bytes(s);
+            const span<const byte> bs = as_bytes(s);
             CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
             CHECK(bs.length() == s.length_bytes());
         }
 
         {
             span<int> s;
-            auto bs = as_bytes(s);
+            const auto bs = as_bytes(s);
             CHECK(bs.length() == s.length());
             CHECK(bs.length() == 0);
             CHECK(bs.size_bytes() == 0);
@@ -1405,7 +1405,7 @@ SUITE(span_tests)
 
         {
             span<int> s = a;
-            auto bs = as_bytes(s);
+            const auto bs = as_bytes(s);
             CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
             CHECK(bs.length() == s.length_bytes());
         }
@@ -1428,7 +1428,7 @@ SUITE(span_tests)
 
         {
             span<int> s;
-            auto bs = as_writeable_bytes(s);
+            const auto bs = as_writeable_bytes(s);
             CHECK(bs.length() == s.length());
             CHECK(bs.length() == 0);
             CHECK(bs.size_bytes() == 0);
@@ -1438,7 +1438,7 @@ SUITE(span_tests)
 
         {
             span<int> s = a;
-            auto bs = as_writeable_bytes(s);
+            const auto bs = as_writeable_bytes(s);
             CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
             CHECK(bs.length() == s.length_bytes());
         }
@@ -1484,11 +1484,11 @@ SUITE(span_tests)
 
         // you can convert statically
         {
-            span<int, 2> s2 = {arr, 2};
+            const span<int, 2> s2 = {arr, 2};
             static_cast<void>(s2);
         }
         {
-            span<int, 1> s1 = s4.first<1>();
+            const span<int, 1> s1 = s4.first<1>();
             static_cast<void>(s1);
         }
 
@@ -1532,7 +1532,7 @@ SUITE(span_tests)
     {
         char lat[] = { '1', '2', '3', '4', '5', '6', 'E', 'F', 'G' };
         span<char> s = lat;
-        auto f_it = s.begin() + 7;
+        const auto f_it = s.begin() + 7;
 
         std::match_results<span<char>::iterator> match;
 

--- a/tests/strided_span_tests.cpp
+++ b/tests/strided_span_tests.cpp
@@ -29,529 +29,529 @@ using namespace gsl;
 
 namespace
 {
-	struct BaseClass {};
-	struct DerivedClass : BaseClass {};
+    struct BaseClass {};
+    struct DerivedClass : BaseClass {};
 }
 
 SUITE(strided_span_tests)
 {
-	TEST (span_section_test)
-	{
-		int a[30][4][5];
+    TEST (span_section_test)
+    {
+        int a[30][4][5];
 
-		auto av = as_multi_span(a);
-		auto sub = av.section({15, 0, 0}, gsl::index<3>{2, 2, 2});
-		auto subsub = sub.section({1, 0, 0}, gsl::index<3>{1, 1, 1});
-		(void)subsub;
-	}
+        const auto av = as_multi_span(a);
+        const auto sub = av.section({15, 0, 0}, gsl::index<3>{2, 2, 2});
+        const auto subsub = sub.section({1, 0, 0}, gsl::index<3>{1, 1, 1});
+        (void)subsub;
+    }
 
-	TEST(span_section)
-	{
-		std::vector<int> data(5 * 10);
-		std::iota(begin(data), end(data), 0);
+    TEST(span_section)
+    {
+        std::vector<int> data(5 * 10);
+        std::iota(begin(data), end(data), 0);
         const multi_span<int, 5, 10> av = as_multi_span(multi_span<int>{data}, dim<5>(), dim<10>());
 
-		strided_span<int, 2> av_section_1 = av.section({ 1, 2 }, { 3, 4 });
-		CHECK((av_section_1[{0, 0}] == 12));
-		CHECK((av_section_1[{0, 1}] == 13));
-		CHECK((av_section_1[{1, 0}] == 22));
-		CHECK((av_section_1[{2, 3}] == 35));
+        const strided_span<int, 2> av_section_1 = av.section({ 1, 2 }, { 3, 4 });
+        CHECK((av_section_1[{0, 0}] == 12));
+        CHECK((av_section_1[{0, 1}] == 13));
+        CHECK((av_section_1[{1, 0}] == 22));
+        CHECK((av_section_1[{2, 3}] == 35));
 
-		strided_span<int, 2> av_section_2 = av_section_1.section({ 1, 2 }, { 2,2 });
-		CHECK((av_section_2[{0, 0}] == 24));
-		CHECK((av_section_2[{0, 1}] == 25));
-		CHECK((av_section_2[{1, 0}] == 34));
-	}
+        const strided_span<int, 2> av_section_2 = av_section_1.section({ 1, 2 }, { 2,2 });
+        CHECK((av_section_2[{0, 0}] == 24));
+        CHECK((av_section_2[{0, 1}] == 25));
+        CHECK((av_section_2[{1, 0}] == 34));
+    }
 
-	TEST(strided_span_constructors)
-	{
-		// Check stride constructor
-		{
-			int arr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-			const int carr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    TEST(strided_span_constructors)
+    {
+        // Check stride constructor
+        {
+            int arr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            const int carr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-			strided_span<int, 1> sav1{ arr, {{9}, {1}} }; // T -> T
-			CHECK(sav1.bounds().index_bounds() == index<1>{ 9 });
-			CHECK(sav1.bounds().stride() == 1);
-			CHECK(sav1[0] == 1 && sav1[8] == 9);
+            strided_span<int, 1> sav1{ arr, {{9}, {1}} }; // T -> T
+            CHECK(sav1.bounds().index_bounds() == index<1>{ 9 });
+            CHECK(sav1.bounds().stride() == 1);
+            CHECK(sav1[0] == 1 && sav1[8] == 9);
 
 
-			strided_span<const int, 1> sav2{ carr, {{ 4 }, { 2 }} }; // const T -> const T
-			CHECK(sav2.bounds().index_bounds() == index<1>{ 4 });
-			CHECK(sav2.bounds().strides() == index<1>{2});
-			CHECK(sav2[0] == 1 && sav2[3] == 7);
+            strided_span<const int, 1> sav2{ carr, {{ 4 }, { 2 }} }; // const T -> const T
+            CHECK(sav2.bounds().index_bounds() == index<1>{ 4 });
+            CHECK(sav2.bounds().strides() == index<1>{2});
+            CHECK(sav2[0] == 1 && sav2[3] == 7);
 
-			strided_span<int, 2> sav3{ arr, {{ 2, 2 },{ 6, 2 }} }; // T -> const T
-			CHECK((sav3.bounds().index_bounds() == index<2>{ 2, 2 }));
-			CHECK((sav3.bounds().strides() == index<2>{ 6, 2 }));
-			CHECK((sav3[{0, 0}] == 1 && sav3[{0, 1}] == 3 && sav3[{1, 0}] == 7));
-		}
+            strided_span<int, 2> sav3{ arr, {{ 2, 2 },{ 6, 2 }} }; // T -> const T
+            CHECK((sav3.bounds().index_bounds() == index<2>{ 2, 2 }));
+            CHECK((sav3.bounds().strides() == index<2>{ 6, 2 }));
+            CHECK((sav3[{0, 0}] == 1 && sav3[{0, 1}] == 3 && sav3[{1, 0}] == 7));
+        }
 
-		// Check multi_span constructor
-		{
-			int arr[] = { 1, 2 };
+        // Check multi_span constructor
+        {
+            int arr[] = { 1, 2 };
 
-			// From non-cv-qualified source
-			{
-				const multi_span<int> src = arr;
+            // From non-cv-qualified source
+            {
+                const multi_span<int> src = arr;
 
-				strided_span<int, 1> sav{ src, {2, 1} };
-				CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav.bounds().strides() == index<1>{ 1 });
-				CHECK(sav[1] == 2);
-
-#if _MSC_VER > 1800
-				//strided_span<const int, 1> sav_c{ {src}, {2, 1} };
-				strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
-#else
-				strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
-#endif
-				CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_c.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_c[1] == 2);
+                strided_span<int, 1> sav{ src, {2, 1} };
+                CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav.bounds().strides() == index<1>{ 1 });
+                CHECK(sav[1] == 2);
 
 #if _MSC_VER > 1800
-				strided_span<volatile int, 1> sav_v{ src, {2, 1} };
+                //strided_span<const int, 1> sav_c{ {src}, {2, 1} };
+                strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
 #else
-				strided_span<volatile int, 1> sav_v{ multi_span<volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
 #endif
-				CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_v.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_v[1] == 2);
+                CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_c.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_c[1] == 2);
 
 #if _MSC_VER > 1800
-				strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<volatile int, 1> sav_v{ src, {2, 1} };
 #else
-				strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<volatile int, 1> sav_v{ multi_span<volatile int>{src}, strided_bounds<1>{2, 1} };
 #endif
-				CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_cv[1] == 2);
-			}
-
-			// From const-qualified source
-			{
-				const multi_span<const int> src{ arr };
-
-				strided_span<const int, 1> sav_c{ src, {2, 1} };
-				CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_c.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_c[1] == 2);
+                CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_v.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_v[1] == 2);
 
 #if _MSC_VER > 1800
-				strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
 #else
-				strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
 #endif
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv[1] == 2);
+            }
 
-				CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_cv[1] == 2);
-			}
+            // From const-qualified source
+            {
+                const multi_span<const int> src{ arr };
 
-			// From volatile-qualified source
-			{
-				const multi_span<volatile int> src{ arr };
-
-				strided_span<volatile int, 1> sav_v{ src, {2, 1} };
-				CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_v.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_v[1] == 2);
+                strided_span<const int, 1> sav_c{ src, {2, 1} };
+                CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_c.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_c[1] == 2);
 
 #if _MSC_VER > 1800
-				strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
 #else
-				strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
 #endif
-				CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_cv[1] == 2);
-			}
 
-			// From cv-qualified source
-			{
-				const multi_span<const volatile int> src{ arr };
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv[1] == 2);
+            }
 
-				strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
-				CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-				CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
-				CHECK(sav_cv[1] == 2);
-			}
-		}
+            // From volatile-qualified source
+            {
+                const multi_span<volatile int> src{ arr };
 
-		// Check const-casting constructor
-		{
-			int arr[2] = { 4, 5 };
+                strided_span<volatile int, 1> sav_v{ src, {2, 1} };
+                CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_v.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_v[1] == 2);
 
-			const multi_span<int, 2> av(arr, 2);
-			multi_span<const int, 2> av2{ av };
-			CHECK(av2[1] == 5);
+#if _MSC_VER > 1800
+                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+#else
+                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+#endif
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv[1] == 2);
+            }
 
-			static_assert(std::is_convertible<const multi_span<int, 2>, multi_span<const int, 2>>::value, "ctor is not implicit!");
+            // From cv-qualified source
+            {
+                const multi_span<const volatile int> src{ arr };
 
-			const strided_span<int, 1> src{ arr, {2, 1} };
-			strided_span<const int, 1> sav{ src };
-			CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav.bounds().stride() == 1);
-			CHECK(sav[1] == 5);
+                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
+                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv[1] == 2);
+            }
+        }
 
-			static_assert(std::is_convertible<const strided_span<int, 1>, strided_span<const int, 1>>::value, "ctor is not implicit!");
-		}
+        // Check const-casting constructor
+        {
+            int arr[2] = { 4, 5 };
 
-		// Check copy constructor
-		{
-			int arr1[2] = { 3, 4 };
-			const strided_span<int, 1> src1{ arr1, {2, 1} };
-			strided_span<int, 1> sav1{ src1 };
+            const multi_span<int, 2> av(arr, 2);
+            multi_span<const int, 2> av2{ av };
+            CHECK(av2[1] == 5);
 
-			CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav1.bounds().stride() == 1);
-			CHECK(sav1[0] == 3);
+            static_assert(std::is_convertible<const multi_span<int, 2>, multi_span<const int, 2>>::value, "ctor is not implicit!");
 
-			int arr2[6] = { 1, 2, 3, 4, 5, 6 };
-			const strided_span<const int, 2> src2{ arr2, {{ 3, 2 }, { 2, 1 }} };
-			strided_span<const int, 2> sav2{ src2 };
-			CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
-			CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
-			CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
-		}
+            const strided_span<int, 1> src{ arr, {2, 1} };
+            strided_span<const int, 1> sav{ src };
+            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav.bounds().stride() == 1);
+            CHECK(sav[1] == 5);
 
-		// Check const-casting assignment operator
-		{
-			int arr1[2] = { 1, 2 };
-			int arr2[6] = { 3, 4, 5, 6, 7, 8 };
+            static_assert(std::is_convertible<const strided_span<int, 1>, strided_span<const int, 1>>::value, "ctor is not implicit!");
+        }
 
-			const strided_span<int, 1> src{ arr1, {{2}, {1}} };
-			strided_span<const int, 1> sav{ arr2, {{3}, {2}} };
-			strided_span<const int, 1>& sav_ref = (sav = src);
-			CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav.bounds().strides() == index<1>{ 1 });
-			CHECK(sav[0] == 1);
-			CHECK(&sav_ref == &sav);
-		}
+        // Check copy constructor
+        {
+            int arr1[2] = { 3, 4 };
+            const strided_span<int, 1> src1{ arr1, {2, 1} };
+            strided_span<int, 1> sav1{ src1 };
 
-		// Check copy assignment operator
-		{
-			int arr1[2] = { 3, 4 };
-			int arr1b[1] = { 0 };
-			const strided_span<int, 1> src1{ arr1, {2, 1} };
-			strided_span<int, 1> sav1{ arr1b, {1, 1} };
-			strided_span<int, 1>& sav1_ref = (sav1 = src1);
-			CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav1.bounds().strides() == index<1>{ 1 });
-			CHECK(sav1[0] == 3);
-			CHECK(&sav1_ref == &sav1);
+            CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav1.bounds().stride() == 1);
+            CHECK(sav1[0] == 3);
 
-			const int arr2[6] = { 1, 2, 3, 4, 5, 6 };
-			const int arr2b[1] = { 0 };
-			const strided_span<const int, 2> src2{ arr2, {{ 3, 2 },{ 2, 1 }} };
-			strided_span<const int, 2> sav2{ arr2b, {{ 1, 1 },{ 1, 1 }} };
-			strided_span<const int, 2>& sav2_ref = (sav2 = src2);
-			CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
-			CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
-			CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
-			CHECK(&sav2_ref == &sav2);
-		}
-	}
+            int arr2[6] = { 1, 2, 3, 4, 5, 6 };
+            const strided_span<const int, 2> src2{ arr2, {{ 3, 2 }, { 2, 1 }} };
+            strided_span<const int, 2> sav2{ src2 };
+            CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
+            CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
+            CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
+        }
 
-	TEST(strided_span_slice)
-	{
-		std::vector<int> data(5 * 10);
-		std::iota(begin(data), end(data), 0);
+        // Check const-casting assignment operator
+        {
+            int arr1[2] = { 1, 2 };
+            int arr2[6] = { 3, 4, 5, 6, 7, 8 };
+
+            const strided_span<int, 1> src{ arr1, {{2}, {1}} };
+            strided_span<const int, 1> sav{ arr2, {{3}, {2}} };
+            strided_span<const int, 1>& sav_ref = (sav = src);
+            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav.bounds().strides() == index<1>{ 1 });
+            CHECK(sav[0] == 1);
+            CHECK(&sav_ref == &sav);
+        }
+
+        // Check copy assignment operator
+        {
+            int arr1[2] = { 3, 4 };
+            int arr1b[1] = { 0 };
+            const strided_span<int, 1> src1{ arr1, {2, 1} };
+            strided_span<int, 1> sav1{ arr1b, {1, 1} };
+            strided_span<int, 1>& sav1_ref = (sav1 = src1);
+            CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav1.bounds().strides() == index<1>{ 1 });
+            CHECK(sav1[0] == 3);
+            CHECK(&sav1_ref == &sav1);
+
+            const int arr2[6] = { 1, 2, 3, 4, 5, 6 };
+            const int arr2b[1] = { 0 };
+            const strided_span<const int, 2> src2{ arr2, {{ 3, 2 },{ 2, 1 }} };
+            strided_span<const int, 2> sav2{ arr2b, {{ 1, 1 },{ 1, 1 }} };
+            strided_span<const int, 2>& sav2_ref = (sav2 = src2);
+            CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
+            CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
+            CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
+            CHECK(&sav2_ref == &sav2);
+        }
+    }
+
+    TEST(strided_span_slice)
+    {
+        std::vector<int> data(5 * 10);
+        std::iota(begin(data), end(data), 0);
         const multi_span<int, 5, 10> src = as_multi_span(multi_span<int>{data}, dim<5>(), dim<10>());
 
-		const strided_span<int, 2> sav{ src, {{5, 10}, {10, 1}} };
+        const strided_span<int, 2> sav{ src, {{5, 10}, {10, 1}} };
 #ifdef CONFIRM_COMPILATION_ERRORS
-		const strided_span<const int, 2> csav{ {src},{ { 5, 10 },{ 10, 1 } } };
+        const strided_span<const int, 2> csav{ {src},{ { 5, 10 },{ 10, 1 } } };
 #endif
-		const strided_span<const int, 2> csav{ multi_span<const int, 5, 10>{ src }, { { 5, 10 },{ 10, 1 } } };
+        const strided_span<const int, 2> csav{ multi_span<const int, 5, 10>{ src }, { { 5, 10 },{ 10, 1 } } };
 
-		strided_span<int, 1> sav_sl = sav[2];
-		CHECK(sav_sl[0] == 20);
-		CHECK(sav_sl[9] == 29);
+        strided_span<int, 1> sav_sl = sav[2];
+        CHECK(sav_sl[0] == 20);
+        CHECK(sav_sl[9] == 29);
 
-		strided_span<const int, 1> csav_sl = sav[3];
-		CHECK(csav_sl[0] == 30);
-		CHECK(csav_sl[9] == 39);
+        strided_span<const int, 1> csav_sl = sav[3];
+        CHECK(csav_sl[0] == 30);
+        CHECK(csav_sl[9] == 39);
 
-		CHECK(sav[4][0] == 40);
-		CHECK(sav[4][9] == 49);
-	}
+        CHECK(sav[4][0] == 40);
+        CHECK(sav[4][9] == 49);
+    }
 
-	TEST(strided_span_column_major)
-	{
-		// strided_span may be used to accomodate more peculiar
-		// use cases, such as column-major multidimensional array
-		// (aka. "FORTRAN" layout).
+    TEST(strided_span_column_major)
+    {
+        // strided_span may be used to accomodate more peculiar
+        // use cases, such as column-major multidimensional array
+        // (aka. "FORTRAN" layout).
 
-		int cm_array[3 * 5] = {
-			1, 4, 7, 10, 13,
-			2, 5, 8, 11, 14,
-			3, 6, 9, 12, 15
-		};
-		strided_span<int, 2> cm_sav{ cm_array, {{ 5, 3 },{ 1, 5 }} };
+        int cm_array[3 * 5] = {
+            1, 4, 7, 10, 13,
+            2, 5, 8, 11, 14,
+            3, 6, 9, 12, 15
+        };
+        strided_span<int, 2> cm_sav{ cm_array, {{ 5, 3 },{ 1, 5 }} };
 
-		// Accessing elements
-		CHECK((cm_sav[{0, 0}] == 1));
-		CHECK((cm_sav[{0, 1}] == 2));
-		CHECK((cm_sav[{1, 0}] == 4));
-		CHECK((cm_sav[{4, 2}] == 15));
+        // Accessing elements
+        CHECK((cm_sav[{0, 0}] == 1));
+        CHECK((cm_sav[{0, 1}] == 2));
+        CHECK((cm_sav[{1, 0}] == 4));
+        CHECK((cm_sav[{4, 2}] == 15));
 
-		// Slice
-		strided_span<int, 1> cm_sl = cm_sav[3];
+        // Slice
+        strided_span<int, 1> cm_sl = cm_sav[3];
 
-		CHECK(cm_sl[0] == 10);
-		CHECK(cm_sl[1] == 11);
-		CHECK(cm_sl[2] == 12);
+        CHECK(cm_sl[0] == 10);
+        CHECK(cm_sl[1] == 11);
+        CHECK(cm_sl[2] == 12);
 
-		// Section
-		strided_span<int, 2> cm_sec = cm_sav.section( { 2, 1 }, { 3, 2 });
+        // Section
+        strided_span<int, 2> cm_sec = cm_sav.section( { 2, 1 }, { 3, 2 });
 
-		CHECK((cm_sec.bounds().index_bounds() == index<2>{3, 2}));
-		CHECK((cm_sec[{0, 0}] == 8));
-		CHECK((cm_sec[{0, 1}] == 9));
-		CHECK((cm_sec[{1, 0}] == 11));
-		CHECK((cm_sec[{2, 1}] == 15));
-	}
+        CHECK((cm_sec.bounds().index_bounds() == index<2>{3, 2}));
+        CHECK((cm_sec[{0, 0}] == 8));
+        CHECK((cm_sec[{0, 1}] == 9));
+        CHECK((cm_sec[{1, 0}] == 11));
+        CHECK((cm_sec[{2, 1}] == 15));
+    }
 
-	TEST(strided_span_bounds)
-	{
-		int arr[] = { 0, 1, 2, 3 };
-		multi_span<int> av(arr);
+    TEST(strided_span_bounds)
+    {
+        int arr[] = { 0, 1, 2, 3 };
+        multi_span<int> av(arr);
 
-		{
-			// incorrect sections
+        {
+            // incorrect sections
 
-			CHECK_THROW(av.section(0, 0)[0], fail_fast);
-			CHECK_THROW(av.section(1, 0)[0], fail_fast);
-			CHECK_THROW(av.section(1, 1)[1], fail_fast);
+            CHECK_THROW(av.section(0, 0)[0], fail_fast);
+            CHECK_THROW(av.section(1, 0)[0], fail_fast);
+            CHECK_THROW(av.section(1, 1)[1], fail_fast);
 
-			CHECK_THROW(av.section(2, 5), fail_fast);
-			CHECK_THROW(av.section(5, 2), fail_fast);
-			CHECK_THROW(av.section(5, 0), fail_fast);
-			CHECK_THROW(av.section(0, 5), fail_fast);
-			CHECK_THROW(av.section(5, 5), fail_fast);
-		}
+            CHECK_THROW(av.section(2, 5), fail_fast);
+            CHECK_THROW(av.section(5, 2), fail_fast);
+            CHECK_THROW(av.section(5, 0), fail_fast);
+            CHECK_THROW(av.section(0, 5), fail_fast);
+            CHECK_THROW(av.section(5, 5), fail_fast);
+        }
 
-		{
-			// zero stride
-			strided_span<int, 1> sav{ av,{ { 4 },{} } };
-			CHECK(sav[0] == 0);
-			CHECK(sav[3] == 0);
-			CHECK_THROW(sav[4], fail_fast);
-		}
+        {
+            // zero stride
+            strided_span<int, 1> sav{ av,{ { 4 },{} } };
+            CHECK(sav[0] == 0);
+            CHECK(sav[3] == 0);
+            CHECK_THROW(sav[4], fail_fast);
+        }
 
-		{
-			// zero extent
-			strided_span<int, 1> sav{ av,{ {},{ 1 } } };
-			CHECK_THROW(sav[0], fail_fast);
-		}
+        {
+            // zero extent
+            strided_span<int, 1> sav{ av,{ {},{ 1 } } };
+            CHECK_THROW(sav[0], fail_fast);
+        }
 
-		{
-			// zero extent and stride
-			strided_span<int, 1> sav{ av,{ {},{} } };
-			CHECK_THROW(sav[0], fail_fast);
-		}
+        {
+            // zero extent and stride
+            strided_span<int, 1> sav{ av,{ {},{} } };
+            CHECK_THROW(sav[0], fail_fast);
+        }
 
-		{
-			// strided array ctor with matching strided bounds
-			strided_span<int, 1> sav{ arr,{ 4, 1 } };
-			CHECK(sav.bounds().index_bounds() == index<1>{ 4 });
-			CHECK(sav[3] == 3);
-			CHECK_THROW(sav[4], fail_fast);
-		}
+        {
+            // strided array ctor with matching strided bounds
+            strided_span<int, 1> sav{ arr,{ 4, 1 } };
+            CHECK(sav.bounds().index_bounds() == index<1>{ 4 });
+            CHECK(sav[3] == 3);
+            CHECK_THROW(sav[4], fail_fast);
+        }
 
-		{
-			// strided array ctor with smaller strided bounds
-			strided_span<int, 1> sav{ arr,{ 2, 1 } };
-			CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav[1] == 1);
-			CHECK_THROW(sav[2], fail_fast);
-		}
+        {
+            // strided array ctor with smaller strided bounds
+            strided_span<int, 1> sav{ arr,{ 2, 1 } };
+            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav[1] == 1);
+            CHECK_THROW(sav[2], fail_fast);
+        }
 
-		{
-			// strided array ctor with fitting irregular bounds
-			strided_span<int, 1> sav{ arr,{ 2, 3 } };
-			CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-			CHECK(sav[0] == 0);
-			CHECK(sav[1] == 3);
-			CHECK_THROW(sav[2], fail_fast);
-		}
+        {
+            // strided array ctor with fitting irregular bounds
+            strided_span<int, 1> sav{ arr,{ 2, 3 } };
+            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav[0] == 0);
+            CHECK(sav[1] == 3);
+            CHECK_THROW(sav[2], fail_fast);
+        }
 
-		{
-			// bounds cross data boundaries - from static arrays
-			CHECK_THROW((strided_span<int, 1> { arr, { 3, 2 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { arr, { 3, 3 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { arr, { 4, 5 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { arr, { 5, 1 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { arr, { 5, 5 } }), fail_fast);
-		}
+        {
+            // bounds cross data boundaries - from static arrays
+            CHECK_THROW((strided_span<int, 1> { arr, { 3, 2 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { arr, { 3, 3 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { arr, { 4, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { arr, { 5, 1 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { arr, { 5, 5 } }), fail_fast);
+        }
 
-		{
-			// bounds cross data boundaries - from array view
-			CHECK_THROW((strided_span<int, 1> { av, { 3, 2 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av, { 3, 3 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av, { 4, 5 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av, { 5, 1 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av, { 5, 5 } }), fail_fast);
-		}
+        {
+            // bounds cross data boundaries - from array view
+            CHECK_THROW((strided_span<int, 1> { av, { 3, 2 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av, { 3, 3 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av, { 4, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av, { 5, 1 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av, { 5, 5 } }), fail_fast);
+        }
 
-		{
-			// bounds cross data boundaries - from dynamic arrays
-			CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 2 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 3 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 4, 5 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 1 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 5 } }), fail_fast);
-			CHECK_THROW((strided_span<int, 1> { av.data(), 2, { 2, 2 } }), fail_fast);
-		}
+        {
+            // bounds cross data boundaries - from dynamic arrays
+            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 2 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 3 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 4, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 1 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1> { av.data(), 2, { 2, 2 } }), fail_fast);
+        }
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-		{
-			strided_span<int, 1> sav0{ av.data(), { 3, 2 } };
-			strided_span<int, 1> sav1{ arr, { 1 } };
-			strided_span<int, 1> sav2{ arr, { 1,1,1 } };
-			strided_span<int, 1> sav3{ av, { 1 } };
-			strided_span<int, 1> sav4{ av, { 1,1,1 } };
-			strided_span<int, 2> sav5{ av.as_multi_span(dim<2>(), dim<2>()), { 1 } };
-			strided_span<int, 2> sav6{ av.as_multi_span(dim<2>(), dim<2>()), { 1,1,1 } };
-			strided_span<int, 2> sav7{ av.as_multi_span(dim<2>(), dim<2>()), { { 1,1 },{ 1,1 },{ 1,1 } } };
+        {
+            strided_span<int, 1> sav0{ av.data(), { 3, 2 } };
+            strided_span<int, 1> sav1{ arr, { 1 } };
+            strided_span<int, 1> sav2{ arr, { 1,1,1 } };
+            strided_span<int, 1> sav3{ av, { 1 } };
+            strided_span<int, 1> sav4{ av, { 1,1,1 } };
+            strided_span<int, 2> sav5{ av.as_multi_span(dim<2>(), dim<2>()), { 1 } };
+            strided_span<int, 2> sav6{ av.as_multi_span(dim<2>(), dim<2>()), { 1,1,1 } };
+            strided_span<int, 2> sav7{ av.as_multi_span(dim<2>(), dim<2>()), { { 1,1 },{ 1,1 },{ 1,1 } } };
 
-			index<1> index{ 0, 1 };
-			strided_span<int, 1> sav8{ arr,{ 1,{ 1,1 } } };
-			strided_span<int, 1> sav9{ arr,{ { 1,1 },{ 1,1 } } };
-			strided_span<int, 1> sav10{ av,{ 1,{ 1,1 } } };
-			strided_span<int, 1> sav11{ av,{ { 1,1 },{ 1,1 } } };
-			strided_span<int, 2> sav12{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1 } } };
-			strided_span<int, 2> sav13{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1,1,1 } } };
-			strided_span<int, 2> sav14{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1,1,1 },{ 1 } } };
-		}
+            index<1> index{ 0, 1 };
+            strided_span<int, 1> sav8{ arr,{ 1,{ 1,1 } } };
+            strided_span<int, 1> sav9{ arr,{ { 1,1 },{ 1,1 } } };
+            strided_span<int, 1> sav10{ av,{ 1,{ 1,1 } } };
+            strided_span<int, 1> sav11{ av,{ { 1,1 },{ 1,1 } } };
+            strided_span<int, 2> sav12{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1 } } };
+            strided_span<int, 2> sav13{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1,1,1 } } };
+            strided_span<int, 2> sav14{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1,1,1 },{ 1 } } };
+        }
 #endif
-	}
+    }
 
-	TEST(strided_span_type_conversion)
-	{
-		int arr[] = { 0, 1, 2, 3 };
-		multi_span<int> av(arr);
+    TEST(strided_span_type_conversion)
+    {
+        int arr[] = { 0, 1, 2, 3 };
+        multi_span<int> av(arr);
 
-		{
-			strided_span<int, 1> sav{ av.data(), av.size(), { av.size() / 2, 2 } };
+        {
+            strided_span<int, 1> sav{ av.data(), av.size(), { av.size() / 2, 2 } };
 #ifdef CONFIRM_COMPILATION_ERRORS
-			strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
+            strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
 #endif
-		}
-		{
-			strided_span<int, 1> sav{ av, { av.size() / 2, 2 } };
+        }
+        {
+            strided_span<int, 1> sav{ av, { av.size() / 2, 2 } };
 #ifdef CONFIRM_COMPILATION_ERRORS
-			strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
+            strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
 #endif
-		}
+        }
 
-		multi_span<const byte, dynamic_range> bytes = as_bytes(av);
+        multi_span<const byte, dynamic_range> bytes = as_bytes(av);
 
-		// retype strided array with regular strides - from raw data
-		{
-			strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
-			strided_span<const byte, 2> sav2{ bytes.data(), bytes.size(), bounds };
-			strided_span<const int, 2> sav3 = sav2.as_strided_span<const int>();
-			CHECK(sav3[0][0] == 0);
-			CHECK(sav3[1][0] == 2);
-			CHECK_THROW(sav3[1][1], fail_fast);
-			CHECK_THROW(sav3[0][1], fail_fast);
-		}
+        // retype strided array with regular strides - from raw data
+        {
+            strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
+            strided_span<const byte, 2> sav2{ bytes.data(), bytes.size(), bounds };
+            strided_span<const int, 2> sav3 = sav2.as_strided_span<const int>();
+            CHECK(sav3[0][0] == 0);
+            CHECK(sav3[1][0] == 2);
+            CHECK_THROW(sav3[1][1], fail_fast);
+            CHECK_THROW(sav3[0][1], fail_fast);
+        }
 
-		// retype strided array with regular strides - from multi_span
-		{
-			strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
-			multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-			strided_span<const byte, 2> sav2{ bytes2, bounds };
-			strided_span<int, 2> sav3 = sav2.as_strided_span<int>();
-			CHECK(sav3[0][0] == 0);
-			CHECK(sav3[1][0] == 2);
-			CHECK_THROW(sav3[1][1], fail_fast);
-			CHECK_THROW(sav3[0][1], fail_fast);
-		}
+        // retype strided array with regular strides - from multi_span
+        {
+            strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
+            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_span<int, 2> sav3 = sav2.as_strided_span<int>();
+            CHECK(sav3[0][0] == 0);
+            CHECK(sav3[1][0] == 2);
+            CHECK_THROW(sav3[1][1], fail_fast);
+            CHECK_THROW(sav3[0][1], fail_fast);
+        }
 
-		// retype strided array with not enough elements - last dimension of the array is too small
-		{
-			strided_bounds<2> bounds{ { 4,2 },{ 4, 1 } };
-			multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-			strided_span<const byte, 2> sav2{ bytes2, bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
+        // retype strided array with not enough elements - last dimension of the array is too small
+        {
+            strided_bounds<2> bounds{ { 4,2 },{ 4, 1 } };
+            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
 
-		// retype strided array with not enough elements - strides are too small
-		{
-			strided_bounds<2> bounds{ { 4,2 },{ 2, 1 } };
-			multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-			strided_span<const byte, 2> sav2{ bytes2, bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
+        // retype strided array with not enough elements - strides are too small
+        {
+            strided_bounds<2> bounds{ { 4,2 },{ 2, 1 } };
+            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
 
-		// retype strided array with not enough elements - last dimension does not divide by the new typesize
-		{
-			strided_bounds<2> bounds{ { 2,6 },{ 4, 1 } };
-			multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-			strided_span<const byte, 2> sav2{ bytes2, bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
+        // retype strided array with not enough elements - last dimension does not divide by the new typesize
+        {
+            strided_bounds<2> bounds{ { 2,6 },{ 4, 1 } };
+            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
 
-		// retype strided array with not enough elements - strides does not divide by the new typesize
-		{
-			strided_bounds<2> bounds{ { 2, 1 },{ 6, 1 } };
-			multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-			strided_span<const byte, 2> sav2{ bytes2, bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
+        // retype strided array with not enough elements - strides does not divide by the new typesize
+        {
+            strided_bounds<2> bounds{ { 2, 1 },{ 6, 1 } };
+            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
 
-		// retype strided array with irregular strides - from raw data
-		{
-			strided_bounds<1> bounds{ bytes.size() / 2, 2 };
-			strided_span<const byte, 1> sav2{ bytes.data(), bytes.size(), bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
+        // retype strided array with irregular strides - from raw data
+        {
+            strided_bounds<1> bounds{ bytes.size() / 2, 2 };
+            strided_span<const byte, 1> sav2{ bytes.data(), bytes.size(), bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
 
-		// retype strided array with irregular strides - from multi_span
-		{
-			strided_bounds<1> bounds{ bytes.size() / 2, 2 };
-			strided_span<const byte, 1> sav2{ bytes, bounds };
-			CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
-		}
-	}
+        // retype strided array with irregular strides - from multi_span
+        {
+            strided_bounds<1> bounds{ bytes.size() / 2, 2 };
+            strided_span<const byte, 1> sav2{ bytes, bounds };
+            CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
+        }
+    }
 
-	TEST(empty_strided_spans)
-	{
-		{
-			multi_span<int, 0> empty_av(nullptr);
-			strided_span<int, 1> empty_sav{ empty_av, { 0, 1 } };
+    TEST(empty_strided_spans)
+    {
+        {
+            multi_span<int, 0> empty_av(nullptr);
+            strided_span<int, 1> empty_sav{ empty_av, { 0, 1 } };
 
-			CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
-			CHECK_THROW(empty_sav[0], fail_fast);
-			CHECK_THROW(empty_sav.begin()[0], fail_fast);
-			CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
+            CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
+            CHECK_THROW(empty_sav[0], fail_fast);
+            CHECK_THROW(empty_sav.begin()[0], fail_fast);
+            CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
 
-			for (auto& v : empty_sav)
-			{
+            for (const auto& v : empty_sav)
+            {
                 (void)v;
-				CHECK(false);
-			}
-		}
+                CHECK(false);
+            }
+        }
 
-		{
-			strided_span<int, 1> empty_sav{ nullptr, 0, { 0, 1 } };
+        {
+            strided_span<int, 1> empty_sav{ nullptr, 0, { 0, 1 } };
 
-			CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
-			CHECK_THROW(empty_sav[0], fail_fast);
-			CHECK_THROW(empty_sav.begin()[0], fail_fast);
-			CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
+            CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
+            CHECK_THROW(empty_sav[0], fail_fast);
+            CHECK_THROW(empty_sav.begin()[0], fail_fast);
+            CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
 
-			for (auto& v : empty_sav)
-			{
+            for (const auto& v : empty_sav)
+            {
                 (void)v;
-				CHECK(false);
-			}
-		}
-	}
+                CHECK(false);
+            }
+        }
+    }
 
     void iterate_every_other_element(multi_span<int, dynamic_range> av)
     {
@@ -614,7 +614,7 @@ SUITE(strided_span_tests)
 
     void iterate_second_slice(multi_span<int, dynamic_range, dynamic_range, dynamic_range> av)
     {
-        int expected[6] = {2,3,10,11,18,19};
+        const int expected[6] = {2,3,10,11,18,19};
         auto section = av.section({0,1,0}, {3,1,2});
 
         for (auto i = 0; i < section.extent<0>(); ++i)
@@ -635,7 +635,7 @@ SUITE(strided_span_tests)
         }
 
         int i = 0;
-        for (auto num : section)
+        for (const auto num : section)
         {
             CHECK(num == expected[i]);
             i++;
@@ -644,7 +644,7 @@ SUITE(strided_span_tests)
 
     TEST(strided_span_section_iteration_3d)
     {
-        int arr[3][4][2];
+        int arr[3][4][2]{};
         for (auto i = 0; i < 3; ++i)
         {
             for (auto j = 0; j < 4; ++j)
@@ -660,8 +660,8 @@ SUITE(strided_span_tests)
 
     TEST(dynamic_strided_span_section_iteration_3d)
     {
-        auto height = 12, width = 2;
-        auto size = height * width;
+        const auto height = 12, width = 2;
+        const auto size = height * width;
 
         auto arr = new int[static_cast<std::size_t>(size)];
         for (auto i = 0; i < size; ++i)
@@ -744,5 +744,5 @@ SUITE(strided_span_tests)
 
 int main(int, const char *[])
 {
-	return UnitTest::RunAllTests();
+    return UnitTest::RunAllTests();
 }

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -230,7 +230,7 @@ SUITE(string_span_tests)
             const char ar2[10] = "Hello";
             const std::string str = "Hello";
             const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            gsl::span<const char> sp = ensure_z("Hello");
+            const gsl::span<const char> sp = ensure_z("Hello");
 
             cstring_span<> span = "Hello";
 
@@ -554,52 +554,52 @@ SUITE(string_span_tests)
         // from const string
         {
             const std::string str = "Hello";
-            cstring_span<> span = str;
+            const cstring_span<> span = str;
             CHECK(span.length() == 5);
         }
 
         // from non-const string
         {
             std::string str = "Hello";
-            cstring_span<> span = str;
+            const cstring_span<> span = str;
             CHECK(span.length() == 5);
         }
 
         // from const vector
         {
             const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            cstring_span<> span = vec;
+            const cstring_span<> span = vec;
             CHECK(span.length() == 5);
         }
 
         // from non-const vector
         {
             std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            cstring_span<> span = vec;
+            const cstring_span<> span = vec;
             CHECK(span.length() == 5);
         }
 
         // from const span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
             const span<const char> inner = vec;
-            cstring_span<> span = inner;
+            const cstring_span<> span = inner;
             CHECK(span.length() == 5);
         }
 
         // from non-const span
         {
             std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            span<char> inner = vec;
-            cstring_span<> span = inner;
+            const span<char> inner = vec;
+            const cstring_span<> span = inner;
             CHECK(span.length() == 5);
         }
 
         // from const string_span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            cstring_span<> tmp = vec;
-            cstring_span<> span = tmp;
+            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const cstring_span<> tmp = vec;
+            const cstring_span<> span = tmp;
             CHECK(span.length() == 5);
         }
 
@@ -726,8 +726,8 @@ SUITE(string_span_tests)
         // from non-const string_span
         {
             std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-            string_span<> tmp = vec;
-            string_span<> span = tmp;
+            const string_span<> tmp = vec;
+            const string_span<> span = tmp;
             CHECK(span.length() == 5);
         }
 
@@ -745,7 +745,7 @@ SUITE(string_span_tests)
         {
             std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
             const string_span<> tmp = vec;
-            string_span<> span = tmp;
+            const string_span<> span = tmp;
             CHECK(span.length() == 5);
         }
     }
@@ -767,29 +767,29 @@ SUITE(string_span_tests)
         // move string_span
         {
             cstring_span<> span = "Hello";
-            auto span1 = std::move(span);
+            const auto span1 = std::move(span);
             CHECK(span1.length() == 5);
         }
         {
             cstring_span<> span = "Hello";
-            auto span1 = move_wrapper(std::move(span));
+            const auto span1 = move_wrapper(std::move(span));
             CHECK(span1.length() == 5);
         }
         {
             cstring_span<> span = "Hello";
-            auto span1 = move_wrapper(std::move(span));
+            const auto span1 = move_wrapper(std::move(span));
             CHECK(span1.length() == 5);
         }
 
         // move span
         {
             span<const char> span = ensure_z("Hello");
-            cstring_span<> span1 = std::move(span);
+            const cstring_span<> span1 = std::move(span);
             CHECK(span1.length() == 5);
         }
         {
             span<const char> span = ensure_z("Hello");
-            cstring_span<> span2 = move_wrapper(std::move(span));
+            const cstring_span<> span2 = move_wrapper(std::move(span));
             CHECK(span2.length() == 5);
         }
 
@@ -940,7 +940,7 @@ SUITE(string_span_tests)
             wchar_t buf[1];
             buf[0] = L'a';
 
-            auto workaround_macro = [&]() { wzstring_span<> zspan({ buf, 1 }); };
+            const auto workaround_macro = [&]() { wzstring_span<> zspan({ buf, 1 }); };
             CHECK_THROW(workaround_macro(), fail_fast);
         }
 
@@ -948,7 +948,7 @@ SUITE(string_span_tests)
         {
             wchar_t buf[10];
 
-            auto name = CreateTempNameW({ buf, 10 });
+            const auto name = CreateTempNameW({ buf, 10 });
             if (!name.empty())
             {
                 cwzstring<> str = name.assume_z();

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -17,6 +17,7 @@
 #include <UnitTest++/UnitTest++.h>
 #include <cstdlib>
 #include <gsl/string_span>
+#include <gsl/gsl> //owner
 #include <vector>
 #include <map>
 
@@ -441,7 +442,7 @@ SUITE(string_span_tests)
 
         // ensure z on c strings
         {
-            char* ptr = new char[3];
+            gsl::owner<char*> ptr = new char[3];
 
             ptr[0] = 'a';
             ptr[1] = 'b';

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -92,7 +92,7 @@ SUITE(utils_tests)
     TEST(narrow)
     {
         int n = 120;
-        char c = narrow<char>(n);
+        const char c = narrow<char>(n);
         CHECK(c == 120);
 
         n = 300;


### PR DESCRIPTION
This PR fixes some of the warnings that the c++ core checker throws in VS2017. Mostly const correctnes "issues" and a few suppressions around pointer arithmetic. 