### PR TITLE
Enable usage of gsl::narrow with exceptions disabled

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -72,18 +72,54 @@ struct fail_fast : public std::logic_error
 {
     explicit fail_fast(char const* const message) : std::logic_error(message) {}
 };
-}
+namespace details
+{
+template <typename Exception>
+[[noreturn]] void throw_exception(Exception&& exception);
+
+} //namespace details
+} //namespace gsl
 
 #if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
 
+namespace gsl
+{
+namespace details
+{
+template <typename Exception>
+[[noreturn]] void throw_exception(Exception&& exception)
+{
+    throw exception;
+}
+
+} //namespace details
+} //namespace gsl
+
 #define GSL_CONTRACT_CHECK(type, cond)                                                             \
     (GSL_LIKELY(cond) ? static_cast<void>(0)                                                       \
-                      : throw gsl::fail_fast("GSL: " type " failure at " __FILE__                  \
-                                             ": " GSL_STRINGIFY(__LINE__)))
+                      : gsl::throw_exception(gsl::fail_fast("GSL: " type " failure at " __FILE__   \
+                                             ": " GSL_STRINGIFY(__LINE__))))
 
 #elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
 #define GSL_CONTRACT_CHECK(type, cond) (GSL_LIKELY(cond) ? static_cast<void>(0) : std::terminate())
+
+namespace gsl
+{
+namespace details
+{
+template <typename Exception>
+[[noreturn]] void throw_exception(Exception&& exception)
+{
+    static_cast<void>(exception);
+    std::terminate();
+}
+
+} //namespace details
+} //namespace gsl
+
+ #define GSL_CONTRACT_CHECK(type, cond)                                                            \
+    (GSL_LIKELY(cond) ? static_cast<void>(0) : std::terminate())
 
 #elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
 

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -121,9 +121,9 @@ template <class T, class U>
 inline T narrow(U u)
 {
     T t = narrow_cast<T>(u);
-    if (static_cast<U>(t) != u) throw narrowing_error();
+    if (static_cast<U>(t) != u) gsl::details::throw_exception(narrowing_error());
     if (!details::is_same_signedness<T, U>::value && ((t < T{}) != (u < U{})))
-        throw narrowing_error();
+        gsl::details::throw_exception(narrowing_error());
     return t;
 }
 


### PR DESCRIPTION
This solution uses the approach of boost::asio to enabling usage of the library in environments where exception usage is either prohibited or not feasible (due to code size constraints). A function template gsl::throw_exception has been added, which in a normal environment just throws the exception. However, when ```GSL_TERMINATE_ON_CONTRACT_VIOLATION``` is defined the function is only declared by gsl and the definition of this function template must be supplied by the library's user.

I could also modify the macro ```GSL_CONTRACT_CHECK``` so that it's exactly the same when exceptions are either enabled and disabled, however this would cause existing, working code that uses ```GSL_TERMINATE_ON_CONTRACT_VIOLATION``` to break. If this approach is chosen then this macro might as well be renamed to ```GSL_NOTHROW_ON_CONTRACT_VIOLATION``` and the behavior on contract violation would be user-defined.

Closes: #468

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>