### PR TITLE
fail_fast should derive from logic_error

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -68,9 +68,9 @@
 
 namespace gsl
 {
-struct fail_fast : public std::runtime_error
+struct fail_fast : public std::logic_error
 {
-    explicit fail_fast(char const* const message) : std::runtime_error(message) {}
+    explicit fail_fast(char const* const message) : std::logic_error(message) {}
 };
 }
 


### PR DESCRIPTION
Fixes #298.

Contract violations are logic errors.