### PR TITLE
Added support of not_null<smart_ptr> comparison

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -117,6 +117,42 @@ std::ostream& operator<<(std::ostream& os, const not_null<T>& val)
     return os;
 }
 
+template <class T, class U>
+bool operator==(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() == rhs.get();
+}
+
+template <class T, class U>
+bool operator!=(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() != rhs.get();
+}
+
+template <class T, class U>
+bool operator<(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() < rhs.get();
+}
+
+template <class T, class U>
+bool operator<=(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() <= rhs.get();
+}
+
+template <class T, class U>
+bool operator>(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() > rhs.get();
+}
+
+template <class T, class U>
+bool operator>=(const not_null<T>& lhs, const not_null<U>& rhs)
+{
+    return lhs.get() >= rhs.get();
+}
+
 // more unwanted operators
 template <class T, class U>
 std::ptrdiff_t operator-(const not_null<T>&, const not_null<U>&) = delete;

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -118,37 +118,37 @@ std::ostream& operator<<(std::ostream& os, const not_null<T>& val)
 }
 
 template <class T, class U>
-bool operator==(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator==(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() == rhs.get())
 {
     return lhs.get() == rhs.get();
 }
 
 template <class T, class U>
-bool operator!=(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator!=(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() != rhs.get())
 {
     return lhs.get() != rhs.get();
 }
 
 template <class T, class U>
-bool operator<(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator<(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() < rhs.get())
 {
     return lhs.get() < rhs.get();
 }
 
 template <class T, class U>
-bool operator<=(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator<=(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() <= rhs.get())
 {
     return lhs.get() <= rhs.get();
 }
 
 template <class T, class U>
-bool operator>(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator>(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() > rhs.get())
 {
     return lhs.get() > rhs.get();
 }
 
 template <class T, class U>
-bool operator>=(const not_null<T>& lhs, const not_null<U>& rhs)
+auto operator>=(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.get() >= rhs.get())
 {
     return lhs.get() >= rhs.get();
 }

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -148,10 +148,9 @@ SUITE(NotNullTests)
 
     TEST(TestNotNullRawPointerComparison)
     {
-        int x = 1;
-        const int y = 2;
-        auto p1 = &x;
-        auto p2 = &y;
+        int ints[2] = {42, 43};
+        int* p1 = &ints[0];
+        const int* p2 = &ints[1];
 
         using NotNull1 = not_null<decltype(p1)>;
         using NotNull2 = not_null<decltype(p2)>;
@@ -181,8 +180,11 @@ SUITE(NotNullTests)
 
     TEST(TestNotNullSharedPtrComparison)
     {
-        auto sp1 = std::make_shared<int>(1);
-        auto sp2 = std::make_shared<const int>(3);
+        int ints[2] = {42, 43};
+        auto emptyDeleter = [](const int*){};
+
+        shared_ptr<int> sp1(&ints[0], emptyDeleter);
+        shared_ptr<const int> sp2(&ints[1], emptyDeleter);
 
         using NotNullSp1 = not_null<decltype(sp1)>;
         using NotNullSp2 = not_null<decltype(sp2)>;
@@ -210,39 +212,37 @@ SUITE(NotNullTests)
         CHECK((NotNullSp2(sp2) >= NotNullSp1(sp1)) == (sp2 >= sp1));
     }
 
-	TEST(TestNotNullCustomPtrComparison)
-	{
-		int i = 42;
-		CustomPtr<int> p1(&i);
-		const int ci = 42;
-		CustomPtr<const int> p2(&ci);
+    TEST(TestNotNullCustomPtrComparison)
+    {
+        int ints[2] = { 42, 43 };
+        CustomPtr<int> p1(&ints[0]);
+        CustomPtr<const int> p2(&ints[1]);
 
-		using NotNull1 = not_null<decltype(p1)>;
-		using NotNull2 = not_null<decltype(p2)>;
+        using NotNull1 = not_null<decltype(p1)>;
+        using NotNull2 = not_null<decltype(p2)>;
 
-		CHECK((NotNull1(p1) == NotNull1(p1)) == "true");
-		CHECK((NotNull1(p1) == NotNull2(p2)) == "false");
+        CHECK((NotNull1(p1) == NotNull1(p1)) == "true");
+        CHECK((NotNull1(p1) == NotNull2(p2)) == "false");
 
-		CHECK((NotNull1(p1) != NotNull1(p1)) == "false");
-		CHECK((NotNull1(p1) != NotNull2(p2)) == "true");
+        CHECK((NotNull1(p1) != NotNull1(p1)) == "false");
+        CHECK((NotNull1(p1) != NotNull2(p2)) == "true");
 
-		CHECK((NotNull1(p1) < NotNull1(p1)) == "false");
-		CHECK((NotNull1(p1) < NotNull2(p2)) == (p1 < p2));
-		CHECK((NotNull2(p2) < NotNull1(p1)) == (p2 < p1));
+        CHECK((NotNull1(p1) < NotNull1(p1)) == "false");
+        CHECK((NotNull1(p1) < NotNull2(p2)) == (p1 < p2));
+        CHECK((NotNull2(p2) < NotNull1(p1)) == (p2 < p1));
 
-		CHECK((NotNull1(p1) > NotNull1(p1)) == "false");
-		CHECK((NotNull1(p1) > NotNull2(p2)) == (p1 > p2));
-		CHECK((NotNull2(p2) > NotNull1(p1)) == (p2 > p1));
+        CHECK((NotNull1(p1) > NotNull1(p1)) == "false");
+        CHECK((NotNull1(p1) > NotNull2(p2)) == (p1 > p2));
+        CHECK((NotNull2(p2) > NotNull1(p1)) == (p2 > p1));
 
-		CHECK((NotNull1(p1) <= NotNull1(p1)) == "true");
-		CHECK((NotNull1(p1) <= NotNull2(p2)) == (p1 <= p2));
-		CHECK((NotNull2(p2) <= NotNull1(p1)) == (p2 <= p1));
+        CHECK((NotNull1(p1) <= NotNull1(p1)) == "true");
+        CHECK((NotNull1(p1) <= NotNull2(p2)) == (p1 <= p2));
+        CHECK((NotNull2(p2) <= NotNull1(p1)) == (p2 <= p1));
 
-		CHECK((NotNull1(p1) >= NotNull1(p1)) == "true");
-		CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
-		CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
-
-	}
+        CHECK((NotNull1(p1) >= NotNull1(p1)) == "true");
+        CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
+        CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
+    }
 }
 
 int main(int, const char *[])

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -180,11 +180,8 @@ SUITE(NotNullTests)
 
     TEST(TestNotNullSharedPtrComparison)
     {
-        int ints[2] = {42, 43};
-        auto emptyDeleter = [](const int*){};
-
-        shared_ptr<int> sp1(&ints[0], emptyDeleter);
-        shared_ptr<const int> sp2(&ints[1], emptyDeleter);
+        auto sp1 = std::make_shared<int>(42);
+        auto sp2 = std::make_shared<const int>(43);
 
         using NotNullSp1 = not_null<decltype(sp1)>;
         using NotNullSp2 = not_null<decltype(sp2)>;

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -18,6 +18,7 @@
 #include <gsl/gsl>
 #include <vector>
 #include <memory>
+#include <string>
 
 using namespace gsl;
 
@@ -33,6 +34,54 @@ struct RefCounted
     operator T*() { return p_; }
     T* p_;
 };
+
+// user defined smart pointer with comparison operators returning non bool value
+template <typename T>
+struct CustomPtr
+{
+	CustomPtr(T* p) : p_(p) {}
+	operator T*() { return p_; }
+	bool operator !=(std::nullptr_t)const { return p_ != nullptr; }
+	T* p_ = nullptr;
+};
+
+template <typename T, typename U>
+std::string operator==(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+    return reinterpret_cast<const void*>(lhs.p_) == reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+template <typename T, typename U>
+std::string operator!=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+	return reinterpret_cast<const void*>(lhs.p_) != reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+template <typename T, typename U>
+std::string operator<(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+	return reinterpret_cast<const void*>(lhs.p_) < reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+template <typename T, typename U>
+std::string operator>(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+	return reinterpret_cast<const void*>(lhs.p_) > reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+template <typename T, typename U>
+std::string operator<=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+	return reinterpret_cast<const void*>(lhs.p_) <= reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+template <typename T, typename U>
+std::string operator>=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
+{
+	return reinterpret_cast<const void*>(lhs.p_) >= reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+}
+
+
 
 SUITE(NotNullTests)
 {
@@ -160,6 +209,40 @@ SUITE(NotNullTests)
         CHECK((NotNullSp1(sp1) >= NotNullSp2(sp2)) == (sp1 >= sp2));
         CHECK((NotNullSp2(sp2) >= NotNullSp1(sp1)) == (sp2 >= sp1));
     }
+
+	TEST(TestNotNullCustomPtrComparison)
+	{
+		int i = 42;
+		CustomPtr<int> p1(&i);
+		const int ci = 42;
+		CustomPtr<const int> p2(&ci);
+
+		using NotNull1 = not_null<decltype(p1)>;
+		using NotNull2 = not_null<decltype(p2)>;
+
+		CHECK((NotNull1(p1) == NotNull1(p1)) == "true");
+		CHECK((NotNull1(p1) == NotNull2(p2)) == "false");
+
+		CHECK((NotNull1(p1) != NotNull1(p1)) == "false");
+		CHECK((NotNull1(p1) != NotNull2(p2)) == "true");
+
+		CHECK((NotNull1(p1) < NotNull1(p1)) == "false");
+		CHECK((NotNull1(p1) < NotNull2(p2)) == (p1 < p2));
+		CHECK((NotNull2(p2) < NotNull1(p1)) == (p2 < p1));
+
+		CHECK((NotNull1(p1) > NotNull1(p1)) == "false");
+		CHECK((NotNull1(p1) > NotNull2(p2)) == (p1 > p2));
+		CHECK((NotNull2(p2) > NotNull1(p1)) == (p2 > p1));
+
+		CHECK((NotNull1(p1) <= NotNull1(p1)) == "true");
+		CHECK((NotNull1(p1) <= NotNull2(p2)) == (p1 <= p2));
+		CHECK((NotNull2(p2) <= NotNull1(p1)) == (p2 <= p1));
+
+		CHECK((NotNull1(p1) >= NotNull1(p1)) == "true");
+		CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
+		CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
+
+	}
 }
 
 int main(int, const char *[])

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -17,6 +17,7 @@
 #include <UnitTest++/UnitTest++.h> 
 #include <gsl/gsl>
 #include <vector>
+#include <memory>
 
 using namespace gsl;
 
@@ -94,6 +95,70 @@ SUITE(NotNullTests)
 
         int* q = nullptr;
         CHECK_THROW(p = q, fail_fast);
+    }
+
+    TEST(TestNotNullRawPointerComparison)
+    {
+        int x = 1;
+        const int y = 2;
+        auto p1 = &x;
+        auto p2 = &y;
+
+        using NotNull1 = not_null<decltype(p1)>;
+        using NotNull2 = not_null<decltype(p2)>;
+
+        CHECK((NotNull1(p1) == NotNull1(p1)) == true);
+        CHECK((NotNull1(p1) == NotNull2(p2)) == false);
+
+        CHECK((NotNull1(p1) != NotNull1(p1)) == false);
+        CHECK((NotNull1(p1) != NotNull2(p2)) == true);
+
+        CHECK((NotNull1(p1) < NotNull1(p1)) == false);
+        CHECK((NotNull1(p1) < NotNull2(p2)) == (p1 < p2));
+        CHECK((NotNull2(p2) < NotNull1(p1)) == (p2 < p1));
+
+        CHECK((NotNull1(p1) > NotNull1(p1)) == false);
+        CHECK((NotNull1(p1) > NotNull2(p2)) == (p1 > p2));
+        CHECK((NotNull2(p2) > NotNull1(p1)) == (p2 > p1));
+
+        CHECK((NotNull1(p1) <= NotNull1(p1)) == true);
+        CHECK((NotNull1(p1) <= NotNull2(p2)) == (p1 <= p2));
+        CHECK((NotNull2(p2) <= NotNull1(p1)) == (p2 <= p1));
+
+        CHECK((NotNull1(p1) >= NotNull1(p1)) == true);
+        CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
+        CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
+    }
+
+    TEST(TestNotNullSharedPtrComparison)
+    {
+        auto sp1 = std::make_shared<int>(1);
+        auto sp2 = std::make_shared<const int>(3);
+
+        using NotNullSp1 = not_null<decltype(sp1)>;
+        using NotNullSp2 = not_null<decltype(sp2)>;
+
+        CHECK((NotNullSp1(sp1) == NotNullSp1(sp1)) == true);
+        CHECK((NotNullSp1(sp1) == NotNullSp2(sp2)) == false);
+
+        CHECK((NotNullSp1(sp1) != NotNullSp1(sp1)) == false);
+        CHECK((NotNullSp1(sp1) != NotNullSp2(sp2)) == true);
+
+        CHECK((NotNullSp1(sp1) < NotNullSp1(sp1)) == false);
+        CHECK((NotNullSp1(sp1) < NotNullSp2(sp2)) == (sp1 < sp2));
+        CHECK((NotNullSp2(sp2) < NotNullSp1(sp1)) == (sp2 < sp1));
+
+        CHECK((NotNullSp1(sp1) > NotNullSp1(sp1)) == false);
+        CHECK((NotNullSp1(sp1) > NotNullSp2(sp2)) == (sp1 > sp2));
+        CHECK((NotNullSp2(sp2) > NotNullSp1(sp1)) == (sp2 > sp1));
+
+        CHECK((NotNullSp1(sp1) <= NotNullSp1(sp1)) == true);
+        CHECK((NotNullSp1(sp1) <= NotNullSp2(sp2)) == (sp1 <= sp2));
+        CHECK((NotNullSp2(sp2) <= NotNullSp1(sp1)) == (sp2 <= sp1));
+
+        CHECK((NotNullSp1(sp1) >= NotNullSp1(sp1)) == true);
+        CHECK((NotNullSp1(sp1) >= NotNullSp2(sp2)) == (sp1 >= sp2));
+        CHECK((NotNullSp2(sp2) >= NotNullSp1(sp1)) == (sp2 >= sp1));
     }
 }
 


### PR DESCRIPTION
This pull requests adds comparison operators support for gsl::not_null on smart pointers such as shared_ptr.

Comparison already worked for `not_null<raw pointer>`. Now not_null smart pointers can also be compared.