### PR TITLE
Reformat files to follow clang-format style

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -24,24 +24,25 @@
 #include <gsl/multi_span>  // multi_span, strided_span...
 #include <gsl/span>        // span
 #include <gsl/string_span> // zstring, string_span, zstring_builder...
-#include <memory>
+
 #include <iostream>
+#include <memory>
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
- #pragma push_macro("constexpr")
- #define constexpr /*constexpr*/
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
 
- // MSVC 2013 workarounds
- #if _MSC_VER <= 1800
-  // noexcept is not understood
-  #pragma push_macro("noexcept")
-  #define noexcept /*noexcept*/
+// MSVC 2013 workarounds
+#if _MSC_VER <= 1800
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
 
-  // turn off some misguided warnings
-  #pragma warning(push)
-  #pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
- #endif // _MSC_VER <= 1800
-#endif // defined(_MSC_VER) && _MSC_VER < 1910
+// turn off some misguided warnings
+#pragma warning(push)
+#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
+#endif                          // _MSC_VER <= 1800
+#endif                          // defined(_MSC_VER) && _MSC_VER < 1910
 
 namespace gsl
 {
@@ -76,10 +77,15 @@ public:
     static_assert(std::is_assignable<T&, std::nullptr_t>::value, "T cannot be assigned nullptr.");
 
     template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
-    constexpr not_null(U&& u) : ptr_(std::forward<U>(u)) { Expects(ptr_ != nullptr); }
+    constexpr not_null(U&& u) : ptr_(std::forward<U>(u))
+    {
+        Expects(ptr_ != nullptr);
+    }
 
     template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
-    constexpr not_null(const not_null<U>& other) : not_null(other.get()) {}
+    constexpr not_null(const not_null<U>& other) : not_null(other.get())
+    {
+    }
 
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
@@ -157,7 +163,7 @@ auto operator>=(const not_null<T>& lhs, const not_null<U>& rhs) -> decltype(lhs.
 template <class T, class U>
 std::ptrdiff_t operator-(const not_null<T>&, const not_null<U>&) = delete;
 template <class T>
-not_null<T> operator-(const not_null<T>&, std::ptrdiff_t)  = delete;
+not_null<T> operator-(const not_null<T>&, std::ptrdiff_t) = delete;
 template <class T>
 not_null<T> operator+(const not_null<T>&, std::ptrdiff_t) = delete;
 template <class T>
@@ -176,15 +182,15 @@ struct hash<gsl::not_null<T>>
 } // namespace std
 
 #if defined(_MSC_VER) && _MSC_VER < 1910
- #undef constexpr
- #pragma pop_macro("constexpr")
+#undef constexpr
+#pragma pop_macro("constexpr")
 
- #if _MSC_VER <= 1800
-  #undef noexcept
-  #pragma pop_macro("noexcept")
+#if _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
 
-  #pragma warning(pop)
- #endif // _MSC_VER <= 1800
+#pragma warning(pop)
+#endif // _MSC_VER <= 1800
 #endif // defined(_MSC_VER) && _MSC_VER < 1910
 
 #endif // GSL_GSL_H

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -20,30 +20,32 @@
 #define GSL_ALGORITHM_H
 
 #include <gsl/span>
+
 #include <algorithm>
 
 #ifdef _MSC_VER
- #pragma warning(push)
+#pragma warning(push)
 
- // turn off some warnings that are noisy about our Expects statements
- #pragma warning(disable : 4127) // conditional expression is constant
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(disable : 4127) // conditional expression is constant
 
- // blanket turn off warnings from CppCoreCheck for now
- // so people aren't annoyed by them when running the tool.
- // more targeted suppressions will be added in a future update to the GSL
- #pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
 #endif // _MSC_VER
 
 namespace gsl
 {
 
-template <class SrcElementType, std::ptrdiff_t SrcExtent,
-          class DestElementType, std::ptrdiff_t DestExtent>
+template <class SrcElementType, std::ptrdiff_t SrcExtent, class DestElementType,
+          std::ptrdiff_t DestExtent>
 void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent> dest)
 {
     static_assert(std::is_assignable<decltype(*dest.data()), decltype(*src.data())>::value,
                   "Elements of source span can not be assigned to elements of destination span");
-    static_assert(SrcExtent == dynamic_extent || DestExtent == dynamic_extent || (SrcExtent <= DestExtent),
+    static_assert(SrcExtent == dynamic_extent || DestExtent == dynamic_extent ||
+                      (SrcExtent <= DestExtent),
                   "Source range is longer than target range");
 
     Expects(dest.size() >= src.size());
@@ -53,7 +55,7 @@ void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent>
 } // namespace gsl
 
 #ifdef _MSC_VER
- #pragma warning(pop)
+#pragma warning(pop)
 #endif // _MSC_VER
 
 #endif // GSL_ALGORITHM_H

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -32,18 +32,18 @@
 //
 #if !(defined(GSL_THROW_ON_CONTRACT_VIOLATION) || defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION) ||  \
       defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION))
- #define GSL_TERMINATE_ON_CONTRACT_VIOLATION
+#define GSL_TERMINATE_ON_CONTRACT_VIOLATION
 #endif
 
 #define GSL_STRINGIFY_DETAIL(x) #x
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)
 
 #if defined(__clang__) || defined(__GNUC__)
- #define GSL_LIKELY(x) __builtin_expect (!!(x), 1)
- #define GSL_UNLIKELY(x) __builtin_expect (!!(x), 0)
+#define GSL_LIKELY(x) __builtin_expect(!!(x), 1)
+#define GSL_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
- #define GSL_LIKELY(x) (!!(x))
- #define GSL_UNLIKELY(x) (!!(x))
+#define GSL_LIKELY(x) (!!(x))
+#define GSL_UNLIKELY(x) (!!(x))
 #endif
 
 //
@@ -53,13 +53,13 @@
 // whether or not cond is actually evaluated.
 //
 #ifdef _MSC_VER
- #define GSL_ASSUME(cond) __assume(cond)
+#define GSL_ASSUME(cond) __assume(cond)
 #elif defined(__clang__)
- #define GSL_ASSUME(cond) __builtin_assume(cond)
+#define GSL_ASSUME(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)
- #define GSL_ASSUME(cond) ((cond) ? static_cast<void>(0) : __builtin_unreachable())
+#define GSL_ASSUME(cond) ((cond) ? static_cast<void>(0) : __builtin_unreachable())
 #else
- #define GSL_ASSUME(cond) static_cast<void>(!!(cond))
+#define GSL_ASSUME(cond) static_cast<void>(!!(cond))
 #endif
 
 //
@@ -76,18 +76,18 @@ struct fail_fast : public std::logic_error
 
 #if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
 
- #define GSL_CONTRACT_CHECK(type, cond)                                                            \
-    (GSL_LIKELY(cond) ? static_cast<void>(0) :                                                     \
-        throw gsl::fail_fast("GSL: " type " failure at " __FILE__ ": " GSL_STRINGIFY(__LINE__)))
+#define GSL_CONTRACT_CHECK(type, cond)                                                             \
+    (GSL_LIKELY(cond) ? static_cast<void>(0)                                                       \
+                      : throw gsl::fail_fast("GSL: " type " failure at " __FILE__                  \
+                                             ": " GSL_STRINGIFY(__LINE__)))
 
 #elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
- #define GSL_CONTRACT_CHECK(type, cond)                                                            \
-    (GSL_LIKELY(cond) ? static_cast<void>(0) : std::terminate())
+#define GSL_CONTRACT_CHECK(type, cond) (GSL_LIKELY(cond) ? static_cast<void>(0) : std::terminate())
 
 #elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
 
- #define GSL_CONTRACT_CHECK(type, cond) GSL_ASSUME(cond)
+#define GSL_CONTRACT_CHECK(type, cond) GSL_ASSUME(cond)
 
 #endif
 

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -22,22 +22,22 @@
 #include <type_traits>
 
 #ifdef _MSC_VER
- #pragma warning(push)
+#pragma warning(push)
 
- // don't warn about function style casts in byte related operators
- #pragma warning(disable : 26493)
+// don't warn about function style casts in byte related operators
+#pragma warning(disable : 26493)
 
- // MSVC 2013 workarounds
- #if _MSC_VER <= 1800
-  // constexpr is not understood
-  #pragma push_macro("constexpr")
-  #define constexpr /*constexpr*/
+// MSVC 2013 workarounds
+#if _MSC_VER <= 1800
+// constexpr is not understood
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
 
-  // noexcept is not understood
-  #pragma push_macro("noexcept")
-  #define noexcept /*noexcept*/
- #endif // _MSC_VER <= 1800
-#endif // _MSC_VER
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
+#endif           // _MSC_VER <= 1800
+#endif           // _MSC_VER
 
 namespace gsl
 {
@@ -109,47 +109,46 @@ inline constexpr IntegerType to_integer(byte b) noexcept
     return static_cast<IntegerType>(b);
 }
 
-template<bool E, typename T>
+template <bool E, typename T>
 inline constexpr byte to_byte_impl(T t) noexcept
 {
     static_assert(
-        E,
-        "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
-        "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version."
-    );
+        E, "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
+           "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version.");
     return static_cast<byte>(t);
 }
-template<>
+template <>
 inline constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept
 {
-     return byte(t);
+    return byte(t);
 }
 
-template<typename T>
+template <typename T>
 inline constexpr byte to_byte(T t) noexcept
 {
-     return to_byte_impl<std::is_same<T, unsigned char>::value, T>(t);
+    return to_byte_impl<std::is_same<T, unsigned char>::value, T>(t);
 }
 
 template <int I>
 inline constexpr byte to_byte() noexcept
 {
-    static_assert(I >= 0 && I <= 255, "gsl::byte only has 8 bits of storage, values must be in range 0-255");
+    static_assert(I >= 0 && I <= 255,
+                  "gsl::byte only has 8 bits of storage, values must be in range 0-255");
     return static_cast<byte>(I);
 }
 
 } // namespace gsl
 
 #ifdef _MSC_VER
- #if _MSC_VER <= 1800
-  #undef constexpr
-  #pragma pop_macro("constexpr")
+#if _MSC_VER <= 1800
+#undef constexpr
+#pragma pop_macro("constexpr")
 
-  #undef noexcept
-  #pragma pop_macro("noexcept")
- #endif // _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
+#endif // _MSC_VER <= 1800
 
- #pragma warning(pop)
+#pragma warning(pop)
 #endif // _MSC_VER
 
 #endif // GSL_BYTE_H

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -20,28 +20,29 @@
 #define GSL_UTIL_H
 
 #include <gsl/gsl_assert> // Ensures/Expects
+
 #include <array>
 #include <exception>
 #include <type_traits>
 #include <utility>
 
 #if defined(_MSC_VER)
- #pragma warning(push)
- #pragma warning(disable : 4127) // conditional expression is constant
+#pragma warning(push)
+#pragma warning(disable : 4127) // conditional expression is constant
 
- #if _MSC_VER < 1910
-  #pragma push_macro("constexpr")
-  #define constexpr /*constexpr*/
-  // MSVC 2013 workarounds
-  #if _MSC_VER <= 1800
-   // noexcept is not understood
-   #pragma push_macro("noexcept")
-   #define noexcept /*noexcept*/
-   // turn off some misguided warnings
-   #pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
-#endif // _MSC_VER
+#if _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
+// MSVC 2013 workarounds
+#if _MSC_VER <= 1800
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
+// turn off some misguided warnings
+#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
+#endif                          // _MSC_VER <= 1800
+#endif                          // _MSC_VER < 1910
+#endif                          // _MSC_VER
 
 namespace gsl
 {
@@ -154,16 +155,16 @@ inline constexpr T at(const std::initializer_list<T> cont, const std::ptrdiff_t 
 } // namespace gsl
 
 #if defined(_MSC_VER)
- #if _MSC_VER < 1910
-  #undef constexpr
-  #pragma pop_macro("constexpr")
+#if _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
 
-  #if _MSC_VER <= 1800
-   #undef noexcept
-   #pragma pop_macro("noexcept")
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
- #pragma warning(pop)
+#if _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
+#endif // _MSC_VER <= 1800
+#endif // _MSC_VER < 1910
+#pragma warning(pop)
 #endif // _MSC_VER
 
 #endif // GSL_UTIL_H

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -22,6 +22,7 @@
 #include <gsl/gsl_assert>
 #include <gsl/gsl_byte>
 #include <gsl/gsl_util>
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -37,34 +38,34 @@
 #include <utility>
 
 #ifdef _MSC_VER
- // turn off some warnings that are noisy about our Expects statements
- #pragma warning(push)
- #pragma warning(disable : 4127) // conditional expression is constant
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(push)
+#pragma warning(disable : 4127) // conditional expression is constant
 
- #if _MSC_VER < 1910
-  #pragma push_macro("constexpr")
-  #define constexpr /*constexpr*/
+#if _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
 
-  // VS 2013 workarounds
-  #if _MSC_VER <= 1800
-   #define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-   #define GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+// VS 2013 workarounds
+#if _MSC_VER <= 1800
+#define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
+#define GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
 
-   // noexcept is not understood
-   #pragma push_macro("noexcept")
-   #define noexcept /*noexcept*/
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
 
-   // turn off some misguided warnings
-   #pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-   #pragma warning(disable : 4512) // warns that assignment op could not be generated
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
-#endif // _MSC_VER
+// turn off some misguided warnings
+#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
+#pragma warning(disable : 4512) // warns that assignment op could not be generated
+#endif                          // _MSC_VER <= 1800
+#endif                          // _MSC_VER < 1910
+#endif                          // _MSC_VER
 
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
- #define GSL_NOEXCEPT /*noexcept*/
+#define GSL_NOEXCEPT /*noexcept*/
 #else
- #define GSL_NOEXCEPT noexcept
+#define GSL_NOEXCEPT noexcept
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
 namespace gsl
@@ -207,7 +208,10 @@ public:
         return ret;
     }
 
-    friend constexpr index operator*(value_type v, const index& rhs) GSL_NOEXCEPT { return rhs * v; }
+    friend constexpr index operator*(value_type v, const index& rhs) GSL_NOEXCEPT
+    {
+        return rhs * v;
+    }
 
     constexpr index& operator*=(value_type v) GSL_NOEXCEPT
     {
@@ -344,10 +348,11 @@ namespace details
         static const std::size_t DynamicNum = Base::DynamicNum + 1;
         static const size_type CurrentRange = dynamic_range;
         static const size_type TotalSize = dynamic_range;
+
     private:
         size_type m_bound;
-    public:
 
+    public:
         BoundsRanges(const std::ptrdiff_t* const arr)
             : Base(arr + 1), m_bound(*arr * this->Base::totalSize())
         {
@@ -492,7 +497,8 @@ namespace details
             return obj_;
         }
 
-        template <std::size_t N, typename MyChain = TypeChain, typename MyBase = typename MyChain::Base>
+        template <std::size_t N, typename MyChain = TypeChain,
+                  typename MyBase = typename MyChain::Base>
         auto getObj(std::false_type)
             -> decltype(TypeListIndexer<MyBase>(static_cast<const MyBase&>(obj_)).template get<N>())
         {
@@ -690,7 +696,10 @@ public:
         return !(*this == rhs);
     }
 
-    constexpr const_iterator begin() const GSL_NOEXCEPT { return const_iterator(*this, index_type{}); }
+    constexpr const_iterator begin() const GSL_NOEXCEPT
+    {
+        return const_iterator(*this, index_type{});
+    }
 
     constexpr const_iterator end() const GSL_NOEXCEPT
     {
@@ -790,9 +799,15 @@ public:
     }
 
     constexpr index_type index_bounds() const GSL_NOEXCEPT { return m_extents; }
-    constexpr const_iterator begin() const GSL_NOEXCEPT { return const_iterator{*this, index_type{}}; }
+    constexpr const_iterator begin() const GSL_NOEXCEPT
+    {
+        return const_iterator{*this, index_type{}};
+    }
 
-    constexpr const_iterator end() const GSL_NOEXCEPT { return const_iterator{*this, index_bounds()}; }
+    constexpr const_iterator end() const GSL_NOEXCEPT
+    {
+        return const_iterator{*this, index_bounds()};
+    }
 
 private:
     index_type m_extents;
@@ -931,18 +946,27 @@ public:
         return curr_ == rhs.curr_;
     }
 
-    constexpr bool operator!=(const bounds_iterator& rhs) const GSL_NOEXCEPT { return !(*this == rhs); }
+    constexpr bool operator!=(const bounds_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(*this == rhs);
+    }
 
     constexpr bool operator<(const bounds_iterator& rhs) const GSL_NOEXCEPT
     {
         return less(curr_, rhs.curr_);
     }
 
-    constexpr bool operator<=(const bounds_iterator& rhs) const GSL_NOEXCEPT { return !(rhs < *this); }
+    constexpr bool operator<=(const bounds_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(rhs < *this);
+    }
 
     constexpr bool operator>(const bounds_iterator& rhs) const GSL_NOEXCEPT { return rhs < *this; }
 
-    constexpr bool operator>=(const bounds_iterator& rhs) const GSL_NOEXCEPT { return !(rhs > *this); }
+    constexpr bool operator>=(const bounds_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(rhs > *this);
+    }
 
     void swap(bounds_iterator& rhs) GSL_NOEXCEPT
     {
@@ -1136,7 +1160,7 @@ namespace details
     template <typename T, typename Arg, typename... Args>
     std::enable_if_t<
         !std::is_same<Arg, dim_t<dynamic_range>>::value && !std::is_same<Arg, Sep>::value, T>
-        static_as_multi_span_helper(Arg, Args... args)
+    static_as_multi_span_helper(Arg, Args... args)
     {
         return static_as_multi_span_helper<T>(args...);
     }
@@ -1227,7 +1251,8 @@ public:
 
     // construct from nullptr with size of 0 (helps with template function calls)
     template <class IntType, typename = std::enable_if_t<std::is_integral<IntType>::value>>
-    constexpr multi_span(std::nullptr_t, IntType size) GSL_NOEXCEPT : multi_span(nullptr, bounds_type{})
+    constexpr multi_span(std::nullptr_t, IntType size) GSL_NOEXCEPT
+        : multi_span(nullptr, bounds_type{})
     {
         static_assert(bounds_type::dynamic_rank != 0 ||
                           (bounds_type::dynamic_rank == 0 && bounds_type::static_size == 0),
@@ -1249,13 +1274,14 @@ public:
     constexpr multi_span(value_type&&) = delete;
 
     // construct from pointer + length
-    constexpr multi_span(pointer ptr, size_type size) GSL_NOEXCEPT : multi_span(ptr, bounds_type{size})
+    constexpr multi_span(pointer ptr, size_type size) GSL_NOEXCEPT
+        : multi_span(ptr, bounds_type{size})
     {
     }
 
     // construct from pointer + length - multidimensional
     constexpr multi_span(pointer data, bounds_type bounds) GSL_NOEXCEPT : data_(data),
-                                                                      bounds_(std::move(bounds))
+                                                                          bounds_(std::move(bounds))
     {
         Expects((bounds_.size() > 0 && data != nullptr) || bounds_.size() == 0);
     }
@@ -1426,9 +1452,8 @@ public:
 
     // subspan() - create a subview of count elements starting at offset
     // supplying dynamic_range for count will consume all available elements from offset
-    constexpr multi_span<ValueType, dynamic_range> subspan(size_type offset,
-                                                           size_type count = dynamic_range) const
-        GSL_NOEXCEPT
+    constexpr multi_span<ValueType, dynamic_range>
+    subspan(size_type offset, size_type count = dynamic_range) const GSL_NOEXCEPT
     {
         Expects((offset >= 0 && offset <= this->size()) &&
                 (count == dynamic_range || (count <= this->size() - offset)));
@@ -1436,8 +1461,8 @@ public:
     }
 
     // section - creates a non-contiguous, strided multi_span from a contiguous one
-    constexpr strided_span<ValueType, Rank> section(index_type origin, index_type extents) const
-        GSL_NOEXCEPT
+    constexpr strided_span<ValueType, Rank> section(index_type origin,
+                                                    index_type extents) const GSL_NOEXCEPT
     {
         size_type size = this->bounds().total_size() - this->bounds().linearize(origin);
         return {&this->operator[](origin), size,
@@ -1451,7 +1476,10 @@ public:
     constexpr size_type length() const GSL_NOEXCEPT { return this->size(); }
 
     // length of the multi_span in bytes
-    constexpr size_type size_bytes() const GSL_NOEXCEPT { return narrow_cast<size_type>(sizeof(value_type)) * this->size(); }
+    constexpr size_type size_bytes() const GSL_NOEXCEPT
+    {
+        return narrow_cast<size_type>(sizeof(value_type)) * this->size();
+    }
 
     // length of the multi_span in bytes
     constexpr size_type length_bytes() const GSL_NOEXCEPT { return this->size_bytes(); }
@@ -1539,8 +1567,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator==(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator==(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return bounds_.size() == other.bounds_.size() &&
                (data_ == other.data_ || std::equal(this->begin(), this->end(), other.begin()));
@@ -1549,8 +1577,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator!=(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator!=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return !(*this == other);
     }
@@ -1558,8 +1586,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator<(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return std::lexicographical_compare(this->begin(), this->end(), other.begin(), other.end());
     }
@@ -1567,8 +1595,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<=(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator<=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return !(other < *this);
     }
@@ -1576,8 +1604,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator>(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return (other < *this);
     }
@@ -1585,8 +1613,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>=(const multi_span<OtherValueType, OtherDimensions...>& other) const
-        GSL_NOEXCEPT
+    constexpr bool
+    operator>=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
     {
         return !(*this < other);
     }
@@ -1638,7 +1666,8 @@ multi_span<byte> as_writeable_bytes(multi_span<U, Dimensions...> s) GSL_NOEXCEPT
 // on all implementations. It should be considered an experimental extension
 // to the standard GSL interface.
 template <typename U, std::ptrdiff_t... Dimensions>
-inline constexpr auto as_multi_span(multi_span<const byte, Dimensions...> s) GSL_NOEXCEPT -> multi_span<
+inline constexpr auto
+as_multi_span(multi_span<const byte, Dimensions...> s) GSL_NOEXCEPT -> multi_span<
     const U, static_cast<std::ptrdiff_t>(
                  multi_span<const byte, Dimensions...>::bounds_type::static_size != dynamic_range
                      ? (static_cast<std::size_t>(
@@ -1830,8 +1859,9 @@ public:
 
         size_type size = this->bounds().total_size() / d;
         return {const_cast<OtherValueType*>(reinterpret_cast<const OtherValueType*>(this->data())),
-                size, bounds_type{resize_extent(this->bounds().index_bounds(), d),
-                                  resize_stride(this->bounds().strides(), d)}};
+                size,
+                bounds_type{resize_extent(this->bounds().index_bounds(), d),
+                            resize_stride(this->bounds().strides(), d)}};
     }
 
     constexpr strided_span section(index_type origin, index_type extents) const
@@ -1898,7 +1928,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator==(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator==(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return bounds_.size() == other.bounds_.size() &&
                (data_ == other.data_ || std::equal(this->begin(), this->end(), other.begin()));
@@ -1907,7 +1938,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator!=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator!=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return !(*this == other);
     }
@@ -1915,7 +1947,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator<(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return std::lexicographical_compare(this->begin(), this->end(), other.begin(), other.end());
     }
@@ -1923,7 +1956,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator<=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator<=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return !(other < *this);
     }
@@ -1931,7 +1965,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator>(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return (other < *this);
     }
@@ -1939,7 +1974,8 @@ public:
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
               typename Dummy = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
-    constexpr bool operator>=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
+    constexpr bool
+    operator>=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
     {
         return !(*this < other);
     }
@@ -2074,15 +2110,24 @@ public:
         Expects(m_validator == rhs.m_validator);
         return data_ == rhs.data_;
     }
-    bool operator!=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT { return !(*this == rhs); }
+    bool operator!=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(*this == rhs);
+    }
     bool operator<(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT
     {
         Expects(m_validator == rhs.m_validator);
         return data_ < rhs.data_;
     }
-    bool operator<=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT { return !(rhs < *this); }
+    bool operator<=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(rhs < *this);
+    }
     bool operator>(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT { return rhs < *this; }
-    bool operator>=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT { return !(rhs > *this); }
+    bool operator>=(const contiguous_span_iterator& rhs) const GSL_NOEXCEPT
+    {
+        return !(rhs > *this);
+    }
     void swap(contiguous_span_iterator& rhs) GSL_NOEXCEPT
     {
         std::swap(data_, rhs.data_);
@@ -2202,20 +2247,20 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 #undef GSL_NOEXCEPT
 
 #ifdef _MSC_VER
- #if _MSC_VER < 1910
-  #if _MSC_VER <= 1800
-   #undef noexcept
-   #pragma pop_macro("noexcept")
+#if _MSC_VER < 1910
+#if _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
 
-   #undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-   #undef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-  #endif // _MSC_VER <= 1800
+#undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
+#undef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
+#endif // _MSC_VER <= 1800
 
-  #undef constexpr
-  #pragma pop_macro("constexpr")
- #endif // _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
+#endif // _MSC_VER < 1910
 
- #pragma warning(pop)
+#pragma warning(pop)
 #endif // _MSC_VER
 
 #endif // GSL_MULTI_SPAN_H

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -23,53 +23,54 @@
 #include <gsl/gsl_assert>
 #include <gsl/gsl_byte>
 #include <gsl/gsl_util>
+
 #include <array>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
-#include <memory>
 
 #ifdef _MSC_VER
- #pragma warning(push)
+#pragma warning(push)
 
- // turn off some warnings that are noisy about our Expects statements
- #pragma warning(disable : 4127) // conditional expression is constant
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(disable : 4127) // conditional expression is constant
 
- // blanket turn off warnings from CppCoreCheck for now
- // so people aren't annoyed by them when running the tool.
- // more targeted suppressions will be added in a future update to the GSL
- #pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
 
- #if _MSC_VER < 1910
-  #pragma push_macro("constexpr")
-  #define constexpr /*constexpr*/
+#if _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
 
-  // VS 2013 workarounds
-  #if _MSC_VER <= 1800
-   #define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-   #define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-   #define GSL_MSVC_NO_CPP14_STD_EQUAL
+// VS 2013 workarounds
+#if _MSC_VER <= 1800
+#define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
+#define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
+#define GSL_MSVC_NO_CPP14_STD_EQUAL
 
-   // noexcept is not understood
-   #pragma push_macro("noexcept")
-   #define noexcept /*noexcept*/
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
 
-   #pragma push_macro("alignof")
-   #define alignof __alignof
+#pragma push_macro("alignof")
+#define alignof __alignof
 
-   // turn off some misguided warnings
-   #pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-   #pragma warning(disable : 4512) // warns that assignment op could not be generated
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
-#endif // _MSC_VER
+// turn off some misguided warnings
+#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
+#pragma warning(disable : 4512) // warns that assignment op could not be generated
+#endif                          // _MSC_VER <= 1800
+#endif                          // _MSC_VER < 1910
+#endif                          // _MSC_VER
 
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
- #define GSL_NOEXCEPT /*noexcept*/
+#define GSL_NOEXCEPT /*noexcept*/
 #else
- #define GSL_NOEXCEPT noexcept
+#define GSL_NOEXCEPT noexcept
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
 namespace gsl
@@ -131,13 +132,13 @@ namespace details
     class span_iterator
     {
         using element_type_ = typename Span::element_type;
+
     public:
         using iterator_category = std::random_access_iterator_tag;
         using value_type = std::remove_cv_t<element_type_>;
         using difference_type = typename Span::index_type;
 
-        using reference =
-            std::conditional_t<IsConst, const element_type_, element_type_> &;
+        using reference = std::conditional_t<IsConst, const element_type_, element_type_>&;
         using pointer = std::add_pointer_t<reference>;
 
         constexpr span_iterator() GSL_NOEXCEPT : span_iterator(nullptr, 0) {}
@@ -154,7 +155,8 @@ namespace details
         {
         }
 
-        constexpr span_iterator<Span, IsConst>& operator=(const span_iterator<Span, IsConst>&) GSL_NOEXCEPT = default;
+        constexpr span_iterator<Span, IsConst>&
+        operator=(const span_iterator<Span, IsConst>&) GSL_NOEXCEPT = default;
 
         constexpr reference operator*() const
         {
@@ -223,7 +225,10 @@ namespace details
             return index_ - rhs.index_;
         }
 
-        constexpr reference operator[](difference_type n) const GSL_NOEXCEPT { return *(*this + n); }
+        constexpr reference operator[](difference_type n) const GSL_NOEXCEPT
+        {
+            return *(*this + n);
+        }
 
         constexpr friend bool operator==(const span_iterator& lhs,
                                          const span_iterator& rhs) GSL_NOEXCEPT
@@ -249,7 +254,8 @@ namespace details
             return !(rhs < lhs);
         }
 
-        constexpr friend bool operator>(const span_iterator& lhs, const span_iterator& rhs) GSL_NOEXCEPT
+        constexpr friend bool operator>(const span_iterator& lhs,
+                                        const span_iterator& rhs) GSL_NOEXCEPT
         {
             return rhs < lhs;
         }
@@ -337,7 +343,7 @@ class span
 public:
     // constants and types
     using element_type = ElementType;
-    using value_type = std::remove_cv_t<ElementType>;    
+    using value_type = std::remove_cv_t<ElementType>;
     using index_type = std::ptrdiff_t;
     using pointer = element_type*;
     using reference = element_type&;
@@ -353,10 +359,12 @@ public:
 
     // [span.cons], span constructors, copy, assignment, and destructor
     template <bool Dependent = false,
-        // "Dependent" is needed to make "std::enable_if_t<Dependent || Extent <= 0>" SFINAE,
-        // since "std::enable_if_t<Extent <= 0>" is ill-formed when Extent is greater than 0.
-        class = std::enable_if_t<(Dependent || Extent <= 0)>>
-    constexpr span() GSL_NOEXCEPT : storage_(nullptr, details::extent_type<0>()) {}
+              // "Dependent" is needed to make "std::enable_if_t<Dependent || Extent <= 0>" SFINAE,
+              // since "std::enable_if_t<Extent <= 0>" is ill-formed when Extent is greater than 0.
+              class = std::enable_if_t<(Dependent || Extent <= 0)>>
+    constexpr span() GSL_NOEXCEPT : storage_(nullptr, details::extent_type<0>())
+    {
+    }
 
     constexpr span(std::nullptr_t) GSL_NOEXCEPT : span() {}
 
@@ -368,7 +376,8 @@ public:
     }
 
     template <std::size_t N>
-    constexpr span(element_type (&arr)[N]) GSL_NOEXCEPT : storage_(&arr[0], details::extent_type<N>())
+    constexpr span(element_type (&arr)[N]) GSL_NOEXCEPT
+        : storage_(&arr[0], details::extent_type<N>())
     {
     }
 
@@ -384,11 +393,18 @@ public:
     {
     }
 
-    template<class ArrayElementType = std::add_pointer<element_type>>
-    constexpr span(const std::unique_ptr<ArrayElementType>& ptr, index_type count) : storage_(ptr.get(), count) {}
+    template <class ArrayElementType = std::add_pointer<element_type>>
+    constexpr span(const std::unique_ptr<ArrayElementType>& ptr, index_type count)
+        : storage_(ptr.get(), count)
+    {
+    }
 
-    constexpr span(const std::unique_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0) {}
-    constexpr span(const std::shared_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0) {}
+    constexpr span(const std::unique_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0)
+    {
+    }
+    constexpr span(const std::shared_ptr<ElementType>& ptr) : storage_(ptr.get(), ptr.get() ? 1 : 0)
+    {
+    }
 
     // NB: the SFINAE here uses .data() as a incomplete/imperfect proxy for the requirement
     // on Container to be a contiguous sequence container.
@@ -498,7 +514,10 @@ public:
     constexpr index_type length() const GSL_NOEXCEPT { return size(); }
     constexpr index_type size() const GSL_NOEXCEPT { return storage_.size(); }
     constexpr index_type length_bytes() const GSL_NOEXCEPT { return size_bytes(); }
-    constexpr index_type size_bytes() const GSL_NOEXCEPT { return size() * narrow_cast<index_type>(sizeof(element_type)); }
+    constexpr index_type size_bytes() const GSL_NOEXCEPT
+    {
+        return size() * narrow_cast<index_type>(sizeof(element_type));
+    }
     constexpr bool empty() const GSL_NOEXCEPT { return size() == 0; }
 
     // [span.elem], span element access
@@ -551,7 +570,7 @@ private:
 // [span.comparison], span comparison operators
 template <class ElementType, std::ptrdiff_t FirstExtent, std::ptrdiff_t SecondExtent>
 inline constexpr bool operator==(const span<ElementType, FirstExtent>& l,
-                          const span<ElementType, SecondExtent>& r)
+                                 const span<ElementType, SecondExtent>& r)
 {
 #ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
     return (l.size() == r.size()) && std::equal(l.begin(), l.end(), r.begin());
@@ -561,31 +580,36 @@ inline constexpr bool operator==(const span<ElementType, FirstExtent>& l,
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
-inline constexpr bool operator!=(const span<ElementType, Extent>& l, const span<ElementType, Extent>& r)
+inline constexpr bool operator!=(const span<ElementType, Extent>& l,
+                                 const span<ElementType, Extent>& r)
 {
     return !(l == r);
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
-inline constexpr bool operator<(const span<ElementType, Extent>& l, const span<ElementType, Extent>& r)
+inline constexpr bool operator<(const span<ElementType, Extent>& l,
+                                const span<ElementType, Extent>& r)
 {
     return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
-inline constexpr bool operator<=(const span<ElementType, Extent>& l, const span<ElementType, Extent>& r)
+inline constexpr bool operator<=(const span<ElementType, Extent>& l,
+                                 const span<ElementType, Extent>& r)
 {
     return !(l > r);
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
-inline constexpr bool operator>(const span<ElementType, Extent>& l, const span<ElementType, Extent>& r)
+inline constexpr bool operator>(const span<ElementType, Extent>& l,
+                                const span<ElementType, Extent>& r)
 {
     return r < l;
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
-inline constexpr bool operator>=(const span<ElementType, Extent>& l, const span<ElementType, Extent>& r)
+inline constexpr bool operator>=(const span<ElementType, Extent>& l,
+                                 const span<ElementType, Extent>& r)
 {
     return !(l < r);
 }
@@ -633,40 +657,46 @@ as_writeable_bytes(span<ElementType, Extent> s) GSL_NOEXCEPT
 // make_span() - Utility functions for creating spans
 //
 template <class ElementType>
-span<ElementType>
-make_span(ElementType* ptr, typename span<ElementType>::index_type count)
-{ return span<ElementType>(ptr, count); }
+span<ElementType> make_span(ElementType* ptr, typename span<ElementType>::index_type count)
+{
+    return span<ElementType>(ptr, count);
+}
 
 template <class ElementType>
-span<ElementType>
-make_span(ElementType* firstElem, ElementType* lastElem)
-{ return span<ElementType>(firstElem, lastElem); }
+span<ElementType> make_span(ElementType* firstElem, ElementType* lastElem)
+{
+    return span<ElementType>(firstElem, lastElem);
+}
 
 template <class ElementType, std::size_t N>
-span<ElementType>
-make_span(ElementType (&arr)[N])
-{ return span<ElementType>(arr); }
+span<ElementType> make_span(ElementType (&arr)[N])
+{
+    return span<ElementType>(arr);
+}
 
 template <class Container>
-span<typename Container::value_type>
-make_span(Container &cont)
-{ return span<typename Container::value_type>(cont); }
+span<typename Container::value_type> make_span(Container& cont)
+{
+    return span<typename Container::value_type>(cont);
+}
 
 template <class Container>
-span<const typename Container::value_type>
-make_span(const Container &cont)
-{ return span<const typename Container::value_type>(cont); }
+span<const typename Container::value_type> make_span(const Container& cont)
+{
+    return span<const typename Container::value_type>(cont);
+}
 
 template <class Ptr>
-span<typename Ptr::element_type>
-make_span(Ptr& cont, std::ptrdiff_t count)
-{ return span<typename Ptr::element_type>(cont, count); }
+span<typename Ptr::element_type> make_span(Ptr& cont, std::ptrdiff_t count)
+{
+    return span<typename Ptr::element_type>(cont, count);
+}
 
 template <class Ptr>
-span<typename Ptr::element_type>
-make_span(Ptr& cont)
-{ return span<typename Ptr::element_type>(cont); }
-
+span<typename Ptr::element_type> make_span(Ptr& cont)
+{
+    return span<typename Ptr::element_type>(cont);
+}
 
 // Specialization of gsl::at for span
 template <class ElementType, std::ptrdiff_t Extent>
@@ -681,24 +711,24 @@ inline constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdif
 #undef GSL_NOEXCEPT
 
 #ifdef _MSC_VER
- #if _MSC_VER < 1910
-  #undef constexpr
-  #pragma pop_macro("constexpr")
+#if _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
 
-  #if _MSC_VER <= 1800
-   #undef noexcept
-   #pragma pop_macro("noexcept")
+#if _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
 
-   #undef alignof
-   #pragma pop_macro("alignof")
+#undef alignof
+#pragma pop_macro("alignof")
 
-   #undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-   #undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-   #undef GSL_MSVC_NO_CPP14_STD_EQUAL
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
+#undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
+#undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
+#undef GSL_MSVC_NO_CPP14_STD_EQUAL
+#endif // _MSC_VER <= 1800
+#endif // _MSC_VER < 1910
 
- #pragma warning(pop)
+#pragma warning(pop)
 #endif // _MSC_VER
 
 #endif // GSL_SPAN_H

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -22,41 +22,42 @@
 #include <gsl/gsl_assert>
 #include <gsl/gsl_util>
 #include <gsl/span>
+
 #include <cstdint>
 #include <cstring>
 #include <string>
 
 #ifdef _MSC_VER
- #pragma warning(push)
+#pragma warning(push)
 
- // blanket turn off warnings from CppCoreCheck for now
- // so people aren't annoyed by them when running the tool.
- // more targeted suppressions will be added in a future update to the GSL
- #pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
 
- #if _MSC_VER < 1910
-  #pragma push_macro("constexpr")
-  #define constexpr /*constexpr*/
+#if _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
 
-  // VS 2013 workarounds
-  #if _MSC_VER <= 1800
-   #define GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
-   #define GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
-   #define GSL_MSVC_NO_CPP14_STD_EQUAL
-   #define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
+// VS 2013 workarounds
+#if _MSC_VER <= 1800
+#define GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
+#define GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
+#define GSL_MSVC_NO_CPP14_STD_EQUAL
+#define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
 
-   // noexcept is not understood
-   #pragma push_macro("noexcept")
-   #define noexcept /*noexcept*/
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
-#endif // _MSC_VER
+// noexcept is not understood
+#pragma push_macro("noexcept")
+#define noexcept /*noexcept*/
+#endif           // _MSC_VER <= 1800
+#endif           // _MSC_VER < 1910
+#endif           // _MSC_VER
 
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
- #define GSL_NOEXCEPT /*noexcept*/
+#define GSL_NOEXCEPT /*noexcept*/
 #else
- #define GSL_NOEXCEPT noexcept
+#define GSL_NOEXCEPT noexcept
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
 namespace gsl
@@ -89,30 +90,26 @@ using wzstring = basic_zstring<wchar_t, Extent>;
 
 namespace details
 {
-    inline std::ptrdiff_t string_length(const char *str, std::ptrdiff_t n)
+    inline std::ptrdiff_t string_length(const char* str, std::ptrdiff_t n)
     {
-        if (str == nullptr || n <= 0)
-            return 0;
+        if (str == nullptr || n <= 0) return 0;
 
         span<const char> str_span{str, n};
 
         std::ptrdiff_t len = 0;
-        while (len < n && str_span[len])
-            len++;
+        while (len < n && str_span[len]) len++;
 
         return len;
     }
 
-    inline std::ptrdiff_t wstring_length(const wchar_t *str, std::ptrdiff_t n)
+    inline std::ptrdiff_t wstring_length(const wchar_t* str, std::ptrdiff_t n)
     {
-        if (str == nullptr || n <= 0)
-            return 0;
+        if (str == nullptr || n <= 0) return 0;
 
         span<const wchar_t> str_span{str, n};
 
         std::ptrdiff_t len = 0;
-        while (len < n && str_span[len])
-            len++;
+        while (len < n && str_span[len]) len++;
 
         return len;
     }
@@ -316,7 +313,8 @@ public:
     }
 
     template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
-    constexpr basic_string_span(const std::array<ArrayElementType, N>& arr) GSL_NOEXCEPT : span_(arr)
+    constexpr basic_string_span(const std::array<ArrayElementType, N>& arr) GSL_NOEXCEPT
+        : span_(arr)
     {
     }
 
@@ -484,14 +482,11 @@ inline std::wstring to_string(wstring_span<> view)
 
 #endif
 
-template <typename CharT,
-	  typename Traits = typename std::char_traits<CharT>,
-	  typename Allocator = std::allocator<CharT>,
-	  typename gCharT,
-	  std::ptrdiff_t Extent>
+template <typename CharT, typename Traits = typename std::char_traits<CharT>,
+          typename Allocator = std::allocator<CharT>, typename gCharT, std::ptrdiff_t Extent>
 std::basic_string<CharT, Traits, Allocator> to_basic_string(basic_string_span<gCharT, Extent> view)
 {
-  return {view.data(), static_cast<std::size_t>(view.length())};
+    return {view.data(), static_cast<std::size_t>(view.length())};
 }
 
 // zero-terminated string span, used to convert
@@ -830,23 +825,23 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 #undef GSL_NOEXCEPT
 
 #ifdef _MSC_VER
- #pragma warning(pop)
+#pragma warning(pop)
 
- #if _MSC_VER < 1910
-  #undef constexpr
-  #pragma pop_macro("constexpr")
+#if _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
 
-  // VS 2013 workarounds
-  #if _MSC_VER <= 1800
-   #undef noexcept
-   #pragma pop_macro("noexcept")
+// VS 2013 workarounds
+#if _MSC_VER <= 1800
+#undef noexcept
+#pragma pop_macro("noexcept")
 
-   #undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
-   #undef GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
-   #undef GSL_MSVC_NO_CPP14_STD_EQUAL
-   #undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-  #endif // _MSC_VER <= 1800
- #endif // _MSC_VER < 1910
+#undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
+#undef GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
+#undef GSL_MSVC_NO_CPP14_STD_EQUAL
+#undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
+#endif // _MSC_VER <= 1800
+#endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
 #endif // GSL_STRING_SPAN_H

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -15,6 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl_algorithm>
 
 #include <array>
@@ -179,8 +180,8 @@ SUITE(copy_tests)
         span<int*, 4> dst_span_static(dst);
 
         // every line should produce a compilation error
-        copy(src_span_dyn,    dst_span_dyn);
-        copy(src_span_dyn,    dst_span_static);
+        copy(src_span_dyn, dst_span_dyn);
+        copy(src_span_dyn, dst_span_static);
         copy(src_span_static, dst_span_dyn);
         copy(src_span_static, dst_span_static);
     }
@@ -196,9 +197,9 @@ SUITE(copy_tests)
         span<int> dst_span_dyn(dst);
         span<int, 4> dst_span_static(dst);
 
-        CHECK_THROW(copy(src_span_dyn,    dst_span_dyn),    fail_fast);
-        CHECK_THROW(copy(src_span_dyn,    dst_span_static), fail_fast);
-        CHECK_THROW(copy(src_span_static, dst_span_dyn),    fail_fast);
+        CHECK_THROW(copy(src_span_dyn, dst_span_dyn), fail_fast);
+        CHECK_THROW(copy(src_span_dyn, dst_span_static), fail_fast);
+        CHECK_THROW(copy(src_span_static, dst_span_dyn), fail_fast);
 
 #ifdef CONFIRM_COMPILATION_ERRORS
         copy(src_span_static, dst_span_static);

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -1,20 +1,21 @@
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <UnitTest++/UnitTest++.h> 
+#include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl>
 
 using namespace gsl;
@@ -34,7 +35,7 @@ SUITE(assertion_tests)
     }
 
     int g(int i)
-    {        
+    {
         i++;
         Ensures(i > 0 && i < 10);
         return i;
@@ -47,7 +48,4 @@ SUITE(assertion_tests)
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -15,9 +15,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl>
-#include <vector>
+
 #include <initializer_list>
+#include <vector>
 
 using gsl::fail_fast;
 
@@ -25,8 +27,8 @@ SUITE(at_tests)
 {
     TEST(static_array)
     {
-        int a[4] = { 1, 2, 3, 4 };
-        const int (&c_a)[4] = a;
+        int a[4] = {1, 2, 3, 4};
+        const int(&c_a)[4] = a;
 
         for (int i = 0; i < 4; ++i) {
             CHECK(&gsl::at(a, i) == &a[i]);
@@ -41,7 +43,7 @@ SUITE(at_tests)
 
     TEST(std_array)
     {
-        std::array<int, 4> a = { 1, 2, 3, 4 };
+        std::array<int, 4> a = {1, 2, 3, 4};
         const std::array<int, 4>& c_a = a;
 
         for (int i = 0; i < 4; ++i) {
@@ -57,7 +59,7 @@ SUITE(at_tests)
 
     TEST(StdVector)
     {
-        std::vector<int> a = { 1, 2, 3, 4 };
+        std::vector<int> a = {1, 2, 3, 4};
         const std::vector<int>& c_a = a;
 
         for (int i = 0; i < 4; ++i) {
@@ -73,26 +75,26 @@ SUITE(at_tests)
 
     TEST(InitializerList)
     {
-        std::initializer_list<int> a = { 1, 2, 3, 4 };
+        std::initializer_list<int> a = {1, 2, 3, 4};
 
         for (int i = 0; i < 4; ++i) {
-            CHECK(gsl::at(a, i) == i+1);
-            CHECK(gsl::at({1,2,3,4}, i) == i+1);
+            CHECK(gsl::at(a, i) == i + 1);
+            CHECK(gsl::at({1, 2, 3, 4}, i) == i + 1);
         }
 
         CHECK_THROW(gsl::at(a, -1), fail_fast);
         CHECK_THROW(gsl::at(a, 4), fail_fast);
-        CHECK_THROW(gsl::at({1,2,3,4}, -1), fail_fast);
-        CHECK_THROW(gsl::at({1,2,3,4}, 4), fail_fast);
+        CHECK_THROW(gsl::at({1, 2, 3, 4}, -1), fail_fast);
+        CHECK_THROW(gsl::at({1, 2, 3, 4}, 4), fail_fast);
     }
 }
 
 #if !defined(_MSC_VER) || defined(__clang__) || _MSC_VER >= 1910
 static constexpr bool test_constexpr()
 {
-    int a1[4] = { 1, 2, 3, 4 };
-    const int (&c_a1)[4] = a1;
-    std::array<int,4> a2 = { 1, 2, 3, 4 };
+    int a1[4] = {1, 2, 3, 4};
+    const int(&c_a1)[4] = a1;
+    std::array<int, 4> a2 = {1, 2, 3, 4};
     const std::array<int, 4>& c_a2 = a2;
 
     for (int i = 0; i < 4; ++i) {
@@ -101,7 +103,7 @@ static constexpr bool test_constexpr()
         // requires C++17:
         // if (&gsl::at(a2, i) != &a2[static_cast<std::size_t>(i)]) return false;
         if (&gsl::at(c_a2, i) != &c_a2[static_cast<std::size_t>(i)]) return false;
-        if (gsl::at({1,2,3,4}, i) != i+1) return false;
+        if (gsl::at({1, 2, 3, 4}, i) != i + 1) return false;
     }
 
     return true;
@@ -110,7 +112,4 @@ static constexpr bool test_constexpr()
 static_assert(test_constexpr(), "FAIL");
 #endif
 
-int main()
-{
-    return UnitTest::RunAllTests();
-}
+int main() { return UnitTest::RunAllTests(); }

--- a/tests/bounds_tests.cpp
+++ b/tests/bounds_tests.cpp
@@ -15,7 +15,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/multi_span>
+
 #include <vector>
 
 using namespace std;
@@ -23,81 +25,76 @@ using namespace gsl;
 
 namespace
 {
-    void use(std::ptrdiff_t&) {}
+void use(std::ptrdiff_t&) {}
 }
 
 SUITE(bounds_test)
 {
-	TEST(basic_bounds)
-	{
-		for (auto point : static_bounds<dynamic_range, 3, 4 > { 2 })
-		{
-			for (decltype(point)::size_type j = 0;
-			     j < static_cast<decltype(point)::size_type>(decltype(point)::rank);
-			     j++)
-			{
-				use(j);
-				use(point[static_cast<std::size_t>(j)]);
-			}
-		}
-	}
+    TEST(basic_bounds)
+    {
+        for (auto point : static_bounds<dynamic_range, 3, 4>{2}) {
+            for (decltype(point)::size_type j = 0;
+                 j < static_cast<decltype(point)::size_type>(decltype(point)::rank); j++)
+            {
+                use(j);
+                use(point[static_cast<std::size_t>(j)]);
+            }
+        }
+    }
 
-	TEST(bounds_basic)
-	{
-		static_bounds<3, 4, 5> b;
-		const auto a = b.slice();
-		(void)a;
-		static_bounds<4, dynamic_range, 2> x{ 4 };
-		x.slice().slice();
-	}
+    TEST(bounds_basic)
+    {
+        static_bounds<3, 4, 5> b;
+        const auto a = b.slice();
+        (void) a;
+        static_bounds<4, dynamic_range, 2> x{4};
+        x.slice().slice();
+    }
 
-	TEST (arrayview_iterator)
-	{
-		static_bounds<4, dynamic_range, 2> bounds{ 3 };
+    TEST(arrayview_iterator)
+    {
+        static_bounds<4, dynamic_range, 2> bounds{3};
 
-		const auto itr = bounds.begin();
-		(void)itr;
+        const auto itr = bounds.begin();
+        (void) itr;
 #ifdef CONFIRM_COMPILATION_ERRORS
-		multi_span<int, 4, dynamic_range, 2> av(nullptr, bounds);
+        multi_span<int, 4, dynamic_range, 2> av(nullptr, bounds);
 
-		auto itr2 = av.cbegin();
+        auto itr2 = av.cbegin();
 
-		for (auto& v : av) {
-			v = 4;
-		}
-		fill(av.begin(), av.end(), 0);
+        for (auto& v : av) {
+            v = 4;
+        }
+        fill(av.begin(), av.end(), 0);
 #endif
-	}
+    }
 
-	TEST (bounds_convertible)
-	{
-		static_bounds<7, 4, 2> b1;
-		static_bounds<7, dynamic_range, 2> b2 = b1;
-		(void)b2;
+    TEST(bounds_convertible)
+    {
+        static_bounds<7, 4, 2> b1;
+        static_bounds<7, dynamic_range, 2> b2 = b1;
+        (void) b2;
 #ifdef CONFIRM_COMPILATION_ERRORS
-		static_bounds<7, dynamic_range, 1> b4 = b2;
+        static_bounds<7, dynamic_range, 1> b4 = b2;
 #endif
 
-		static_bounds<dynamic_range, dynamic_range, dynamic_range> b3 = b1;
-		static_bounds<7, 4, 2> b4 = b3;
-		(void)b4;
+        static_bounds<dynamic_range, dynamic_range, dynamic_range> b3 = b1;
+        static_bounds<7, 4, 2> b4 = b3;
+        (void) b4;
 
-		static_bounds<dynamic_range> b11;
+        static_bounds<dynamic_range> b11;
 
-		static_bounds<dynamic_range> b5;
-		static_bounds<34> b6;
+        static_bounds<dynamic_range> b5;
+        static_bounds<34> b6;
 
-		b5 = static_bounds<20>();
-		CHECK_THROW(b6 = b5, fail_fast);
-		b5 = static_bounds<34>();
-		b6 = b5;
+        b5 = static_bounds<20>();
+        CHECK_THROW(b6 = b5, fail_fast);
+        b5 = static_bounds<34>();
+        b6 = b5;
 
-		CHECK(b5 == b6);
-		CHECK(b5.size() == b6.size());
-	}
+        CHECK(b5 == b6);
+        CHECK(b5.size() == b6.size());
+    }
 }
 
-int main(int, const char *[])
-{
-	return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -15,6 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl_byte>
 
 #include <iostream>
@@ -111,11 +112,11 @@ SUITE(byte_tests)
         CHECK(0x12 == gsl::to_integer<unsigned long>(b));
         CHECK(0x12 == gsl::to_integer<unsigned long long>(b));
 
-//      CHECK(0x12 == gsl::to_integer<float>(b));   // expect compile-time error
-//      CHECK(0x12 == gsl::to_integer<double>(b));  // expect compile-time error
+        //      CHECK(0x12 == gsl::to_integer<float>(b));   // expect compile-time error
+        //      CHECK(0x12 == gsl::to_integer<double>(b));  // expect compile-time error
     }
 
-    int modify_both(gsl::byte& b, int& i)
+    int modify_both(gsl::byte & b, int& i)
     {
         i = 10;
         b = to_byte<5>();
@@ -124,12 +125,11 @@ SUITE(byte_tests)
 
     TEST(aliasing)
     {
-        int i{ 0 };
+        int i{0};
         const int res = modify_both(reinterpret_cast<byte&>(i), i);
         CHECK(res == i);
     }
 }
-
 }
 
 int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -15,6 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/multi_span>
 
 #include <iostream>
@@ -668,7 +669,9 @@ SUITE(multi_span_tests)
         CHECK(s2.empty());
 
         auto get_temp_span = [&]() -> multi_span<int> { return {&arr[1], 2}; };
-        auto use_span = [&](multi_span<const int> s) { CHECK(s.length() == 2 && s.data() == &arr[1]); };
+        auto use_span = [&](multi_span<const int> s) {
+            CHECK(s.length() == 2 && s.data() == &arr[1]);
+        };
         use_span(get_temp_span());
 
         s1 = get_temp_span();
@@ -1028,7 +1031,7 @@ SUITE(multi_span_tests)
             int arr[] = {1, 2, 3};
 
             multi_span<int> s1 = {&arr[0], 2}; // shorter
-            multi_span<int> s2 = arr; // longer
+            multi_span<int> s2 = arr;          // longer
 
             CHECK(s1 != s2);
             CHECK(s2 != s1);
@@ -1283,412 +1286,411 @@ SUITE(multi_span_tests)
         delete[] arr;
     }
 
-    TEST(index_constructors)
-    {
-        {
-            // components of the same type
-            index<3> i1(0, 1, 2);
-            CHECK(i1[0] == 0);
+    TEST(index_constructors){{// components of the same type
+                              index<3> i1(0, 1, 2);
+    CHECK(i1[0] == 0);
 
-            // components of different types
-            std::size_t c0 = 0;
-            std::size_t c1 = 1;
-            index<3> i2(c0, c1, 2);
-            CHECK(i2[0] == 0);
+    // components of different types
+    std::size_t c0 = 0;
+    std::size_t c1 = 1;
+    index<3> i2(c0, c1, 2);
+    CHECK(i2[0] == 0);
 
-            // from array
-            index<3> i3 = {0, 1, 2};
-            CHECK(i3[0] == 0);
+    // from array
+    index<3> i3 = {0, 1, 2};
+    CHECK(i3[0] == 0);
 
-            // from other index of the same size type
-            index<3> i4 = i3;
-            CHECK(i4[0] == 0);
+    // from other index of the same size type
+    index<3> i4 = i3;
+    CHECK(i4[0] == 0);
 
-            // default
-            index<3> i7;
-            CHECK(i7[0] == 0);
+    // default
+    index<3> i7;
+    CHECK(i7[0] == 0);
 
-            // default
-            index<3> i9 = {};
-            CHECK(i9[0] == 0);
-        }
+    // default
+    index<3> i9 = {};
+    CHECK(i9[0] == 0);
+}
 
-        {
-            // components of the same type
-            index<1> i1(0);
-            CHECK(i1[0] == 0);
+{
+    // components of the same type
+    index<1> i1(0);
+    CHECK(i1[0] == 0);
 
-            // components of different types
-            std::size_t c0 = 0;
-            index<1> i2(c0);
-            CHECK(i2[0] == 0);
+    // components of different types
+    std::size_t c0 = 0;
+    index<1> i2(c0);
+    CHECK(i2[0] == 0);
 
-            // from array
-            index<1> i3 = {0};
-            CHECK(i3[0] == 0);
+    // from array
+    index<1> i3 = {0};
+    CHECK(i3[0] == 0);
 
-            // from int
-            index<1> i4 = 0;
-            CHECK(i4[0] == 0);
+    // from int
+    index<1> i4 = 0;
+    CHECK(i4[0] == 0);
 
-            // from other index of the same size type
-            index<1> i5 = i3;
-            CHECK(i5[0] == 0);
+    // from other index of the same size type
+    index<1> i5 = i3;
+    CHECK(i5[0] == 0);
 
-            // default
-            index<1> i8;
-            CHECK(i8[0] == 0);
+    // default
+    index<1> i8;
+    CHECK(i8[0] == 0);
 
-            // default
-            index<1> i9 = {};
-            CHECK(i9[0] == 0);
-        }
+    // default
+    index<1> i9 = {};
+    CHECK(i9[0] == 0);
+}
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            index<3> i1(0, 1);
-            index<3> i2(0, 1, 2, 3);
-            index<3> i3 = {0};
-            index<3> i4 = {0, 1, 2, 3};
-            index<1> i5 = {0, 1};
-        }
+{
+    index<3> i1(0, 1);
+    index<3> i2(0, 1, 2, 3);
+    index<3> i3 = {0};
+    index<3> i4 = {0, 1, 2, 3};
+    index<1> i5 = {0, 1};
+}
 #endif
-    }
+}
 
-    TEST(index_operations)
+TEST(index_operations)
+{
+    ptrdiff_t a[3] = {0, 1, 2};
+    ptrdiff_t b[3] = {3, 4, 5};
+    index<3> i = a;
+    index<3> j = b;
+
+    CHECK(i[0] == 0);
+    CHECK(i[1] == 1);
+    CHECK(i[2] == 2);
+
     {
-        ptrdiff_t a[3] = {0, 1, 2};
-        ptrdiff_t b[3] = {3, 4, 5};
-        index<3> i = a;
-        index<3> j = b;
+        index<3> k = i + j;
 
         CHECK(i[0] == 0);
         CHECK(i[1] == 1);
         CHECK(i[2] == 2);
-
-        {
-            index<3> k = i + j;
-
-            CHECK(i[0] == 0);
-            CHECK(i[1] == 1);
-            CHECK(i[2] == 2);
-            CHECK(k[0] == 3);
-            CHECK(k[1] == 5);
-            CHECK(k[2] == 7);
-        }
-
-        {
-            index<3> k = i * 3;
-
-            CHECK(i[0] == 0);
-            CHECK(i[1] == 1);
-            CHECK(i[2] == 2);
-            CHECK(k[0] == 0);
-            CHECK(k[1] == 3);
-            CHECK(k[2] == 6);
-        }
-
-        {
-            index<3> k = 3 * i;
-
-            CHECK(i[0] == 0);
-            CHECK(i[1] == 1);
-            CHECK(i[2] == 2);
-            CHECK(k[0] == 0);
-            CHECK(k[1] == 3);
-            CHECK(k[2] == 6);
-        }
-
-        {
-            index<2> k = details::shift_left(i);
-
-            CHECK(i[0] == 0);
-            CHECK(i[1] == 1);
-            CHECK(i[2] == 2);
-            CHECK(k[0] == 1);
-            CHECK(k[1] == 2);
-        }
+        CHECK(k[0] == 3);
+        CHECK(k[1] == 5);
+        CHECK(k[2] == 7);
     }
 
-    void iterate_second_column(multi_span<int, dynamic_range, dynamic_range> av)
     {
-        auto length = av.size() / 2;
+        index<3> k = i * 3;
 
-        // view to the second column
-        auto section = av.section({0, 1}, {length, 1});
+        CHECK(i[0] == 0);
+        CHECK(i[1] == 1);
+        CHECK(i[2] == 2);
+        CHECK(k[0] == 0);
+        CHECK(k[1] == 3);
+        CHECK(k[2] == 6);
+    }
 
-        CHECK(section.size() == length);
-        for (auto i = 0; i < section.size(); ++i) {
-            CHECK(section[i][0] == av[i][1]);
-        }
+    {
+        index<3> k = 3 * i;
 
-        for (auto i = 0; i < section.size(); ++i) {
-            auto idx = index<2>{i, 0}; // avoid braces inside the CHECK macro
+        CHECK(i[0] == 0);
+        CHECK(i[1] == 1);
+        CHECK(i[2] == 2);
+        CHECK(k[0] == 0);
+        CHECK(k[1] == 3);
+        CHECK(k[2] == 6);
+    }
+
+    {
+        index<2> k = details::shift_left(i);
+
+        CHECK(i[0] == 0);
+        CHECK(i[1] == 1);
+        CHECK(i[2] == 2);
+        CHECK(k[0] == 1);
+        CHECK(k[1] == 2);
+    }
+}
+
+void iterate_second_column(multi_span<int, dynamic_range, dynamic_range> av)
+{
+    auto length = av.size() / 2;
+
+    // view to the second column
+    auto section = av.section({0, 1}, {length, 1});
+
+    CHECK(section.size() == length);
+    for (auto i = 0; i < section.size(); ++i) {
+        CHECK(section[i][0] == av[i][1]);
+    }
+
+    for (auto i = 0; i < section.size(); ++i) {
+        auto idx = index<2>{i, 0}; // avoid braces inside the CHECK macro
+        CHECK(section[idx] == av[i][1]);
+    }
+
+    CHECK(section.bounds().index_bounds()[0] == length);
+    CHECK(section.bounds().index_bounds()[1] == 1);
+    for (auto i = 0; i < section.bounds().index_bounds()[0]; ++i) {
+        for (auto j = 0; j < section.bounds().index_bounds()[1]; ++j) {
+            auto idx = index<2>{i, j}; // avoid braces inside the CHECK macro
             CHECK(section[idx] == av[i][1]);
         }
-
-        CHECK(section.bounds().index_bounds()[0] == length);
-        CHECK(section.bounds().index_bounds()[1] == 1);
-        for (auto i = 0; i < section.bounds().index_bounds()[0]; ++i) {
-            for (auto j = 0; j < section.bounds().index_bounds()[1]; ++j) {
-                auto idx = index<2>{i, j}; // avoid braces inside the CHECK macro
-                CHECK(section[idx] == av[i][1]);
-            }
-        }
-
-        auto check_sum = 0;
-        for (auto i = 0; i < length; ++i) {
-            check_sum += av[i][1];
-        }
-
-        {
-            auto idx = 0;
-            auto sum = 0;
-            for (auto num : section) {
-                CHECK(num == av[idx][1]);
-                sum += num;
-                idx++;
-            }
-
-            CHECK(sum == check_sum);
-        }
-        {
-            auto idx = length - 1;
-            auto sum = 0;
-            for (auto iter = section.rbegin(); iter != section.rend(); ++iter) {
-                CHECK(*iter == av[idx][1]);
-                sum += *iter;
-                idx--;
-            }
-
-            CHECK(sum == check_sum);
-        }
     }
 
-    TEST(span_section_iteration)
-    {
-        int arr[4][2] = {{4, 0}, {5, 1}, {6, 2}, {7, 3}};
-
-        // static bounds
-        {
-            multi_span<int, 4, 2> av = arr;
-            iterate_second_column(av);
-        }
-        // first bound is dynamic
-        {
-            multi_span<int, dynamic_range, 2> av = arr;
-            iterate_second_column(av);
-        }
-        // second bound is dynamic
-        {
-            multi_span<int, 4, dynamic_range> av = arr;
-            iterate_second_column(av);
-        }
-        // both bounds are dynamic
-        {
-            multi_span<int, dynamic_range, dynamic_range> av = arr;
-            iterate_second_column(av);
-        }
+    auto check_sum = 0;
+    for (auto i = 0; i < length; ++i) {
+        check_sum += av[i][1];
     }
 
-    TEST(dynamic_span_section_iteration)
     {
-        auto height = 4, width = 2;
-        auto size = height * width;
-
-        auto arr = new int[static_cast<std::size_t>(size)];
-        for (auto i = 0; i < size; ++i) {
-            arr[i] = i;
+        auto idx = 0;
+        auto sum = 0;
+        for (auto num : section) {
+            CHECK(num == av[idx][1]);
+            sum += num;
+            idx++;
         }
 
-        auto av = as_multi_span(arr, size);
-
-        // first bound is dynamic
-        {
-            multi_span<int, dynamic_range, 2> av2 = as_multi_span(av, dim(height), dim(width));
-            iterate_second_column(av2);
-        }
-        // second bound is dynamic
-        {
-            multi_span<int, 4, dynamic_range> av2 = as_multi_span(av, dim(height), dim(width));
-            iterate_second_column(av2);
-        }
-        // both bounds are dynamic
-        {
-            multi_span<int, dynamic_range, dynamic_range> av2 = as_multi_span(av, dim(height), dim(width));
-            iterate_second_column(av2);
+        CHECK(sum == check_sum);
+    }
+    {
+        auto idx = length - 1;
+        auto sum = 0;
+        for (auto iter = section.rbegin(); iter != section.rend(); ++iter) {
+            CHECK(*iter == av[idx][1]);
+            sum += *iter;
+            idx--;
         }
 
-        delete[] arr;
+        CHECK(sum == check_sum);
+    }
+}
+
+TEST(span_section_iteration)
+{
+    int arr[4][2] = {{4, 0}, {5, 1}, {6, 2}, {7, 3}};
+
+    // static bounds
+    {
+        multi_span<int, 4, 2> av = arr;
+        iterate_second_column(av);
+    }
+    // first bound is dynamic
+    {
+        multi_span<int, dynamic_range, 2> av = arr;
+        iterate_second_column(av);
+    }
+    // second bound is dynamic
+    {
+        multi_span<int, 4, dynamic_range> av = arr;
+        iterate_second_column(av);
+    }
+    // both bounds are dynamic
+    {
+        multi_span<int, dynamic_range, dynamic_range> av = arr;
+        iterate_second_column(av);
+    }
+}
+
+TEST(dynamic_span_section_iteration)
+{
+    auto height = 4, width = 2;
+    auto size = height * width;
+
+    auto arr = new int[static_cast<std::size_t>(size)];
+    for (auto i = 0; i < size; ++i) {
+        arr[i] = i;
     }
 
-    TEST(span_structure_size)
+    auto av = as_multi_span(arr, size);
+
+    // first bound is dynamic
     {
-        double(*arr)[3][4] = new double[100][3][4];
-        multi_span<double, dynamic_range, 3, 4> av1(arr, 10);
-
-        struct EffectiveStructure
-        {
-            double* v1;
-            ptrdiff_t v2;
-        };
-        CHECK(sizeof(av1) == sizeof(EffectiveStructure));
-
-        CHECK_THROW(av1[10][3][4], fail_fast);
-
-        multi_span<const double, dynamic_range, 6, 4> av2 = as_multi_span(av1, dim(5), dim<6>(), dim<4>());
-        (void) av2;
+        multi_span<int, dynamic_range, 2> av2 = as_multi_span(av, dim(height), dim(width));
+        iterate_second_column(av2);
+    }
+    // second bound is dynamic
+    {
+        multi_span<int, 4, dynamic_range> av2 = as_multi_span(av, dim(height), dim(width));
+        iterate_second_column(av2);
+    }
+    // both bounds are dynamic
+    {
+        multi_span<int, dynamic_range, dynamic_range> av2 =
+            as_multi_span(av, dim(height), dim(width));
+        iterate_second_column(av2);
     }
 
-    TEST(fixed_size_conversions)
+    delete[] arr;
+}
+
+TEST(span_structure_size)
+{
+    double(*arr)[3][4] = new double[100][3][4];
+    multi_span<double, dynamic_range, 3, 4> av1(arr, 10);
+
+    struct EffectiveStructure
     {
-        int arr[] = {1, 2, 3, 4};
+        double* v1;
+        ptrdiff_t v2;
+    };
+    CHECK(sizeof(av1) == sizeof(EffectiveStructure));
 
-        // converting to an multi_span from an equal size array is ok
-        multi_span<int, 4> av4 = arr;
-        CHECK(av4.length() == 4);
+    CHECK_THROW(av1[10][3][4], fail_fast);
 
-        // converting to dynamic_range a_v is always ok
-        {
-            multi_span<int, dynamic_range> av = av4;
-            (void) av;
-        }
-        {
-            multi_span<int, dynamic_range> av = arr;
-            (void) av;
-        }
+    multi_span<const double, dynamic_range, 6, 4> av2 =
+        as_multi_span(av1, dim(5), dim<6>(), dim<4>());
+    (void) av2;
+}
+
+TEST(fixed_size_conversions)
+{
+    int arr[] = {1, 2, 3, 4};
+
+    // converting to an multi_span from an equal size array is ok
+    multi_span<int, 4> av4 = arr;
+    CHECK(av4.length() == 4);
+
+    // converting to dynamic_range a_v is always ok
+    {
+        multi_span<int, dynamic_range> av = av4;
+        (void) av;
+    }
+    {
+        multi_span<int, dynamic_range> av = arr;
+        (void) av;
+    }
 
 // initialization or assignment to static multi_span that REDUCES size is NOT ok
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            multi_span<int, 2> av2 = arr;
-        }
-        {
-            multi_span<int, 2> av2 = av4;
-        }
+    {
+        multi_span<int, 2> av2 = arr;
+    }
+    {
+        multi_span<int, 2> av2 = av4;
+    }
 #endif
 
-        {
-            multi_span<int, dynamic_range> av = arr;
-            multi_span<int, 2> av2 = av;
-            (void) av2;
-        }
+    {
+        multi_span<int, dynamic_range> av = arr;
+        multi_span<int, 2> av2 = av;
+        (void) av2;
+    }
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            multi_span<int, dynamic_range> av = arr;
-            multi_span<int, 2, 1> av2 = av.as_multi_span(dim<2>(), dim<2>());
-        }
+    {
+        multi_span<int, dynamic_range> av = arr;
+        multi_span<int, 2, 1> av2 = av.as_multi_span(dim<2>(), dim<2>());
+    }
 #endif
 
-        {
-            multi_span<int, dynamic_range> av = arr;
-            multi_span<int, 2, 1> av2 = as_multi_span(av, dim(2), dim(2));
-            auto workaround_macro = [&]() { return av2[{1, 0}] == 2; };
-            CHECK(workaround_macro());
-        }
+    {
+        multi_span<int, dynamic_range> av = arr;
+        multi_span<int, 2, 1> av2 = as_multi_span(av, dim(2), dim(2));
+        auto workaround_macro = [&]() { return av2[{1, 0}] == 2; };
+        CHECK(workaround_macro());
+    }
 
-        // but doing so explicitly is ok
+    // but doing so explicitly is ok
 
-        // you can convert statically
-        {
-            multi_span<int, 2> av2 = {arr, 2};
-            (void) av2;
-        }
-        {
-            multi_span<int, 1> av2 = av4.first<1>();
-            (void) av2;
-        }
+    // you can convert statically
+    {
+        multi_span<int, 2> av2 = {arr, 2};
+        (void) av2;
+    }
+    {
+        multi_span<int, 1> av2 = av4.first<1>();
+        (void) av2;
+    }
 
-        // ...or dynamically
-        {
-            // NB: implicit conversion to multi_span<int,2> from multi_span<int,dynamic_range>
-            multi_span<int, 1> av2 = av4.first(1);
-            (void) av2;
-        }
+    // ...or dynamically
+    {
+        // NB: implicit conversion to multi_span<int,2> from multi_span<int,dynamic_range>
+        multi_span<int, 1> av2 = av4.first(1);
+        (void) av2;
+    }
 
-        // initialization or assignment to static multi_span that requires size INCREASE is not ok.
-        int arr2[2] = {1, 2};
+    // initialization or assignment to static multi_span that requires size INCREASE is not ok.
+    int arr2[2] = {1, 2};
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            multi_span<int, 4> av4 = arr2;
-        }
-        {
-            multi_span<int, 2> av2 = arr2;
-            multi_span<int, 4> av4 = av2;
-        }
+    {
+        multi_span<int, 4> av4 = arr2;
+    }
+    {
+        multi_span<int, 2> av2 = arr2;
+        multi_span<int, 4> av4 = av2;
+    }
 #endif
-        {
-            auto f = [&]() {
-                multi_span<int, 4> av9 = {arr2, 2};
-                (void) av9;
-            };
-            CHECK_THROW(f(), fail_fast);
-        }
-
-        // this should fail - we are trying to assign a small dynamic a_v to a fixed_size larger one
-        multi_span<int, dynamic_range> av = arr2;
+    {
         auto f = [&]() {
-            multi_span<int, 4> av2 = av;
-            (void) av2;
+            multi_span<int, 4> av9 = {arr2, 2};
+            (void) av9;
         };
         CHECK_THROW(f(), fail_fast);
     }
 
-    TEST(as_writeable_bytes)
-    {
-        int a[] = {1, 2, 3, 4};
+    // this should fail - we are trying to assign a small dynamic a_v to a fixed_size larger one
+    multi_span<int, dynamic_range> av = arr2;
+    auto f = [&]() {
+        multi_span<int, 4> av2 = av;
+        (void) av2;
+    };
+    CHECK_THROW(f(), fail_fast);
+}
 
-        {
+TEST(as_writeable_bytes)
+{
+    int a[] = {1, 2, 3, 4};
+
+    {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            // you should not be able to get writeable bytes for const objects
-            multi_span<const int, dynamic_range> av = a;
-            auto wav = av.as_writeable_bytes();
+        // you should not be able to get writeable bytes for const objects
+        multi_span<const int, dynamic_range> av = a;
+        auto wav = av.as_writeable_bytes();
 #endif
-        }
-
-        {
-            multi_span<int, dynamic_range> av;
-            auto wav = as_writeable_bytes(av);
-            CHECK(wav.length() == av.length());
-            CHECK(wav.length() == 0);
-            CHECK(wav.size_bytes() == 0);
-        }
-
-        {
-            multi_span<int, dynamic_range> av = a;
-            auto wav = as_writeable_bytes(av);
-            CHECK(wav.data() == reinterpret_cast<byte*>(&a[0]));
-            CHECK(static_cast<std::size_t>(wav.length()) == sizeof(a));
-        }
     }
 
-    TEST(iterator)
     {
-        int a[] = {1, 2, 3, 4};
+        multi_span<int, dynamic_range> av;
+        auto wav = as_writeable_bytes(av);
+        CHECK(wav.length() == av.length());
+        CHECK(wav.length() == 0);
+        CHECK(wav.size_bytes() == 0);
+    }
 
-        {
-            multi_span<int, dynamic_range> av = a;
-            auto wav = as_writeable_bytes(av);
-            for (auto& b : wav) {
-                b = byte(0);
-            }
-            for (std::size_t i = 0; i < 4; ++i) {
-                CHECK(a[i] == 0);
-            }
+    {
+        multi_span<int, dynamic_range> av = a;
+        auto wav = as_writeable_bytes(av);
+        CHECK(wav.data() == reinterpret_cast<byte*>(&a[0]));
+        CHECK(static_cast<std::size_t>(wav.length()) == sizeof(a));
+    }
+}
+
+TEST(iterator)
+{
+    int a[] = {1, 2, 3, 4};
+
+    {
+        multi_span<int, dynamic_range> av = a;
+        auto wav = as_writeable_bytes(av);
+        for (auto& b : wav) {
+            b = byte(0);
         }
-
-        {
-            multi_span<int, dynamic_range> av = a;
-            for (auto& n : av) {
-                n = 1;
-            }
-            for (std::size_t i = 0; i < 4; ++i) {
-                CHECK(a[i] == 1);
-            }
+        for (std::size_t i = 0; i < 4; ++i) {
+            CHECK(a[i] == 0);
         }
     }
+
+    {
+        multi_span<int, dynamic_range> av = a;
+        for (auto& n : av) {
+            n = 1;
+        }
+        for (std::size_t i = 0; i < 4; ++i) {
+            CHECK(a[i] == 1);
+        }
+    }
+}
 }
 
 int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -1,33 +1,41 @@
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <UnitTest++/UnitTest++.h> 
+#include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl>
-#include <vector>
+
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace gsl;
 
-struct MyBase {};
-struct MyDerived : public MyBase {};
-struct Unrelated {};
+struct MyBase
+{
+};
+struct MyDerived : public MyBase
+{
+};
+struct Unrelated
+{
+};
 
 // stand-in for a user-defined ref-counted class
-template<typename T>
+template <typename T>
 struct RefCounted
 {
     RefCounted(T* p) : p_(p) {}
@@ -39,95 +47,97 @@ struct RefCounted
 template <typename T>
 struct CustomPtr
 {
-	CustomPtr(T* p) : p_(p) {}
-	operator T*() { return p_; }
-	bool operator !=(std::nullptr_t)const { return p_ != nullptr; }
-	T* p_ = nullptr;
+    CustomPtr(T* p) : p_(p) {}
+    operator T*() { return p_; }
+    bool operator!=(std::nullptr_t) const { return p_ != nullptr; }
+    T* p_ = nullptr;
 };
 
 template <typename T, typename U>
 std::string operator==(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-    return reinterpret_cast<const void*>(lhs.p_) == reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) == reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                          : "false";
 }
 
 template <typename T, typename U>
 std::string operator!=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-	return reinterpret_cast<const void*>(lhs.p_) != reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) != reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                          : "false";
 }
 
 template <typename T, typename U>
 std::string operator<(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-	return reinterpret_cast<const void*>(lhs.p_) < reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) < reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                         : "false";
 }
 
 template <typename T, typename U>
 std::string operator>(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-	return reinterpret_cast<const void*>(lhs.p_) > reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) > reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                         : "false";
 }
 
 template <typename T, typename U>
 std::string operator<=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-	return reinterpret_cast<const void*>(lhs.p_) <= reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) <= reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                          : "false";
 }
 
 template <typename T, typename U>
 std::string operator>=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
-	return reinterpret_cast<const void*>(lhs.p_) >= reinterpret_cast<const void*>(rhs.p_) ? "true" : "false";
+    return reinterpret_cast<const void*>(lhs.p_) >= reinterpret_cast<const void*>(rhs.p_) ? "true"
+                                                                                          : "false";
 }
-
-
 
 SUITE(NotNullTests)
 {
 
-    bool helper(not_null<int*> p)
-    {
-        return *p == 12;
-    }
+    bool helper(not_null<int*> p) { return *p == 12; }
 
     TEST(TestNotNullConstructors)
     {
 #ifdef CONFIRM_COMPILATION_ERRORS
-        not_null<int*> p = nullptr; // yay...does not compile!
+        not_null<int*> p = nullptr;         // yay...does not compile!
         not_null<std::vector<char>*> p = 0; // yay...does not compile!
-        not_null<int*> p; // yay...does not compile!
+        not_null<int*> p;                   // yay...does not compile!
         std::unique_ptr<int> up = std::make_unique<int>(120);
         not_null<int*> p = up;
 
         // Forbid non-nullptr assignable types
         not_null<std::vector<int>> f(std::vector<int>{1});
         not_null<int> z(10);
-        not_null<std::vector<int>> y({1,2});
+        not_null<std::vector<int>> y({1, 2});
 #endif
-      int i = 12; 
-      auto rp = RefCounted<int>(&i);
-      not_null<int*> p(rp);
-      CHECK(p.get() == &i);
+        int i = 12;
+        auto rp = RefCounted<int>(&i);
+        not_null<int*> p(rp);
+        CHECK(p.get() == &i);
 
-      not_null<std::shared_ptr<int>> x(std::make_shared<int>(10)); // shared_ptr<int> is nullptr assignable
+        not_null<std::shared_ptr<int>> x(
+            std::make_shared<int>(10)); // shared_ptr<int> is nullptr assignable
     }
 
     TEST(TestNotNullCasting)
     {
         MyBase base;
-	MyDerived derived;
-	Unrelated unrelated;
-	not_null<Unrelated*> u = &unrelated;
-        (void)u;
-	not_null<MyDerived*> p = &derived;
+        MyDerived derived;
+        Unrelated unrelated;
+        not_null<Unrelated*> u = &unrelated;
+        (void) u;
+        not_null<MyDerived*> p = &derived;
         not_null<MyBase*> q = &base;
-	q = p; // allowed with heterogeneous copy ctor
+        q = p; // allowed with heterogeneous copy ctor
         CHECK(q == p);
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-	q = u; // no viable conversion possible between MyBase* and Unrelated*
-	p = q; // not possible to implicitly convert MyBase* to MyDerived*
+        q = u; // no viable conversion possible between MyBase* and Unrelated*
+        p = q; // not possible to implicitly convert MyBase* to MyDerived*
 
         not_null<Unrelated*> r = p;
         not_null<Unrelated*> s = reinterpret_cast<Unrelated*>(p);
@@ -139,7 +149,7 @@ SUITE(NotNullTests)
     TEST(TestNotNullAssignment)
     {
         int i = 12;
-        not_null<int*> p = &i; 
+        not_null<int*> p = &i;
         CHECK(helper(p));
 
         int* q = nullptr;
@@ -211,7 +221,7 @@ SUITE(NotNullTests)
 
     TEST(TestNotNullCustomPtrComparison)
     {
-        int ints[2] = { 42, 43 };
+        int ints[2] = {42, 43};
         CustomPtr<int> p1(&ints[0]);
         CustomPtr<const int> p2(&ints[1]);
 
@@ -242,7 +252,4 @@ SUITE(NotNullTests)
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -1,31 +1,30 @@
-/////////////////////////////////////////////////////////////////////////////// 
-// 
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved. 
-// 
-// This code is licensed under the MIT License (MIT). 
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-// THE SOFTWARE. 
-// 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <UnitTest++/UnitTest++.h> 
+#include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl>
+
 #include <functional>
 
 using namespace gsl;
 
 SUITE(owner_tests)
 {
-    void f(int* i)
-    {
-        *i += 1;
-    }
+    void f(int* i) { *i += 1; }
 
     TEST(basic_test)
     {
@@ -37,7 +36,4 @@ SUITE(owner_tests)
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -15,15 +15,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/span>
 
 #include <iostream>
 #include <list>
 #include <map>
 #include <memory>
+#include <regex>
 #include <string>
 #include <vector>
-#include <regex>
 
 using namespace std;
 using namespace gsl;
@@ -148,7 +149,9 @@ SUITE(span_tests)
         }
 
         {
-            auto workaround_macro = []() { span<int, 1> s{ nullptr, static_cast<span<int>::index_type>(0) }; };
+            auto workaround_macro = []() {
+                span<int, 1> s{nullptr, static_cast<span<int>::index_type>(0)};
+            };
             CHECK_THROW(workaround_macro(), fail_fast);
         }
 
@@ -265,13 +268,13 @@ SUITE(span_tests)
 
         {
             int* p = nullptr;
-            span<int> s{ p, p };
+            span<int> s{p, p};
             CHECK(s.length() == 0 && s.data() == nullptr);
         }
 
         {
             int* p = nullptr;
-            span<int, 0> s{ p, p };
+            span<int, 0> s{p, p};
             CHECK(s.length() == 0 && s.data() == nullptr);
         }
 
@@ -314,7 +317,7 @@ SUITE(span_tests)
             CHECK(s.length() == 5 && s.data() == &arr[0]);
         }
 
-        int arr2d[2][3] = { 1, 2, 3, 4, 5, 6 };
+        int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
 
 #ifdef CONFIRM_COMPILATION_ERRORS
         {
@@ -338,11 +341,11 @@ SUITE(span_tests)
         }
 
         {
-            span<int, 6> s{ arr2d };
+            span<int, 6> s{arr2d};
         }
 #endif
         {
-            span<int[3]> s{ &(arr2d[0]), 1 };
+            span<int[3]> s{&(arr2d[0]), 1};
             CHECK(s.length() == 1 && s.data() == &arr2d[0]);
         }
 
@@ -450,7 +453,7 @@ SUITE(span_tests)
         }
 
         {
-            auto get_an_array = []()->std::array<int, 4> { return{1, 2, 3, 4}; };
+            auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
             auto take_a_span = [](span<int> s) { static_cast<void>(s); };
             // try to take a temporary std::array
             take_a_span(get_an_array());
@@ -458,7 +461,7 @@ SUITE(span_tests)
 #endif
 
         {
-            auto get_an_array = []() -> std::array<int, 4> { return { 1, 2, 3, 4 }; };
+            auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
             auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
             // try to take a temporary std::array
             take_a_span(get_an_array());
@@ -588,8 +591,7 @@ SUITE(span_tests)
         {
             auto arr = std::make_unique<int[]>(4);
 
-            for (auto i = 0U; i < 4; i++)
-                arr[i] = gsl::narrow_cast<int>(i + 1);
+            for (auto i = 0U; i < 4; i++) arr[i] = gsl::narrow_cast<int>(i + 1);
 
             {
                 span<int> s{arr, 4};
@@ -695,14 +697,14 @@ SUITE(span_tests)
         }
 
         {
-            auto get_temp_vector = []() -> std::vector<int> { return{}; };
+            auto get_temp_vector = []() -> std::vector<int> { return {}; };
             auto use_span = [](span<const int> s) { static_cast<void>(s); };
             use_span(get_temp_vector());
         }
 
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            auto get_temp_string = []() -> std::string { return{}; };
+            auto get_temp_string = []() -> std::string { return {}; };
             auto use_span = [](span<char> s) { static_cast<void>(s); };
             use_span(get_temp_string());
 #endif
@@ -744,826 +746,817 @@ SUITE(span_tests)
         }
     }
 
-    TEST(from_convertible_span_constructor)
-    {
-        {
-            span<DerivedClass> avd;
-            span<const DerivedClass> avcd = avd;
-            static_cast<void>(avcd);
-        }
+    TEST(from_convertible_span_constructor){{span<DerivedClass> avd;
+    span<const DerivedClass> avcd = avd;
+    static_cast<void>(avcd);
+}
 
-        {
+{
 #ifdef CONFIRM_COMPILATION_ERRORS
-            span<DerivedClass> avd;
-            span<BaseClass> avb = avd;
-            static_cast<void>(avb);
+    span<DerivedClass> avd;
+    span<BaseClass> avb = avd;
+    static_cast<void>(avb);
 #endif
-        }
+}
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            span<int> s;
-            span<unsigned int> s2 = s;
-            static_cast<void>(s2);
-        }
+{
+    span<int> s;
+    span<unsigned int> s2 = s;
+    static_cast<void>(s2);
+}
 
-        {
-            span<int> s;
-            span<const unsigned int> s2 = s;
-            static_cast<void>(s2);
-        }
+{
+    span<int> s;
+    span<const unsigned int> s2 = s;
+    static_cast<void>(s2);
+}
 
-        {
-            span<int> s;
-            span<short> s2 = s;
-            static_cast<void>(s2);
-        }
+{
+    span<int> s;
+    span<short> s2 = s;
+    static_cast<void>(s2);
+}
 #endif
+}
+
+TEST(copy_move_and_assignment)
+{
+    span<int> s1;
+    CHECK(s1.empty());
+
+    int arr[] = {3, 4, 5};
+
+    span<const int> s2 = arr;
+    CHECK(s2.length() == 3 && s2.data() == &arr[0]);
+
+    s2 = s1;
+    CHECK(s2.empty());
+
+    auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
+    auto use_span = [&](span<const int> s) { CHECK(s.length() == 2 && s.data() == &arr[1]); };
+    use_span(get_temp_span());
+
+    s1 = get_temp_span();
+    CHECK(s1.length() == 2 && s1.data() == &arr[1]);
+}
+
+TEST(first)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
+
+    {
+        span<int, 5> av = arr;
+        CHECK(av.first<2>().length() == 2);
+        CHECK(av.first(2).length() == 2);
     }
 
-    TEST(copy_move_and_assignment)
     {
-        span<int> s1;
-        CHECK(s1.empty());
-
-        int arr[] = {3, 4, 5};
-
-        span<const int> s2 = arr;
-        CHECK(s2.length() == 3 && s2.data() == &arr[0]);
-
-        s2 = s1;
-        CHECK(s2.empty());
-
-        auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
-        auto use_span = [&](span<const int> s) { CHECK(s.length() == 2 && s.data() == &arr[1]); };
-        use_span(get_temp_span());
-
-        s1 = get_temp_span();
-        CHECK(s1.length() == 2 && s1.data() == &arr[1]);
+        span<int, 5> av = arr;
+        CHECK(av.first<0>().length() == 0);
+        CHECK(av.first(0).length() == 0);
     }
 
-    TEST(first)
     {
-        int arr[5] = {1, 2, 3, 4, 5};
+        span<int, 5> av = arr;
+        CHECK(av.first<5>().length() == 5);
+        CHECK(av.first(5).length() == 5);
+    }
 
-        {
-            span<int, 5> av = arr;
-            CHECK(av.first<2>().length() == 2);
-            CHECK(av.first(2).length() == 2);
-        }
-
-        {
-            span<int, 5> av = arr;
-            CHECK(av.first<0>().length() == 0);
-            CHECK(av.first(0).length() == 0);
-        }
-
-        {
-            span<int, 5> av = arr;
-            CHECK(av.first<5>().length() == 5);
-            CHECK(av.first(5).length() == 5);
-        }
-
-        {
-            span<int, 5> av = arr;
+    {
+        span<int, 5> av = arr;
 #ifdef CONFIRM_COMPILATION_ERRORS
-            CHECK(av.first<6>().length() == 6);
-            CHECK(av.first<-1>().length() == -1);
+        CHECK(av.first<6>().length() == 6);
+        CHECK(av.first<-1>().length() == -1);
 #endif
-            CHECK_THROW(av.first(6).length(), fail_fast);
-        }
-
-        {
-            span<int> av;
-            CHECK(av.first<0>().length() == 0);
-            CHECK(av.first(0).length() == 0);
-        }
+        CHECK_THROW(av.first(6).length(), fail_fast);
     }
 
-    TEST(last)
     {
-        int arr[5] = {1, 2, 3, 4, 5};
+        span<int> av;
+        CHECK(av.first<0>().length() == 0);
+        CHECK(av.first(0).length() == 0);
+    }
+}
 
-        {
-            span<int, 5> av = arr;
-            CHECK(av.last<2>().length() == 2);
-            CHECK(av.last(2).length() == 2);
-        }
+TEST(last)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
 
-        {
-            span<int, 5> av = arr;
-            CHECK(av.last<0>().length() == 0);
-            CHECK(av.last(0).length() == 0);
-        }
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<2>().length() == 2);
+        CHECK(av.last(2).length() == 2);
+    }
 
-        {
-            span<int, 5> av = arr;
-            CHECK(av.last<5>().length() == 5);
-            CHECK(av.last(5).length() == 5);
-        }
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<0>().length() == 0);
+        CHECK(av.last(0).length() == 0);
+    }
 
-        {
-            span<int, 5> av = arr;
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<5>().length() == 5);
+        CHECK(av.last(5).length() == 5);
+    }
+
+    {
+        span<int, 5> av = arr;
 #ifdef CONFIRM_COMPILATION_ERRORS
-            CHECK(av.last<6>().length() == 6);
+        CHECK(av.last<6>().length() == 6);
 #endif
-            CHECK_THROW(av.last(6).length(), fail_fast);
-        }
-
-        {
-            span<int> av;
-            CHECK(av.last<0>().length() == 0);
-            CHECK(av.last(0).length() == 0);
-        }
+        CHECK_THROW(av.last(6).length(), fail_fast);
     }
 
-    TEST(subspan)
     {
-        int arr[5] = {1, 2, 3, 4, 5};
+        span<int> av;
+        CHECK(av.last<0>().length() == 0);
+        CHECK(av.last(0).length() == 0);
+    }
+}
 
-        {
-            span<int, 5> av = arr;
-            CHECK((av.subspan<2, 2>().length() == 2));
-            CHECK(av.subspan(2, 2).length() == 2);
-            CHECK(av.subspan(2, 3).length() == 3);
-        }
+TEST(subspan)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
 
-        {
-            span<int, 5> av = arr;
-            CHECK((av.subspan<0, 0>().length() == 0));
-            CHECK(av.subspan(0, 0).length() == 0);
-        }
-
-        {
-            span<int, 5> av = arr;
-            CHECK((av.subspan<0, 5>().length() == 5));
-            CHECK(av.subspan(0, 5).length() == 5);
-            CHECK_THROW(av.subspan(0, 6).length(), fail_fast);
-            CHECK_THROW(av.subspan(1, 5).length(), fail_fast);
-        }
-
-        {
-            span<int, 5> av = arr;
-            CHECK((av.subspan<4, 0>().length() == 0));
-            CHECK(av.subspan(4, 0).length() == 0);
-            CHECK(av.subspan(5, 0).length() == 0);
-            CHECK_THROW(av.subspan(6, 0).length(), fail_fast);
-        }
-
-        {
-            span<int> av;
-            CHECK((av.subspan<0, 0>().length() == 0));
-            CHECK(av.subspan(0, 0).length() == 0);
-            CHECK_THROW((av.subspan<1, 0>().length()), fail_fast);
-        }
-
-        {
-            span<int> av;
-            CHECK(av.subspan(0).length() == 0);
-            CHECK_THROW(av.subspan(1).length(), fail_fast);
-        }
-
-        {
-            span<int> av = arr;
-            CHECK(av.subspan(0).length() == 5);
-            CHECK(av.subspan(1).length() == 4);
-            CHECK(av.subspan(4).length() == 1);
-            CHECK(av.subspan(5).length() == 0);
-            CHECK_THROW(av.subspan(6).length(), fail_fast);
-            const auto av2 = av.subspan(1);
-            for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
-        }
-
-        {
-            span<int, 5> av = arr;
-            CHECK(av.subspan(0).length() == 5);
-            CHECK(av.subspan(1).length() == 4);
-            CHECK(av.subspan(4).length() == 1);
-            CHECK(av.subspan(5).length() == 0);
-            CHECK_THROW(av.subspan(6).length(), fail_fast);
-            const auto av2 = av.subspan(1);
-            for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
-        }
+    {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<2, 2>().length() == 2));
+        CHECK(av.subspan(2, 2).length() == 2);
+        CHECK(av.subspan(2, 3).length() == 3);
     }
 
-    TEST(at_call)
     {
-        int arr[4] = {1, 2, 3, 4};
-
-        {
-            span<int> s = arr;
-            CHECK(s.at(0) == 1);
-            CHECK_THROW(s.at(5), fail_fast);
-        }
-
-        {
-            int arr2d[2] = {1, 6};
-            span<int, 2> s = arr2d;
-            CHECK(s.at(0) == 1);
-            CHECK(s.at(1) == 6);
-            CHECK_THROW(s.at(2) ,fail_fast);
-        }
+        span<int, 5> av = arr;
+        CHECK((av.subspan<0, 0>().length() == 0));
+        CHECK(av.subspan(0, 0).length() == 0);
     }
 
-    TEST(operator_function_call)
     {
-        int arr[4] = {1, 2, 3, 4};
-
-        {
-            span<int> s = arr;
-            CHECK(s(0) == 1);
-            CHECK_THROW(s(5), fail_fast);
-        }
-
-        {
-            int arr2d[2] = {1, 6};
-            span<int, 2> s = arr2d;
-            CHECK(s(0) == 1);
-            CHECK(s(1) == 6);
-            CHECK_THROW(s(2) ,fail_fast);
-        }
+        span<int, 5> av = arr;
+        CHECK((av.subspan<0, 5>().length() == 5));
+        CHECK(av.subspan(0, 5).length() == 5);
+        CHECK_THROW(av.subspan(0, 6).length(), fail_fast);
+        CHECK_THROW(av.subspan(1, 5).length(), fail_fast);
     }
 
-    TEST(iterator_default_init)
     {
-        span<int>::iterator it1;
-        span<int>::iterator it2;
-        CHECK(it1 == it2);
+        span<int, 5> av = arr;
+        CHECK((av.subspan<4, 0>().length() == 0));
+        CHECK(av.subspan(4, 0).length() == 0);
+        CHECK(av.subspan(5, 0).length() == 0);
+        CHECK_THROW(av.subspan(6, 0).length(), fail_fast);
     }
 
-    TEST(const_iterator_default_init)
     {
-        span<int>::const_iterator it1;
-        span<int>::const_iterator it2;
-        CHECK(it1 == it2);
+        span<int> av;
+        CHECK((av.subspan<0, 0>().length() == 0));
+        CHECK(av.subspan(0, 0).length() == 0);
+        CHECK_THROW((av.subspan<1, 0>().length()), fail_fast);
     }
 
-    TEST(iterator_conversions)
     {
-        span<int>::iterator badIt;
-        span<int>::const_iterator badConstIt;
-        CHECK(badIt == badConstIt);
+        span<int> av;
+        CHECK(av.subspan(0).length() == 0);
+        CHECK_THROW(av.subspan(1).length(), fail_fast);
+    }
 
-        int a[] = { 1, 2, 3, 4 };
+    {
+        span<int> av = arr;
+        CHECK(av.subspan(0).length() == 5);
+        CHECK(av.subspan(1).length() == 4);
+        CHECK(av.subspan(4).length() == 1);
+        CHECK(av.subspan(5).length() == 0);
+        CHECK_THROW(av.subspan(6).length(), fail_fast);
+        const auto av2 = av.subspan(1);
+        for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
+    }
+
+    {
+        span<int, 5> av = arr;
+        CHECK(av.subspan(0).length() == 5);
+        CHECK(av.subspan(1).length() == 4);
+        CHECK(av.subspan(4).length() == 1);
+        CHECK(av.subspan(5).length() == 0);
+        CHECK_THROW(av.subspan(6).length(), fail_fast);
+        const auto av2 = av.subspan(1);
+        for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
+    }
+}
+
+TEST(at_call)
+{
+    int arr[4] = {1, 2, 3, 4};
+
+    {
+        span<int> s = arr;
+        CHECK(s.at(0) == 1);
+        CHECK_THROW(s.at(5), fail_fast);
+    }
+
+    {
+        int arr2d[2] = {1, 6};
+        span<int, 2> s = arr2d;
+        CHECK(s.at(0) == 1);
+        CHECK(s.at(1) == 6);
+        CHECK_THROW(s.at(2), fail_fast);
+    }
+}
+
+TEST(operator_function_call)
+{
+    int arr[4] = {1, 2, 3, 4};
+
+    {
+        span<int> s = arr;
+        CHECK(s(0) == 1);
+        CHECK_THROW(s(5), fail_fast);
+    }
+
+    {
+        int arr2d[2] = {1, 6};
+        span<int, 2> s = arr2d;
+        CHECK(s(0) == 1);
+        CHECK(s(1) == 6);
+        CHECK_THROW(s(2), fail_fast);
+    }
+}
+
+TEST(iterator_default_init)
+{
+    span<int>::iterator it1;
+    span<int>::iterator it2;
+    CHECK(it1 == it2);
+}
+
+TEST(const_iterator_default_init)
+{
+    span<int>::const_iterator it1;
+    span<int>::const_iterator it2;
+    CHECK(it1 == it2);
+}
+
+TEST(iterator_conversions)
+{
+    span<int>::iterator badIt;
+    span<int>::const_iterator badConstIt;
+    CHECK(badIt == badConstIt);
+
+    int a[] = {1, 2, 3, 4};
+    span<int> s = a;
+
+    auto it = s.begin();
+    auto cit = s.cbegin();
+
+    CHECK(it == cit);
+    CHECK(cit == it);
+
+    span<int>::const_iterator cit2 = it;
+    CHECK(cit2 == cit);
+
+    span<int>::const_iterator cit3 = it + 4;
+    CHECK(cit3 == s.cend());
+}
+
+TEST(iterator_comparisons)
+{
+    int a[] = {1, 2, 3, 4};
+    {
         span<int> s = a;
-
-        auto it = s.begin();
-        auto cit = s.cbegin();
+        span<int>::iterator it = s.begin();
+        auto it2 = it + 1;
+        span<int>::const_iterator cit = s.cbegin();
 
         CHECK(it == cit);
         CHECK(cit == it);
+        CHECK(it == it);
+        CHECK(cit == cit);
+        CHECK(cit == s.begin());
+        CHECK(s.begin() == cit);
+        CHECK(s.cbegin() == cit);
+        CHECK(it == s.begin());
+        CHECK(s.begin() == it);
 
-        span<int>::const_iterator cit2 = it;
-        CHECK(cit2 == cit);
+        CHECK(it != it2);
+        CHECK(it2 != it);
+        CHECK(it != s.end());
+        CHECK(it2 != s.end());
+        CHECK(s.end() != it);
+        CHECK(it2 != cit);
+        CHECK(cit != it2);
 
-        span<int>::const_iterator cit3 = it + 4;
-        CHECK(cit3 == s.cend());
+        CHECK(it < it2);
+        CHECK(it <= it2);
+        CHECK(it2 <= s.end());
+        CHECK(it < s.end());
+        CHECK(it <= cit);
+        CHECK(cit <= it);
+        CHECK(cit < it2);
+        CHECK(cit <= it2);
+        CHECK(cit < s.end());
+        CHECK(cit <= s.end());
+
+        CHECK(it2 > it);
+        CHECK(it2 >= it);
+        CHECK(s.end() > it2);
+        CHECK(s.end() >= it2);
+        CHECK(it2 > cit);
+        CHECK(it2 >= cit);
     }
+}
 
-    TEST(iterator_comparisons)
-    {
-        int a[] = { 1, 2, 3, 4 };
-        {
-            span<int> s = a;
-            span<int>::iterator it = s.begin();
-            auto it2 = it + 1;
-            span<int>::const_iterator cit = s.cbegin();
-
-            CHECK(it == cit);
-            CHECK(cit == it);
-            CHECK(it == it);
-            CHECK(cit == cit);
-            CHECK(cit == s.begin());
-            CHECK(s.begin() == cit);
-            CHECK(s.cbegin() == cit);
-            CHECK(it == s.begin());
-            CHECK(s.begin() == it);
-
-            CHECK(it != it2);
-            CHECK(it2 != it);
-            CHECK(it != s.end());
-            CHECK(it2 != s.end());
-            CHECK(s.end() != it);
-            CHECK(it2 != cit);
-            CHECK(cit != it2);
-
-            CHECK(it < it2);
-            CHECK(it <= it2);
-            CHECK(it2 <= s.end());
-            CHECK(it < s.end());
-            CHECK(it <= cit);
-            CHECK(cit <= it);
-            CHECK(cit < it2);
-            CHECK(cit <= it2);
-            CHECK(cit < s.end());
-            CHECK(cit <= s.end());
-
-            CHECK(it2 > it);
-            CHECK(it2 >= it);
-            CHECK(s.end() > it2);
-            CHECK(s.end() >= it2);
-            CHECK(it2 > cit);
-            CHECK(it2 >= cit);
-        }
-    }
-
-    TEST(begin_end)
-    {
-        {
-            int a[] = { 1, 2, 3, 4 };
-            span<int> s = a;
-
-            span<int>::iterator it = s.begin();
-            span<int>::iterator it2 = std::begin(s);
-            CHECK(it == it2);
-
-            it = s.end();
-            it2 = std::end(s);
-            CHECK(it == it2);
-        }
-
-        {
-            int a[] = { 1, 2, 3, 4 };
-            span<int> s = a;
-
-            auto it = s.begin();
-            auto first = it;
-            CHECK(it == first);
-            CHECK(*it == 1);
-
-            auto beyond = s.end();
-            CHECK(it != beyond);
-            CHECK_THROW(*beyond, fail_fast);
-
-            CHECK(beyond - first == 4);
-            CHECK(first - first == 0);
-            CHECK(beyond - beyond == 0);
-
-            ++it;
-            CHECK(it - first == 1);
-            CHECK(*it == 2);
-            *it = 22;
-            CHECK(*it == 22);
-            CHECK(beyond - it == 3);
-
-            it = first;
-            CHECK(it == first);
-            while (it != s.end())
-            {
-                *it = 5;
-                ++it;
-            }
-
-            CHECK(it == beyond);
-            CHECK(it - beyond == 0);
-
-            for (const auto& n : s)
-            {
-                CHECK(n == 5);
-            }
-        }
-    }
-
-    TEST(cbegin_cend)
-    {
-        {
-            int a[] = { 1, 2, 3, 4 };
-            span<int> s = a;
-
-            span<int>::const_iterator cit = s.cbegin();
-            span<int>::const_iterator cit2 = std::cbegin(s);
-            CHECK(cit == cit2);
-
-            cit = s.cend();
-            cit2 = std::cend(s);
-            CHECK(cit == cit2);
-        }
-
-        {
-            int a[] = {1, 2, 3, 4};
-            span<int> s = a;
-
-            auto it = s.cbegin();
-            auto first = it;
-            CHECK(it == first);
-            CHECK(*it == 1);
-
-            auto beyond = s.cend();
-            CHECK(it != beyond);
-            CHECK_THROW(*beyond, fail_fast);
-
-            CHECK(beyond - first == 4);
-            CHECK(first - first == 0);
-            CHECK(beyond - beyond == 0);
-
-            ++it;
-            CHECK(it - first == 1);
-            CHECK(*it == 2);
-            CHECK(beyond - it == 3);
-
-            int last = 0;
-            it = first;
-            CHECK(it == first);
-            while (it != s.cend())
-            {
-                CHECK(*it == last + 1);
-
-                last = *it;
-                ++it;
-            }
-
-            CHECK(it == beyond);
-            CHECK(it - beyond == 0);
-        }
-    }
-
-    TEST(rbegin_rend)
-    {
-        {
-            int a[] = {1, 2, 3, 4};
-            span<int> s = a;
-
-            auto it = s.rbegin();
-            auto first = it;
-            CHECK(it == first);
-            CHECK(*it == 4);
-
-            auto beyond = s.rend();
-            CHECK(it != beyond);
-            CHECK_THROW(*beyond, fail_fast);
-
-            CHECK(beyond - first == 4);
-            CHECK(first - first == 0);
-            CHECK(beyond - beyond == 0);
-
-            ++it;
-            CHECK(it - first == 1);
-            CHECK(*it == 3);
-            *it = 22;
-            CHECK(*it == 22);
-            CHECK(beyond - it == 3);
-
-            it = first;
-            CHECK(it == first);
-            while (it != s.rend())
-            {
-                *it = 5;
-                ++it;
-            }
-
-            CHECK(it == beyond);
-            CHECK(it - beyond == 0);
-
-            for (const auto& n : s)
-            {
-                CHECK(n == 5);
-            }
-        }
-    }
-
-    TEST(crbegin_crend)
-    {
-        {
-            int a[] = {1, 2, 3, 4};
-            span<int> s = a;
-
-            auto it = s.crbegin();
-            auto first = it;
-            CHECK(it == first);
-            CHECK(*it == 4);
-
-            auto beyond = s.crend();
-            CHECK(it != beyond);
-            CHECK_THROW(*beyond, fail_fast);
-
-            CHECK(beyond - first == 4);
-            CHECK(first - first == 0);
-            CHECK(beyond - beyond == 0);
-
-            ++it;
-            CHECK(it - first == 1);
-            CHECK(*it == 3);
-            CHECK(beyond - it == 3);
-
-            it = first;
-            CHECK(it == first);
-            int last = 5;
-            while (it != s.crend())
-            {
-                CHECK(*it == last - 1);
-                last = *it;
-
-                ++it;
-            }
-
-            CHECK(it == beyond);
-            CHECK(it - beyond == 0);
-        }
-    }
-
-    TEST(comparison_operators)
-    {
-        {
-            span<int> s1 = nullptr;
-            span<int> s2 = nullptr;
-            CHECK(s1 == s2);
-            CHECK(!(s1 != s2));
-            CHECK(!(s1 < s2));
-            CHECK(s1 <= s2);
-            CHECK(!(s1 > s2));
-            CHECK(s1 >= s2);
-            CHECK(s2 == s1);
-            CHECK(!(s2 != s1));
-            CHECK(!(s2 < s1));
-            CHECK(s2 <= s1);
-            CHECK(!(s2 > s1));
-            CHECK(s2 >= s1);
-        }
-
-        {
-            int arr[] = {2, 1};
-            span<int> s1 = arr;
-            span<int> s2 = arr;
-
-            CHECK(s1 == s2);
-            CHECK(!(s1 != s2));
-            CHECK(!(s1 < s2));
-            CHECK(s1 <= s2);
-            CHECK(!(s1 > s2));
-            CHECK(s1 >= s2);
-            CHECK(s2 == s1);
-            CHECK(!(s2 != s1));
-            CHECK(!(s2 < s1));
-            CHECK(s2 <= s1);
-            CHECK(!(s2 > s1));
-            CHECK(s2 >= s1);
-        }
-
-        {
-            int arr[] = {2, 1}; // bigger
-
-            span<int> s1 = nullptr;
-            span<int> s2 = arr;
-
-            CHECK(s1 != s2);
-            CHECK(s2 != s1);
-            CHECK(!(s1 == s2));
-            CHECK(!(s2 == s1));
-            CHECK(s1 < s2);
-            CHECK(!(s2 < s1));
-            CHECK(s1 <= s2);
-            CHECK(!(s2 <= s1));
-            CHECK(s2 > s1);
-            CHECK(!(s1 > s2));
-            CHECK(s2 >= s1);
-            CHECK(!(s1 >= s2));
-        }
-
-        {
-            int arr1[] = {1, 2};
-            int arr2[] = {1, 2};
-            span<int> s1 = arr1;
-            span<int> s2 = arr2;
-
-            CHECK(s1 == s2);
-            CHECK(!(s1 != s2));
-            CHECK(!(s1 < s2));
-            CHECK(s1 <= s2);
-            CHECK(!(s1 > s2));
-            CHECK(s1 >= s2);
-            CHECK(s2 == s1);
-            CHECK(!(s2 != s1));
-            CHECK(!(s2 < s1));
-            CHECK(s2 <= s1);
-            CHECK(!(s2 > s1));
-            CHECK(s2 >= s1);
-        }
-
-        {
-            int arr[] = {1, 2, 3};
-
-            span<int> s1 = {&arr[0], 2}; // shorter
-            span<int> s2 = arr; // longer
-
-            CHECK(s1 != s2);
-            CHECK(s2 != s1);
-            CHECK(!(s1 == s2));
-            CHECK(!(s2 == s1));
-            CHECK(s1 < s2);
-            CHECK(!(s2 < s1));
-            CHECK(s1 <= s2);
-            CHECK(!(s2 <= s1));
-            CHECK(s2 > s1);
-            CHECK(!(s1 > s2));
-            CHECK(s2 >= s1);
-            CHECK(!(s1 >= s2));
-        }
-
-        {
-            int arr1[] = {1, 2}; // smaller
-            int arr2[] = {2, 1}; // bigger
-
-            span<int> s1 = arr1;
-            span<int> s2 = arr2;
-
-            CHECK(s1 != s2);
-            CHECK(s2 != s1);
-            CHECK(!(s1 == s2));
-            CHECK(!(s2 == s1));
-            CHECK(s1 < s2);
-            CHECK(!(s2 < s1));
-            CHECK(s1 <= s2);
-            CHECK(!(s2 <= s1));
-            CHECK(s2 > s1);
-            CHECK(!(s1 > s2));
-            CHECK(s2 >= s1);
-            CHECK(!(s1 >= s2));
-        }
-    }
-
-    TEST(as_bytes)
+TEST(begin_end)
+{
     {
         int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-        {
-            const span<const int> s = a;
-            CHECK(s.length() == 4);
-            const span<const byte> bs = as_bytes(s);
-            CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-            CHECK(bs.length() == s.length_bytes());
-        }
+        span<int>::iterator it = s.begin();
+        span<int>::iterator it2 = std::begin(s);
+        CHECK(it == it2);
 
-        {
-            span<int> s;
-            const auto bs = as_bytes(s);
-            CHECK(bs.length() == s.length());
-            CHECK(bs.length() == 0);
-            CHECK(bs.size_bytes() == 0);
-            CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-            CHECK(bs.data() == nullptr);
-        }
-
-        {
-            span<int> s = a;
-            const auto bs = as_bytes(s);
-            CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-            CHECK(bs.length() == s.length_bytes());
-        }
+        it = s.end();
+        it2 = std::end(s);
+        CHECK(it == it2);
     }
 
-    TEST(as_writeable_bytes)
     {
         int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-        {
+        auto it = s.begin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 1);
+
+        auto beyond = s.end();
+        CHECK(it != beyond);
+        CHECK_THROW(*beyond, fail_fast);
+
+        CHECK(beyond - first == 4);
+        CHECK(first - first == 0);
+        CHECK(beyond - beyond == 0);
+
+        ++it;
+        CHECK(it - first == 1);
+        CHECK(*it == 2);
+        *it = 22;
+        CHECK(*it == 22);
+        CHECK(beyond - it == 3);
+
+        it = first;
+        CHECK(it == first);
+        while (it != s.end()) {
+            *it = 5;
+            ++it;
+        }
+
+        CHECK(it == beyond);
+        CHECK(it - beyond == 0);
+
+        for (const auto& n : s) {
+            CHECK(n == 5);
+        }
+    }
+}
+
+TEST(cbegin_cend)
+{
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
+
+        span<int>::const_iterator cit = s.cbegin();
+        span<int>::const_iterator cit2 = std::cbegin(s);
+        CHECK(cit == cit2);
+
+        cit = s.cend();
+        cit2 = std::cend(s);
+        CHECK(cit == cit2);
+    }
+
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
+
+        auto it = s.cbegin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 1);
+
+        auto beyond = s.cend();
+        CHECK(it != beyond);
+        CHECK_THROW(*beyond, fail_fast);
+
+        CHECK(beyond - first == 4);
+        CHECK(first - first == 0);
+        CHECK(beyond - beyond == 0);
+
+        ++it;
+        CHECK(it - first == 1);
+        CHECK(*it == 2);
+        CHECK(beyond - it == 3);
+
+        int last = 0;
+        it = first;
+        CHECK(it == first);
+        while (it != s.cend()) {
+            CHECK(*it == last + 1);
+
+            last = *it;
+            ++it;
+        }
+
+        CHECK(it == beyond);
+        CHECK(it - beyond == 0);
+    }
+}
+
+TEST(rbegin_rend)
+{
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
+
+        auto it = s.rbegin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 4);
+
+        auto beyond = s.rend();
+        CHECK(it != beyond);
+        CHECK_THROW(*beyond, fail_fast);
+
+        CHECK(beyond - first == 4);
+        CHECK(first - first == 0);
+        CHECK(beyond - beyond == 0);
+
+        ++it;
+        CHECK(it - first == 1);
+        CHECK(*it == 3);
+        *it = 22;
+        CHECK(*it == 22);
+        CHECK(beyond - it == 3);
+
+        it = first;
+        CHECK(it == first);
+        while (it != s.rend()) {
+            *it = 5;
+            ++it;
+        }
+
+        CHECK(it == beyond);
+        CHECK(it - beyond == 0);
+
+        for (const auto& n : s) {
+            CHECK(n == 5);
+        }
+    }
+}
+
+TEST(crbegin_crend)
+{
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
+
+        auto it = s.crbegin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 4);
+
+        auto beyond = s.crend();
+        CHECK(it != beyond);
+        CHECK_THROW(*beyond, fail_fast);
+
+        CHECK(beyond - first == 4);
+        CHECK(first - first == 0);
+        CHECK(beyond - beyond == 0);
+
+        ++it;
+        CHECK(it - first == 1);
+        CHECK(*it == 3);
+        CHECK(beyond - it == 3);
+
+        it = first;
+        CHECK(it == first);
+        int last = 5;
+        while (it != s.crend()) {
+            CHECK(*it == last - 1);
+            last = *it;
+
+            ++it;
+        }
+
+        CHECK(it == beyond);
+        CHECK(it - beyond == 0);
+    }
+}
+
+TEST(comparison_operators)
+{
+    {
+        span<int> s1 = nullptr;
+        span<int> s2 = nullptr;
+        CHECK(s1 == s2);
+        CHECK(!(s1 != s2));
+        CHECK(!(s1 < s2));
+        CHECK(s1 <= s2);
+        CHECK(!(s1 > s2));
+        CHECK(s1 >= s2);
+        CHECK(s2 == s1);
+        CHECK(!(s2 != s1));
+        CHECK(!(s2 < s1));
+        CHECK(s2 <= s1);
+        CHECK(!(s2 > s1));
+        CHECK(s2 >= s1);
+    }
+
+    {
+        int arr[] = {2, 1};
+        span<int> s1 = arr;
+        span<int> s2 = arr;
+
+        CHECK(s1 == s2);
+        CHECK(!(s1 != s2));
+        CHECK(!(s1 < s2));
+        CHECK(s1 <= s2);
+        CHECK(!(s1 > s2));
+        CHECK(s1 >= s2);
+        CHECK(s2 == s1);
+        CHECK(!(s2 != s1));
+        CHECK(!(s2 < s1));
+        CHECK(s2 <= s1);
+        CHECK(!(s2 > s1));
+        CHECK(s2 >= s1);
+    }
+
+    {
+        int arr[] = {2, 1}; // bigger
+
+        span<int> s1 = nullptr;
+        span<int> s2 = arr;
+
+        CHECK(s1 != s2);
+        CHECK(s2 != s1);
+        CHECK(!(s1 == s2));
+        CHECK(!(s2 == s1));
+        CHECK(s1 < s2);
+        CHECK(!(s2 < s1));
+        CHECK(s1 <= s2);
+        CHECK(!(s2 <= s1));
+        CHECK(s2 > s1);
+        CHECK(!(s1 > s2));
+        CHECK(s2 >= s1);
+        CHECK(!(s1 >= s2));
+    }
+
+    {
+        int arr1[] = {1, 2};
+        int arr2[] = {1, 2};
+        span<int> s1 = arr1;
+        span<int> s2 = arr2;
+
+        CHECK(s1 == s2);
+        CHECK(!(s1 != s2));
+        CHECK(!(s1 < s2));
+        CHECK(s1 <= s2);
+        CHECK(!(s1 > s2));
+        CHECK(s1 >= s2);
+        CHECK(s2 == s1);
+        CHECK(!(s2 != s1));
+        CHECK(!(s2 < s1));
+        CHECK(s2 <= s1);
+        CHECK(!(s2 > s1));
+        CHECK(s2 >= s1);
+    }
+
+    {
+        int arr[] = {1, 2, 3};
+
+        span<int> s1 = {&arr[0], 2}; // shorter
+        span<int> s2 = arr;          // longer
+
+        CHECK(s1 != s2);
+        CHECK(s2 != s1);
+        CHECK(!(s1 == s2));
+        CHECK(!(s2 == s1));
+        CHECK(s1 < s2);
+        CHECK(!(s2 < s1));
+        CHECK(s1 <= s2);
+        CHECK(!(s2 <= s1));
+        CHECK(s2 > s1);
+        CHECK(!(s1 > s2));
+        CHECK(s2 >= s1);
+        CHECK(!(s1 >= s2));
+    }
+
+    {
+        int arr1[] = {1, 2}; // smaller
+        int arr2[] = {2, 1}; // bigger
+
+        span<int> s1 = arr1;
+        span<int> s2 = arr2;
+
+        CHECK(s1 != s2);
+        CHECK(s2 != s1);
+        CHECK(!(s1 == s2));
+        CHECK(!(s2 == s1));
+        CHECK(s1 < s2);
+        CHECK(!(s2 < s1));
+        CHECK(s1 <= s2);
+        CHECK(!(s2 <= s1));
+        CHECK(s2 > s1);
+        CHECK(!(s1 > s2));
+        CHECK(s2 >= s1);
+        CHECK(!(s1 >= s2));
+    }
+}
+
+TEST(as_bytes)
+{
+    int a[] = {1, 2, 3, 4};
+
+    {
+        const span<const int> s = a;
+        CHECK(s.length() == 4);
+        const span<const byte> bs = as_bytes(s);
+        CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        CHECK(bs.length() == s.length_bytes());
+    }
+
+    {
+        span<int> s;
+        const auto bs = as_bytes(s);
+        CHECK(bs.length() == s.length());
+        CHECK(bs.length() == 0);
+        CHECK(bs.size_bytes() == 0);
+        CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        CHECK(bs.data() == nullptr);
+    }
+
+    {
+        span<int> s = a;
+        const auto bs = as_bytes(s);
+        CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        CHECK(bs.length() == s.length_bytes());
+    }
+}
+
+TEST(as_writeable_bytes)
+{
+    int a[] = {1, 2, 3, 4};
+
+    {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            // you should not be able to get writeable bytes for const objects
-            span<const int> s = a;
-            CHECK(s.length() == 4);
-            span<const byte> bs = as_writeable_bytes(s);
-            CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-            CHECK(bs.length() == s.length_bytes());
+        // you should not be able to get writeable bytes for const objects
+        span<const int> s = a;
+        CHECK(s.length() == 4);
+        span<const byte> bs = as_writeable_bytes(s);
+        CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        CHECK(bs.length() == s.length_bytes());
 #endif
-        }
-
-        {
-            span<int> s;
-            const auto bs = as_writeable_bytes(s);
-            CHECK(bs.length() == s.length());
-            CHECK(bs.length() == 0);
-            CHECK(bs.size_bytes() == 0);
-            CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-            CHECK(bs.data() == nullptr);
-        }
-
-        {
-            span<int> s = a;
-            const auto bs = as_writeable_bytes(s);
-            CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-            CHECK(bs.length() == s.length_bytes());
-        }
     }
 
-    TEST(fixed_size_conversions)
     {
-        int arr[] = {1, 2, 3, 4};
+        span<int> s;
+        const auto bs = as_writeable_bytes(s);
+        CHECK(bs.length() == s.length());
+        CHECK(bs.length() == 0);
+        CHECK(bs.size_bytes() == 0);
+        CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        CHECK(bs.data() == nullptr);
+    }
 
-        // converting to an span from an equal size array is ok
-        span<int, 4> s4 = arr;
-        CHECK(s4.length() == 4);
+    {
+        span<int> s = a;
+        const auto bs = as_writeable_bytes(s);
+        CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        CHECK(bs.length() == s.length_bytes());
+    }
+}
 
-        // converting to dynamic_range is always ok
-        {
-            span<int> s = s4;
-            CHECK(s.length() == s4.length());
-            static_cast<void>(s);
-        }
+TEST(fixed_size_conversions)
+{
+    int arr[] = {1, 2, 3, 4};
+
+    // converting to an span from an equal size array is ok
+    span<int, 4> s4 = arr;
+    CHECK(s4.length() == 4);
+
+    // converting to dynamic_range is always ok
+    {
+        span<int> s = s4;
+        CHECK(s.length() == s4.length());
+        static_cast<void>(s);
+    }
 
 // initialization or assignment to static span that REDUCES size is NOT ok
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            span<int, 2> s = arr;
-        }
-        {
-            span<int, 2> s2 = s4;
-            static_cast<void>(s2);
-        }
+    {
+        span<int, 2> s = arr;
+    }
+    {
+        span<int, 2> s2 = s4;
+        static_cast<void>(s2);
+    }
 #endif
 
-        // even when done dynamically
-        {
-            span<int> s = arr;
-            auto f = [&]() {
-                span<int, 2> s2 = s;
-                static_cast<void>(s2);
-            };
-            CHECK_THROW(f(), fail_fast);
-        }
-
-        // but doing so explicitly is ok
-
-        // you can convert statically
-        {
-            const span<int, 2> s2 = {arr, 2};
+    // even when done dynamically
+    {
+        span<int> s = arr;
+        auto f = [&]() {
+            span<int, 2> s2 = s;
             static_cast<void>(s2);
-        }
-        {
-            const span<int, 1> s1 = s4.first<1>();
-            static_cast<void>(s1);
-        }
+        };
+        CHECK_THROW(f(), fail_fast);
+    }
 
-        // ...or dynamically
-        {
-            // NB: implicit conversion to span<int,1> from span<int>
-            span<int, 1> s1 = s4.first(1);
-            static_cast<void>(s1);
-        }
+    // but doing so explicitly is ok
 
-        // initialization or assignment to static span that requires size INCREASE is not ok.
-        int arr2[2] = {1, 2};
+    // you can convert statically
+    {
+        const span<int, 2> s2 = {arr, 2};
+        static_cast<void>(s2);
+    }
+    {
+        const span<int, 1> s1 = s4.first<1>();
+        static_cast<void>(s1);
+    }
+
+    // ...or dynamically
+    {
+        // NB: implicit conversion to span<int,1> from span<int>
+        span<int, 1> s1 = s4.first(1);
+        static_cast<void>(s1);
+    }
+
+    // initialization or assignment to static span that requires size INCREASE is not ok.
+    int arr2[2] = {1, 2};
 
 #ifdef CONFIRM_COMPILATION_ERRORS
-        {
-            span<int, 4> s3 = arr2;
-        }
-        {
-            span<int, 2> s2 = arr2;
-            span<int, 4> s4a = s2;
-        }
+    {
+        span<int, 4> s3 = arr2;
+    }
+    {
+        span<int, 2> s2 = arr2;
+        span<int, 4> s4a = s2;
+    }
 #endif
-        {
-            auto f = [&]() {
-                span<int, 4> _s4 = {arr2, 2};
-                static_cast<void>(_s4);
-            };
-            CHECK_THROW(f(), fail_fast);
-        }
-
-        // this should fail - we are trying to assign a small dynamic span to a fixed_size larger one
-        span<int> av = arr2;
+    {
         auto f = [&]() {
-            span<int, 4> _s4 = av;
+            span<int, 4> _s4 = {arr2, 2};
             static_cast<void>(_s4);
         };
         CHECK_THROW(f(), fail_fast);
     }
 
-    TEST(interop_with_std_regex)
-    {
-        char lat[] = { '1', '2', '3', '4', '5', '6', 'E', 'F', 'G' };
-        span<char> s = lat;
-        const auto f_it = s.begin() + 7;
+    // this should fail - we are trying to assign a small dynamic span to a fixed_size larger one
+    span<int> av = arr2;
+    auto f = [&]() {
+        span<int, 4> _s4 = av;
+        static_cast<void>(_s4);
+    };
+    CHECK_THROW(f(), fail_fast);
+}
 
-        std::match_results<span<char>::iterator> match;
+TEST(interop_with_std_regex)
+{
+    char lat[] = {'1', '2', '3', '4', '5', '6', 'E', 'F', 'G'};
+    span<char> s = lat;
+    const auto f_it = s.begin() + 7;
 
-        std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
-        CHECK(match.ready());
-        CHECK(!match.empty());
-        CHECK(match[0].matched);
-        CHECK(match[0].first == s.begin());
-        CHECK(match[0].second == s.end());
+    std::match_results<span<char>::iterator> match;
 
-        std::regex_search(s.begin(), s.end(), match, std::regex("F"));
-        CHECK(match.ready());
-        CHECK(!match.empty());
-        CHECK(match[0].matched);
-        CHECK(match[0].first == f_it);
-        CHECK(match[0].second == (f_it + 1));
-    }
+    std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
+    CHECK(match.ready());
+    CHECK(!match.empty());
+    CHECK(match[0].matched);
+    CHECK(match[0].first == s.begin());
+    CHECK(match[0].second == s.end());
 
-    TEST(interop_with_gsl_at)
-    {
-        int arr[5] = {1, 2, 3, 4, 5};
-        span<int> s{arr};
-        CHECK(at(s,0) == 1 && at(s,1) == 2);
-    }
+    std::regex_search(s.begin(), s.end(), match, std::regex("F"));
+    CHECK(match.ready());
+    CHECK(!match.empty());
+    CHECK(match[0].matched);
+    CHECK(match[0].first == f_it);
+    CHECK(match[0].second == (f_it + 1));
+}
 
-    TEST(default_constructible)
-    {
-        CHECK((std::is_default_constructible<span<int>>::value));
-        CHECK((std::is_default_constructible<span<int, 0>>::value));
-        CHECK((!std::is_default_constructible<span<int, 42>>::value));
-    }
+TEST(interop_with_gsl_at)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
+    span<int> s{arr};
+    CHECK(at(s, 0) == 1 && at(s, 1) == 2);
+}
+
+TEST(default_constructible)
+{
+    CHECK((std::is_default_constructible<span<int>>::value));
+    CHECK((std::is_default_constructible<span<int, 0>>::value));
+    CHECK((!std::is_default_constructible<span<int, 42>>::value));
+}
 }
 
 int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/strided_span_tests.cpp
+++ b/tests/strided_span_tests.cpp
@@ -15,34 +15,39 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/multi_span>
 
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <list>
-#include <iostream>
-#include <memory>
-#include <map>
 
 using namespace std;
 using namespace gsl;
 
 namespace
 {
-    struct BaseClass {};
-    struct DerivedClass : BaseClass {};
+struct BaseClass
+{
+};
+struct DerivedClass : BaseClass
+{
+};
 }
 
 SUITE(strided_span_tests)
 {
-    TEST (span_section_test)
+    TEST(span_section_test)
     {
         int a[30][4][5];
 
         const auto av = as_multi_span(a);
         const auto sub = av.section({15, 0, 0}, gsl::index<3>{2, 2, 2});
         const auto subsub = sub.section({1, 0, 0}, gsl::index<3>{1, 1, 1});
-        (void)subsub;
+        (void) subsub;
     }
 
     TEST(span_section)
@@ -51,13 +56,13 @@ SUITE(strided_span_tests)
         std::iota(begin(data), end(data), 0);
         const multi_span<int, 5, 10> av = as_multi_span(multi_span<int>{data}, dim<5>(), dim<10>());
 
-        const strided_span<int, 2> av_section_1 = av.section({ 1, 2 }, { 3, 4 });
+        const strided_span<int, 2> av_section_1 = av.section({1, 2}, {3, 4});
         CHECK((av_section_1[{0, 0}] == 12));
         CHECK((av_section_1[{0, 1}] == 13));
         CHECK((av_section_1[{1, 0}] == 22));
         CHECK((av_section_1[{2, 3}] == 35));
 
-        const strided_span<int, 2> av_section_2 = av_section_1.section({ 1, 2 }, { 2,2 });
+        const strided_span<int, 2> av_section_2 = av_section_1.section({1, 2}, {2, 2});
         CHECK((av_section_2[{0, 0}] == 24));
         CHECK((av_section_2[{0, 1}] == 25));
         CHECK((av_section_2[{1, 0}] == 34));
@@ -67,188 +72,197 @@ SUITE(strided_span_tests)
     {
         // Check stride constructor
         {
-            int arr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            const int carr[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            int arr[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+            const int carr[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-            strided_span<int, 1> sav1{ arr, {{9}, {1}} }; // T -> T
-            CHECK(sav1.bounds().index_bounds() == index<1>{ 9 });
+            strided_span<int, 1> sav1{arr, {{9}, {1}}}; // T -> T
+            CHECK(sav1.bounds().index_bounds() == index<1>{9});
             CHECK(sav1.bounds().stride() == 1);
             CHECK(sav1[0] == 1 && sav1[8] == 9);
 
-
-            strided_span<const int, 1> sav2{ carr, {{ 4 }, { 2 }} }; // const T -> const T
-            CHECK(sav2.bounds().index_bounds() == index<1>{ 4 });
+            strided_span<const int, 1> sav2{carr, {{4}, {2}}}; // const T -> const T
+            CHECK(sav2.bounds().index_bounds() == index<1>{4});
             CHECK(sav2.bounds().strides() == index<1>{2});
             CHECK(sav2[0] == 1 && sav2[3] == 7);
 
-            strided_span<int, 2> sav3{ arr, {{ 2, 2 },{ 6, 2 }} }; // T -> const T
-            CHECK((sav3.bounds().index_bounds() == index<2>{ 2, 2 }));
-            CHECK((sav3.bounds().strides() == index<2>{ 6, 2 }));
+            strided_span<int, 2> sav3{arr, {{2, 2}, {6, 2}}}; // T -> const T
+            CHECK((sav3.bounds().index_bounds() == index<2>{2, 2}));
+            CHECK((sav3.bounds().strides() == index<2>{6, 2}));
             CHECK((sav3[{0, 0}] == 1 && sav3[{0, 1}] == 3 && sav3[{1, 0}] == 7));
         }
 
         // Check multi_span constructor
         {
-            int arr[] = { 1, 2 };
+            int arr[] = {1, 2};
 
             // From non-cv-qualified source
             {
                 const multi_span<int> src = arr;
 
-                strided_span<int, 1> sav{ src, {2, 1} };
-                CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav.bounds().strides() == index<1>{ 1 });
+                strided_span<int, 1> sav{src, {2, 1}};
+                CHECK(sav.bounds().index_bounds() == index<1>{2});
+                CHECK(sav.bounds().strides() == index<1>{1});
                 CHECK(sav[1] == 2);
 
 #if _MSC_VER > 1800
-                //strided_span<const int, 1> sav_c{ {src}, {2, 1} };
-                strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
+                // strided_span<const int, 1> sav_c{ {src}, {2, 1} };
+                strided_span<const int, 1> sav_c{multi_span<const int>{src},
+                                                 strided_bounds<1>{2, 1}};
 #else
-                strided_span<const int, 1> sav_c{ multi_span<const int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const int, 1> sav_c{multi_span<const int>{src},
+                                                 strided_bounds<1>{2, 1}};
 #endif
-                CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_c.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_c.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_c.bounds().strides() == index<1>{1});
                 CHECK(sav_c[1] == 2);
 
 #if _MSC_VER > 1800
-                strided_span<volatile int, 1> sav_v{ src, {2, 1} };
+                strided_span<volatile int, 1> sav_v{src, {2, 1}};
 #else
-                strided_span<volatile int, 1> sav_v{ multi_span<volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<volatile int, 1> sav_v{multi_span<volatile int>{src},
+                                                    strided_bounds<1>{2, 1}};
 #endif
-                CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_v.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_v.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_v.bounds().strides() == index<1>{1});
                 CHECK(sav_v[1] == 2);
 
 #if _MSC_VER > 1800
-                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<const volatile int, 1> sav_cv{src, {2, 1}};
 #else
-                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const volatile int, 1> sav_cv{multi_span<const volatile int>{src},
+                                                           strided_bounds<1>{2, 1}};
 #endif
-                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_cv.bounds().strides() == index<1>{1});
                 CHECK(sav_cv[1] == 2);
             }
 
             // From const-qualified source
             {
-                const multi_span<const int> src{ arr };
+                const multi_span<const int> src{arr};
 
-                strided_span<const int, 1> sav_c{ src, {2, 1} };
-                CHECK(sav_c.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_c.bounds().strides() == index<1>{ 1 });
+                strided_span<const int, 1> sav_c{src, {2, 1}};
+                CHECK(sav_c.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_c.bounds().strides() == index<1>{1});
                 CHECK(sav_c[1] == 2);
 
 #if _MSC_VER > 1800
-                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<const volatile int, 1> sav_cv{src, {2, 1}};
 #else
-                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const volatile int, 1> sav_cv{multi_span<const volatile int>{src},
+                                                           strided_bounds<1>{2, 1}};
 #endif
 
-                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_cv.bounds().strides() == index<1>{1});
                 CHECK(sav_cv[1] == 2);
             }
 
             // From volatile-qualified source
             {
-                const multi_span<volatile int> src{ arr };
+                const multi_span<volatile int> src{arr};
 
-                strided_span<volatile int, 1> sav_v{ src, {2, 1} };
-                CHECK(sav_v.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_v.bounds().strides() == index<1>{ 1 });
+                strided_span<volatile int, 1> sav_v{src, {2, 1}};
+                CHECK(sav_v.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_v.bounds().strides() == index<1>{1});
                 CHECK(sav_v[1] == 2);
 
 #if _MSC_VER > 1800
-                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
+                strided_span<const volatile int, 1> sav_cv{src, {2, 1}};
 #else
-                strided_span<const volatile int, 1> sav_cv{ multi_span<const volatile int>{src}, strided_bounds<1>{2, 1} };
+                strided_span<const volatile int, 1> sav_cv{multi_span<const volatile int>{src},
+                                                           strided_bounds<1>{2, 1}};
 #endif
-                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_cv.bounds().strides() == index<1>{1});
                 CHECK(sav_cv[1] == 2);
             }
 
             // From cv-qualified source
             {
-                const multi_span<const volatile int> src{ arr };
+                const multi_span<const volatile int> src{arr};
 
-                strided_span<const volatile int, 1> sav_cv{ src, {2, 1} };
-                CHECK(sav_cv.bounds().index_bounds() == index<1>{ 2 });
-                CHECK(sav_cv.bounds().strides() == index<1>{ 1 });
+                strided_span<const volatile int, 1> sav_cv{src, {2, 1}};
+                CHECK(sav_cv.bounds().index_bounds() == index<1>{2});
+                CHECK(sav_cv.bounds().strides() == index<1>{1});
                 CHECK(sav_cv[1] == 2);
             }
         }
 
         // Check const-casting constructor
         {
-            int arr[2] = { 4, 5 };
+            int arr[2] = {4, 5};
 
             const multi_span<int, 2> av(arr, 2);
-            multi_span<const int, 2> av2{ av };
+            multi_span<const int, 2> av2{av};
             CHECK(av2[1] == 5);
 
-            static_assert(std::is_convertible<const multi_span<int, 2>, multi_span<const int, 2>>::value, "ctor is not implicit!");
+            static_assert(
+                std::is_convertible<const multi_span<int, 2>, multi_span<const int, 2>>::value,
+                "ctor is not implicit!");
 
-            const strided_span<int, 1> src{ arr, {2, 1} };
-            strided_span<const int, 1> sav{ src };
-            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            const strided_span<int, 1> src{arr, {2, 1}};
+            strided_span<const int, 1> sav{src};
+            CHECK(sav.bounds().index_bounds() == index<1>{2});
             CHECK(sav.bounds().stride() == 1);
             CHECK(sav[1] == 5);
 
-            static_assert(std::is_convertible<const strided_span<int, 1>, strided_span<const int, 1>>::value, "ctor is not implicit!");
+            static_assert(
+                std::is_convertible<const strided_span<int, 1>, strided_span<const int, 1>>::value,
+                "ctor is not implicit!");
         }
 
         // Check copy constructor
         {
-            int arr1[2] = { 3, 4 };
-            const strided_span<int, 1> src1{ arr1, {2, 1} };
-            strided_span<int, 1> sav1{ src1 };
+            int arr1[2] = {3, 4};
+            const strided_span<int, 1> src1{arr1, {2, 1}};
+            strided_span<int, 1> sav1{src1};
 
-            CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
+            CHECK(sav1.bounds().index_bounds() == index<1>{2});
             CHECK(sav1.bounds().stride() == 1);
             CHECK(sav1[0] == 3);
 
-            int arr2[6] = { 1, 2, 3, 4, 5, 6 };
-            const strided_span<const int, 2> src2{ arr2, {{ 3, 2 }, { 2, 1 }} };
-            strided_span<const int, 2> sav2{ src2 };
-            CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
-            CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
+            int arr2[6] = {1, 2, 3, 4, 5, 6};
+            const strided_span<const int, 2> src2{arr2, {{3, 2}, {2, 1}}};
+            strided_span<const int, 2> sav2{src2};
+            CHECK((sav2.bounds().index_bounds() == index<2>{3, 2}));
+            CHECK((sav2.bounds().strides() == index<2>{2, 1}));
             CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
         }
 
         // Check const-casting assignment operator
         {
-            int arr1[2] = { 1, 2 };
-            int arr2[6] = { 3, 4, 5, 6, 7, 8 };
+            int arr1[2] = {1, 2};
+            int arr2[6] = {3, 4, 5, 6, 7, 8};
 
-            const strided_span<int, 1> src{ arr1, {{2}, {1}} };
-            strided_span<const int, 1> sav{ arr2, {{3}, {2}} };
+            const strided_span<int, 1> src{arr1, {{2}, {1}}};
+            strided_span<const int, 1> sav{arr2, {{3}, {2}}};
             strided_span<const int, 1>& sav_ref = (sav = src);
-            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
-            CHECK(sav.bounds().strides() == index<1>{ 1 });
+            CHECK(sav.bounds().index_bounds() == index<1>{2});
+            CHECK(sav.bounds().strides() == index<1>{1});
             CHECK(sav[0] == 1);
             CHECK(&sav_ref == &sav);
         }
 
         // Check copy assignment operator
         {
-            int arr1[2] = { 3, 4 };
-            int arr1b[1] = { 0 };
-            const strided_span<int, 1> src1{ arr1, {2, 1} };
-            strided_span<int, 1> sav1{ arr1b, {1, 1} };
+            int arr1[2] = {3, 4};
+            int arr1b[1] = {0};
+            const strided_span<int, 1> src1{arr1, {2, 1}};
+            strided_span<int, 1> sav1{arr1b, {1, 1}};
             strided_span<int, 1>& sav1_ref = (sav1 = src1);
-            CHECK(sav1.bounds().index_bounds() == index<1>{ 2 });
-            CHECK(sav1.bounds().strides() == index<1>{ 1 });
+            CHECK(sav1.bounds().index_bounds() == index<1>{2});
+            CHECK(sav1.bounds().strides() == index<1>{1});
             CHECK(sav1[0] == 3);
             CHECK(&sav1_ref == &sav1);
 
-            const int arr2[6] = { 1, 2, 3, 4, 5, 6 };
-            const int arr2b[1] = { 0 };
-            const strided_span<const int, 2> src2{ arr2, {{ 3, 2 },{ 2, 1 }} };
-            strided_span<const int, 2> sav2{ arr2b, {{ 1, 1 },{ 1, 1 }} };
+            const int arr2[6] = {1, 2, 3, 4, 5, 6};
+            const int arr2b[1] = {0};
+            const strided_span<const int, 2> src2{arr2, {{3, 2}, {2, 1}}};
+            strided_span<const int, 2> sav2{arr2b, {{1, 1}, {1, 1}}};
             strided_span<const int, 2>& sav2_ref = (sav2 = src2);
-            CHECK((sav2.bounds().index_bounds() == index<2>{ 3, 2 }));
-            CHECK((sav2.bounds().strides() == index<2>{ 2, 1 }));
+            CHECK((sav2.bounds().index_bounds() == index<2>{3, 2}));
+            CHECK((sav2.bounds().strides() == index<2>{2, 1}));
             CHECK((sav2[{0, 0}] == 1 && sav2[{2, 0}] == 5));
             CHECK(&sav2_ref == &sav2);
         }
@@ -258,13 +272,15 @@ SUITE(strided_span_tests)
     {
         std::vector<int> data(5 * 10);
         std::iota(begin(data), end(data), 0);
-        const multi_span<int, 5, 10> src = as_multi_span(multi_span<int>{data}, dim<5>(), dim<10>());
+        const multi_span<int, 5, 10> src =
+            as_multi_span(multi_span<int>{data}, dim<5>(), dim<10>());
 
-        const strided_span<int, 2> sav{ src, {{5, 10}, {10, 1}} };
+        const strided_span<int, 2> sav{src, {{5, 10}, {10, 1}}};
 #ifdef CONFIRM_COMPILATION_ERRORS
-        const strided_span<const int, 2> csav{ {src},{ { 5, 10 },{ 10, 1 } } };
+        const strided_span<const int, 2> csav{{src}, {{5, 10}, {10, 1}}};
 #endif
-        const strided_span<const int, 2> csav{ multi_span<const int, 5, 10>{ src }, { { 5, 10 },{ 10, 1 } } };
+        const strided_span<const int, 2> csav{multi_span<const int, 5, 10>{src},
+                                              {{5, 10}, {10, 1}}};
 
         strided_span<int, 1> sav_sl = sav[2];
         CHECK(sav_sl[0] == 20);
@@ -284,12 +300,8 @@ SUITE(strided_span_tests)
         // use cases, such as column-major multidimensional array
         // (aka. "FORTRAN" layout).
 
-        int cm_array[3 * 5] = {
-            1, 4, 7, 10, 13,
-            2, 5, 8, 11, 14,
-            3, 6, 9, 12, 15
-        };
-        strided_span<int, 2> cm_sav{ cm_array, {{ 5, 3 },{ 1, 5 }} };
+        int cm_array[3 * 5] = {1, 4, 7, 10, 13, 2, 5, 8, 11, 14, 3, 6, 9, 12, 15};
+        strided_span<int, 2> cm_sav{cm_array, {{5, 3}, {1, 5}}};
 
         // Accessing elements
         CHECK((cm_sav[{0, 0}] == 1));
@@ -305,7 +317,7 @@ SUITE(strided_span_tests)
         CHECK(cm_sl[2] == 12);
 
         // Section
-        strided_span<int, 2> cm_sec = cm_sav.section( { 2, 1 }, { 3, 2 });
+        strided_span<int, 2> cm_sec = cm_sav.section({2, 1}, {3, 2});
 
         CHECK((cm_sec.bounds().index_bounds() == index<2>{3, 2}));
         CHECK((cm_sec[{0, 0}] == 8));
@@ -316,7 +328,7 @@ SUITE(strided_span_tests)
 
     TEST(strided_span_bounds)
     {
-        int arr[] = { 0, 1, 2, 3 };
+        int arr[] = {0, 1, 2, 3};
         multi_span<int> av(arr);
 
         {
@@ -335,7 +347,7 @@ SUITE(strided_span_tests)
 
         {
             // zero stride
-            strided_span<int, 1> sav{ av,{ { 4 },{} } };
+            strided_span<int, 1> sav{av, {{4}, {}}};
             CHECK(sav[0] == 0);
             CHECK(sav[3] == 0);
             CHECK_THROW(sav[4], fail_fast);
@@ -343,36 +355,36 @@ SUITE(strided_span_tests)
 
         {
             // zero extent
-            strided_span<int, 1> sav{ av,{ {},{ 1 } } };
+            strided_span<int, 1> sav{av, {{}, {1}}};
             CHECK_THROW(sav[0], fail_fast);
         }
 
         {
             // zero extent and stride
-            strided_span<int, 1> sav{ av,{ {},{} } };
+            strided_span<int, 1> sav{av, {{}, {}}};
             CHECK_THROW(sav[0], fail_fast);
         }
 
         {
             // strided array ctor with matching strided bounds
-            strided_span<int, 1> sav{ arr,{ 4, 1 } };
-            CHECK(sav.bounds().index_bounds() == index<1>{ 4 });
+            strided_span<int, 1> sav{arr, {4, 1}};
+            CHECK(sav.bounds().index_bounds() == index<1>{4});
             CHECK(sav[3] == 3);
             CHECK_THROW(sav[4], fail_fast);
         }
 
         {
             // strided array ctor with smaller strided bounds
-            strided_span<int, 1> sav{ arr,{ 2, 1 } };
-            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            strided_span<int, 1> sav{arr, {2, 1}};
+            CHECK(sav.bounds().index_bounds() == index<1>{2});
             CHECK(sav[1] == 1);
             CHECK_THROW(sav[2], fail_fast);
         }
 
         {
             // strided array ctor with fitting irregular bounds
-            strided_span<int, 1> sav{ arr,{ 2, 3 } };
-            CHECK(sav.bounds().index_bounds() == index<1>{ 2 });
+            strided_span<int, 1> sav{arr, {2, 3}};
+            CHECK(sav.bounds().index_bounds() == index<1>{2});
             CHECK(sav[0] == 0);
             CHECK(sav[1] == 3);
             CHECK_THROW(sav[2], fail_fast);
@@ -380,68 +392,69 @@ SUITE(strided_span_tests)
 
         {
             // bounds cross data boundaries - from static arrays
-            CHECK_THROW((strided_span<int, 1> { arr, { 3, 2 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { arr, { 3, 3 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { arr, { 4, 5 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { arr, { 5, 1 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { arr, { 5, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{arr, {3, 2}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{arr, {3, 3}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{arr, {4, 5}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{arr, {5, 1}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{arr, {5, 5}}), fail_fast);
         }
 
         {
             // bounds cross data boundaries - from array view
-            CHECK_THROW((strided_span<int, 1> { av, { 3, 2 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av, { 3, 3 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av, { 4, 5 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av, { 5, 1 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av, { 5, 5 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av, {3, 2}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av, {3, 3}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av, {4, 5}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av, {5, 1}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av, {5, 5}}), fail_fast);
         }
 
         {
             // bounds cross data boundaries - from dynamic arrays
-            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 2 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 3, 3 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 4, 5 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 1 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av.data(), 4, { 5, 5 } }), fail_fast);
-            CHECK_THROW((strided_span<int, 1> { av.data(), 2, { 2, 2 } }), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 4, {3, 2}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 4, {3, 3}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 4, {4, 5}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 4, {5, 1}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 4, {5, 5}}), fail_fast);
+            CHECK_THROW((strided_span<int, 1>{av.data(), 2, {2, 2}}), fail_fast);
         }
 
 #ifdef CONFIRM_COMPILATION_ERRORS
         {
-            strided_span<int, 1> sav0{ av.data(), { 3, 2 } };
-            strided_span<int, 1> sav1{ arr, { 1 } };
-            strided_span<int, 1> sav2{ arr, { 1,1,1 } };
-            strided_span<int, 1> sav3{ av, { 1 } };
-            strided_span<int, 1> sav4{ av, { 1,1,1 } };
-            strided_span<int, 2> sav5{ av.as_multi_span(dim<2>(), dim<2>()), { 1 } };
-            strided_span<int, 2> sav6{ av.as_multi_span(dim<2>(), dim<2>()), { 1,1,1 } };
-            strided_span<int, 2> sav7{ av.as_multi_span(dim<2>(), dim<2>()), { { 1,1 },{ 1,1 },{ 1,1 } } };
+            strided_span<int, 1> sav0{av.data(), {3, 2}};
+            strided_span<int, 1> sav1{arr, {1}};
+            strided_span<int, 1> sav2{arr, {1, 1, 1}};
+            strided_span<int, 1> sav3{av, {1}};
+            strided_span<int, 1> sav4{av, {1, 1, 1}};
+            strided_span<int, 2> sav5{av.as_multi_span(dim<2>(), dim<2>()), {1}};
+            strided_span<int, 2> sav6{av.as_multi_span(dim<2>(), dim<2>()), {1, 1, 1}};
+            strided_span<int, 2> sav7{av.as_multi_span(dim<2>(), dim<2>()),
+                                      {{1, 1}, {1, 1}, {1, 1}}};
 
-            index<1> index{ 0, 1 };
-            strided_span<int, 1> sav8{ arr,{ 1,{ 1,1 } } };
-            strided_span<int, 1> sav9{ arr,{ { 1,1 },{ 1,1 } } };
-            strided_span<int, 1> sav10{ av,{ 1,{ 1,1 } } };
-            strided_span<int, 1> sav11{ av,{ { 1,1 },{ 1,1 } } };
-            strided_span<int, 2> sav12{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1 } } };
-            strided_span<int, 2> sav13{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1 },{ 1,1,1 } } };
-            strided_span<int, 2> sav14{ av.as_multi_span(dim<2>(), dim<2>()),{ { 1,1,1 },{ 1 } } };
+            index<1> index{0, 1};
+            strided_span<int, 1> sav8{arr, {1, {1, 1}}};
+            strided_span<int, 1> sav9{arr, {{1, 1}, {1, 1}}};
+            strided_span<int, 1> sav10{av, {1, {1, 1}}};
+            strided_span<int, 1> sav11{av, {{1, 1}, {1, 1}}};
+            strided_span<int, 2> sav12{av.as_multi_span(dim<2>(), dim<2>()), {{1}, {1}}};
+            strided_span<int, 2> sav13{av.as_multi_span(dim<2>(), dim<2>()), {{1}, {1, 1, 1}}};
+            strided_span<int, 2> sav14{av.as_multi_span(dim<2>(), dim<2>()), {{1, 1, 1}, {1}}};
         }
 #endif
     }
 
     TEST(strided_span_type_conversion)
     {
-        int arr[] = { 0, 1, 2, 3 };
+        int arr[] = {0, 1, 2, 3};
         multi_span<int> av(arr);
 
         {
-            strided_span<int, 1> sav{ av.data(), av.size(), { av.size() / 2, 2 } };
+            strided_span<int, 1> sav{av.data(), av.size(), {av.size() / 2, 2}};
 #ifdef CONFIRM_COMPILATION_ERRORS
             strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
 #endif
         }
         {
-            strided_span<int, 1> sav{ av, { av.size() / 2, 2 } };
+            strided_span<int, 1> sav{av, {av.size() / 2, 2}};
 #ifdef CONFIRM_COMPILATION_ERRORS
             strided_span<long, 1> lsav1 = sav.as_strided_span<long, 1>();
 #endif
@@ -451,8 +464,8 @@ SUITE(strided_span_tests)
 
         // retype strided array with regular strides - from raw data
         {
-            strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
-            strided_span<const byte, 2> sav2{ bytes.data(), bytes.size(), bounds };
+            strided_bounds<2> bounds{{2, bytes.size() / 4}, {bytes.size() / 2, 1}};
+            strided_span<const byte, 2> sav2{bytes.data(), bytes.size(), bounds};
             strided_span<const int, 2> sav3 = sav2.as_strided_span<const int>();
             CHECK(sav3[0][0] == 0);
             CHECK(sav3[1][0] == 2);
@@ -462,9 +475,10 @@ SUITE(strided_span_tests)
 
         // retype strided array with regular strides - from multi_span
         {
-            strided_bounds<2> bounds{ { 2, bytes.size() / 4 }, { bytes.size() / 2, 1 } };
-            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_bounds<2> bounds{{2, bytes.size() / 4}, {bytes.size() / 2, 1}};
+            multi_span<const byte, 2, dynamic_range> bytes2 =
+                as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{bytes2, bounds};
             strided_span<int, 2> sav3 = sav2.as_strided_span<int>();
             CHECK(sav3[0][0] == 0);
             CHECK(sav3[1][0] == 2);
@@ -474,47 +488,53 @@ SUITE(strided_span_tests)
 
         // retype strided array with not enough elements - last dimension of the array is too small
         {
-            strided_bounds<2> bounds{ { 4,2 },{ 4, 1 } };
-            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_bounds<2> bounds{{4, 2}, {4, 1}};
+            multi_span<const byte, 2, dynamic_range> bytes2 =
+                as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{bytes2, bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
 
         // retype strided array with not enough elements - strides are too small
         {
-            strided_bounds<2> bounds{ { 4,2 },{ 2, 1 } };
-            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_bounds<2> bounds{{4, 2}, {2, 1}};
+            multi_span<const byte, 2, dynamic_range> bytes2 =
+                as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{bytes2, bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
 
-        // retype strided array with not enough elements - last dimension does not divide by the new typesize
+        // retype strided array with not enough elements - last dimension does not divide by the new
+        // typesize
         {
-            strided_bounds<2> bounds{ { 2,6 },{ 4, 1 } };
-            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_bounds<2> bounds{{2, 6}, {4, 1}};
+            multi_span<const byte, 2, dynamic_range> bytes2 =
+                as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{bytes2, bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
 
-        // retype strided array with not enough elements - strides does not divide by the new typesize
+        // retype strided array with not enough elements - strides does not divide by the new
+        // typesize
         {
-            strided_bounds<2> bounds{ { 2, 1 },{ 6, 1 } };
-            multi_span<const byte, 2, dynamic_range> bytes2 = as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
-            strided_span<const byte, 2> sav2{ bytes2, bounds };
+            strided_bounds<2> bounds{{2, 1}, {6, 1}};
+            multi_span<const byte, 2, dynamic_range> bytes2 =
+                as_multi_span(bytes, dim<2>(), dim(bytes.size() / 2));
+            strided_span<const byte, 2> sav2{bytes2, bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
 
         // retype strided array with irregular strides - from raw data
         {
-            strided_bounds<1> bounds{ bytes.size() / 2, 2 };
-            strided_span<const byte, 1> sav2{ bytes.data(), bytes.size(), bounds };
+            strided_bounds<1> bounds{bytes.size() / 2, 2};
+            strided_span<const byte, 1> sav2{bytes.data(), bytes.size(), bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
 
         // retype strided array with irregular strides - from multi_span
         {
-            strided_bounds<1> bounds{ bytes.size() / 2, 2 };
-            strided_span<const byte, 1> sav2{ bytes, bounds };
+            strided_bounds<1> bounds{bytes.size() / 2, 2};
+            strided_span<const byte, 1> sav2{bytes, bounds};
             CHECK_THROW(sav2.as_strided_span<int>(), fail_fast);
         }
     }
@@ -523,31 +543,29 @@ SUITE(strided_span_tests)
     {
         {
             multi_span<int, 0> empty_av(nullptr);
-            strided_span<int, 1> empty_sav{ empty_av, { 0, 1 } };
+            strided_span<int, 1> empty_sav{empty_av, {0, 1}};
 
-            CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
+            CHECK(empty_sav.bounds().index_bounds() == index<1>{0});
             CHECK_THROW(empty_sav[0], fail_fast);
             CHECK_THROW(empty_sav.begin()[0], fail_fast);
             CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
 
-            for (const auto& v : empty_sav)
-            {
-                (void)v;
+            for (const auto& v : empty_sav) {
+                (void) v;
                 CHECK(false);
             }
         }
 
         {
-            strided_span<int, 1> empty_sav{ nullptr, 0, { 0, 1 } };
+            strided_span<int, 1> empty_sav{nullptr, 0, {0, 1}};
 
-            CHECK(empty_sav.bounds().index_bounds() == index<1>{ 0 });
+            CHECK(empty_sav.bounds().index_bounds() == index<1>{0});
             CHECK_THROW(empty_sav[0], fail_fast);
             CHECK_THROW(empty_sav.begin()[0], fail_fast);
             CHECK_THROW(empty_sav.cbegin()[0], fail_fast);
 
-            for (const auto& v : empty_sav)
-            {
-                (void)v;
+            for (const auto& v : empty_sav) {
+                (void) v;
                 CHECK(false);
             }
         }
@@ -561,20 +579,18 @@ SUITE(strided_span_tests)
 #if _MSC_VER > 1800
         auto bounds = strided_bounds<1>({length}, {2});
 #else
-        auto bounds = strided_bounds<1>(index<1>{ length }, index<1>{ 2 });
+        auto bounds = strided_bounds<1>(index<1>{length}, index<1>{2});
 #endif
         strided_span<int, 1> strided(&av.data()[1], av.size() - 1, bounds);
 
         CHECK(strided.size() == length);
         CHECK(strided.bounds().index_bounds()[0] == length);
-        for (auto i = 0; i < strided.size(); ++i)
-        {
+        for (auto i = 0; i < strided.size(); ++i) {
             CHECK(strided[i] == av[2 * i + 1]);
         }
 
         int idx = 0;
-        for (auto num : strided)
-        {
+        for (auto num : strided) {
             CHECK(num == av[2 * idx + 1]);
             idx++;
         }
@@ -582,7 +598,7 @@ SUITE(strided_span_tests)
 
     TEST(strided_span_section_iteration)
     {
-        int arr[8] = {4,0,5,1,6,2,7,3};
+        int arr[8] = {4, 0, 5, 1, 6, 2, 7, 3};
 
         // static bounds
         {
@@ -600,8 +616,7 @@ SUITE(strided_span_tests)
     TEST(dynamic_strided_span_section_iteration)
     {
         auto arr = new int[8];
-        for (int i = 0; i < 4; ++i)
-        {
+        for (int i = 0; i < 4; ++i) {
             arr[2 * i] = 4 + i;
             arr[2 * i + 1] = i;
         }
@@ -614,29 +629,25 @@ SUITE(strided_span_tests)
 
     void iterate_second_slice(multi_span<int, dynamic_range, dynamic_range, dynamic_range> av)
     {
-        const int expected[6] = {2,3,10,11,18,19};
-        auto section = av.section({0,1,0}, {3,1,2});
+        const int expected[6] = {2, 3, 10, 11, 18, 19};
+        auto section = av.section({0, 1, 0}, {3, 1, 2});
 
-        for (auto i = 0; i < section.extent<0>(); ++i)
-        {
+        for (auto i = 0; i < section.extent<0>(); ++i) {
             for (auto j = 0; j < section.extent<1>(); ++j)
-                for (auto k = 0; k < section.extent<2>(); ++k)
-                {
-                    auto idx = index<3>{i,j,k}; // avoid braces in the CHECK macro
+                for (auto k = 0; k < section.extent<2>(); ++k) {
+                    auto idx = index<3>{i, j, k}; // avoid braces in the CHECK macro
                     CHECK(section[idx] == expected[2 * i + 2 * j + k]);
                 }
         }
 
-        for (auto i = 0; i < section.extent<0>(); ++i)
-        {
+        for (auto i = 0; i < section.extent<0>(); ++i) {
             for (auto j = 0; j < section.extent<1>(); ++j)
                 for (auto k = 0; k < section.extent<2>(); ++k)
                     CHECK(section[i][j][k] == expected[2 * i + 2 * j + k]);
         }
 
         int i = 0;
-        for (const auto num : section)
-        {
+        for (const auto num : section) {
             CHECK(num == expected[i]);
             i++;
         }
@@ -645,11 +656,9 @@ SUITE(strided_span_tests)
     TEST(strided_span_section_iteration_3d)
     {
         int arr[3][4][2]{};
-        for (auto i = 0; i < 3; ++i)
-        {
+        for (auto i = 0; i < 3; ++i) {
             for (auto j = 0; j < 4; ++j)
-                for (auto k = 0; k < 2; ++k)
-                    arr[i][j][k] = 8 * i + 2 * j + k;
+                for (auto k = 0; k < 2; ++k) arr[i][j][k] = 8 * i + 2 * j + k;
         }
 
         {
@@ -664,8 +673,7 @@ SUITE(strided_span_tests)
         const auto size = height * width;
 
         auto arr = new int[static_cast<std::size_t>(size)];
-        for (auto i = 0; i < size; ++i)
-        {
+        for (auto i = 0; i < size; ++i) {
             arr[i] = i;
         }
 
@@ -695,9 +703,14 @@ SUITE(strided_span_tests)
     {
         // get an multi_span of 'c' values from the list of X's
 
-        struct X { int a; int b; int c; };
+        struct X
+        {
+            int a;
+            int b;
+            int c;
+        };
 
-        X arr[4] = {{0,1,2},{3,4,5},{6,7,8},{9,10,11}};
+        X arr[4] = {{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}};
 
         int s = sizeof(int) / sizeof(byte);
         auto d2 = 3 * s;
@@ -710,9 +723,11 @@ SUITE(strided_span_tests)
         CHECK(av.bounds().index_bounds()[1] == 12);
 
         // get the last 4 columns
-        auto section = av.section({0, 2 * s}, {4, s}); // { { arr[0].c[0], arr[0].c[1], arr[0].c[2], arr[0].c[3] } , { arr[1].c[0], ... } , ... }
+        auto section = av.section({0, 2 * s}, {4, s}); // { { arr[0].c[0], arr[0].c[1], arr[0].c[2],
+                                                       // arr[0].c[3] } , { arr[1].c[0], ... } , ...
+                                                       // }
 
-                                                       // convert to array 4x1 array of integers
+        // convert to array 4x1 array of integers
         auto cs = section.as_strided_span<int>(); // { { arr[0].c }, {arr[1].c } , ... }
 
         CHECK(cs.bounds().index_bounds()[0] == 4);
@@ -720,9 +735,8 @@ SUITE(strided_span_tests)
 
         // transpose to 1x4 array
         strided_bounds<2> reverse_bounds{
-            {cs.bounds().index_bounds()[1] , cs.bounds().index_bounds()[0]},
-            {cs.bounds().strides()[1], cs.bounds().strides()[0]}
-        };
+            {cs.bounds().index_bounds()[1], cs.bounds().index_bounds()[0]},
+            {cs.bounds().strides()[1], cs.bounds().strides()[0]}};
 
         strided_span<int, 2> transposed{cs.data(), cs.bounds().total_size(), reverse_bounds};
 
@@ -733,16 +747,11 @@ SUITE(strided_span_tests)
         CHECK_THROW(result.bounds().index_bounds()[1], fail_fast);
 
         int i = 0;
-        for (auto& num : result)
-        {
+        for (auto& num : result) {
             CHECK(num == arr[i].c);
             i++;
         }
-
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -15,15 +15,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
-#include <cstdlib>
-#include <gsl/string_span>
+
 #include <gsl/gsl> //owner
-#include <vector>
+#include <gsl/string_span>
+
+#include <cstdlib>
 #include <map>
+#include <vector>
 
 using namespace std;
 using namespace gsl;
-
 
 SUITE(string_span_tests)
 {
@@ -48,7 +49,7 @@ SUITE(string_span_tests)
     TEST(TestConstructFromStdVector)
     {
         std::vector<char> vec(5, 'h');
-        string_span<> v {vec};
+        string_span<> v{vec};
         CHECK(v.length() == static_cast<string_span<>::index_type>(vec.size()));
     }
 
@@ -96,7 +97,7 @@ SUITE(string_span_tests)
     {
         char stack_string[] = "Hello";
         cstring_span<> v = ensure_z(stack_string);
-        (void)v;
+        (void) v;
 #ifdef CONFIRM_COMPILATION_ERRORS
         string_span<> v2 = v;
         string_span<> v3 = "Hello";
@@ -117,12 +118,13 @@ SUITE(string_span_tests)
 
     TEST(TestToBasicString)
     {
-        auto s = gsl::to_basic_string<char,std::char_traits<char>,::std::allocator<char>>(cstring_span<>{});
+        auto s = gsl::to_basic_string<char, std::char_traits<char>, ::std::allocator<char>>(
+            cstring_span<>{});
         CHECK(s.length() == 0);
 
         char stack_string[] = "Hello";
         cstring_span<> v = ensure_z(stack_string);
-        auto s2 = gsl::to_basic_string<char,std::char_traits<char>,::std::allocator<char>>(v);
+        auto s2 = gsl::to_basic_string<char, std::char_traits<char>, ::std::allocator<char>>(v);
         CHECK(static_cast<cstring_span<>::index_type>(s2.length()) == v.length());
         CHECK(s2.length() == 5);
     }
@@ -150,12 +152,12 @@ SUITE(string_span_tests)
         {
             cstring_span<> span = "Hello";
 
-            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar[] = {'H', 'e', 'l', 'l', 'o'};
             const char ar1[] = "Hello";
             const char ar2[10] = "Hello";
             const char* ptr = "Hello";
             const std::string str = "Hello";
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             gsl::span<const char> sp = ensure_z("Hello");
 
             // comparison to  literal
@@ -187,7 +189,7 @@ SUITE(string_span_tests)
         }
 
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
 
             string_span<> span = ar;
 
@@ -195,7 +197,7 @@ SUITE(string_span_tests)
             char ar2[10] = "Hello";
             char* ptr = ar;
             std::string str = "Hello";
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             gsl::span<char> sp = ensure_z(ar1);
 
             // comparison to static array with no null termination
@@ -223,13 +225,12 @@ SUITE(string_span_tests)
             CHECK(span == span);
         }
 
-
         {
-            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar[] = {'H', 'e', 'l', 'l', 'o'};
             const char ar1[] = "Hello";
             const char ar2[10] = "Hello";
             const std::string str = "Hello";
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const gsl::span<const char> sp = ensure_z("Hello");
 
             cstring_span<> span = "Hello";
@@ -261,13 +262,13 @@ SUITE(string_span_tests)
 
             // const span, non-const other type
 
-            char _ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char _ar[] = {'H', 'e', 'l', 'l', 'o'};
             char _ar1[] = "Hello";
             char _ar2[10] = "Hello";
             char* _ptr = _ar;
             std::string _str = "Hello";
-            std::vector<char> _vec = { 'H', 'e', 'l', 'l', 'o' };
-            gsl::span<char> _sp{ _ar, 5 };
+            std::vector<char> _vec = {'H', 'e', 'l', 'l', 'o'};
+            gsl::span<char> _sp{_ar, 5};
 
             CHECK(span == _ar);
             CHECK(span == _ar1);
@@ -289,7 +290,7 @@ SUITE(string_span_tests)
             CHECK(_vec == span);
             CHECK(_sp == span);
 
-            string_span<> _span{ _ptr, 5 };
+            string_span<> _span{_ptr, 5};
 
             // non-const span, non-const other type
 
@@ -344,7 +345,7 @@ SUITE(string_span_tests)
         }
 
         {
-            std::vector<char> str1 = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> str1 = {'H', 'e', 'l', 'l', 'o'};
             cstring_span<> span1 = str1;
             std::vector<char> str2 = std::move(str1);
             cstring_span<> span2 = str2;
@@ -359,12 +360,12 @@ SUITE(string_span_tests)
         {
             cstring_span<> span = "Hello";
 
-            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar[] = {'H', 'e', 'l', 'l', 'o'};
             const char ar1[] = "Hello";
             const char ar2[10] = "Hello";
             const char* ptr = "Hello";
             const std::string str = "Hello";
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
 
             // comparison to  literal
             CHECK(span < cstring_span<>("Helloo"));
@@ -390,7 +391,7 @@ SUITE(string_span_tests)
         }
 
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
 
             string_span<> span = ar;
 
@@ -401,8 +402,7 @@ SUITE(string_span_tests)
             char ar2[10] = "Hello";
             char* ptr = ar;
             std::string str = "Hello";
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
-
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
 
             // comparison to static array with no null termination
             CHECK(span <= string_span<>(ar));
@@ -466,7 +466,7 @@ SUITE(string_span_tests)
             CHECK(span.length() == 6);
         }
 
-        // from const span of a final extent to non-const string_span
+// from const span of a final extent to non-const string_span
 #ifdef CONFIRM_COMPILATION_ERRORS
         {
             span<const char, 6> sp = "Hello";
@@ -475,7 +475,7 @@ SUITE(string_span_tests)
         }
 #endif
 
-        // from string temporary
+// from string temporary
 #ifdef CONFIRM_COMPILATION_ERRORS
         {
             cstring_span<> span = std::string("Hello");
@@ -502,14 +502,14 @@ SUITE(string_span_tests)
 
         // from const static array
         {
-            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar[] = {'H', 'e', 'l', 'l', 'o'};
             cstring_span<> span = ar;
             CHECK(span.length() == 5);
         }
 
         // from non-const static array
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
             cstring_span<> span = ar;
             CHECK(span.length() == 5);
         }
@@ -517,37 +517,37 @@ SUITE(string_span_tests)
         // from const ptr and length
         {
             const char* ptr = "Hello";
-            cstring_span<> span{ ptr, 5 };
+            cstring_span<> span{ptr, 5};
             CHECK(span.length() == 5);
         }
 
         // from const ptr and length, include 0
         {
             const char* ptr = "Hello";
-            cstring_span<> span{ ptr, 6 };
+            cstring_span<> span{ptr, 6};
             CHECK(span.length() == 6);
         }
 
         // from const ptr and length, 0 inside
         {
             const char* ptr = "He\0lo";
-            cstring_span<> span{ ptr, 5 };
+            cstring_span<> span{ptr, 5};
             CHECK(span.length() == 5);
         }
 
         // from non-const ptr and length
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
             char* ptr = ar;
-            cstring_span<> span{ ptr, 5 };
+            cstring_span<> span{ptr, 5};
             CHECK(span.length() == 5);
         }
 
         // from non-const ptr and length, 0 inside
         {
-            char ar[] = { 'H', 'e', '\0', 'l', 'o' };
+            char ar[] = {'H', 'e', '\0', 'l', 'o'};
             char* ptr = ar;
-            cstring_span<> span{ ptr, 5 };
+            cstring_span<> span{ptr, 5};
             CHECK(span.length() == 5);
         }
 
@@ -567,21 +567,21 @@ SUITE(string_span_tests)
 
         // from const vector
         {
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const cstring_span<> span = vec;
             CHECK(span.length() == 5);
         }
 
         // from non-const vector
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const cstring_span<> span = vec;
             CHECK(span.length() == 5);
         }
 
         // from const span
         {
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const span<const char> inner = vec;
             const cstring_span<> span = inner;
             CHECK(span.length() == 5);
@@ -589,7 +589,7 @@ SUITE(string_span_tests)
 
         // from non-const span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const span<char> inner = vec;
             const cstring_span<> span = inner;
             CHECK(span.length() == 5);
@@ -597,7 +597,7 @@ SUITE(string_span_tests)
 
         // from const string_span
         {
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const cstring_span<> tmp = vec;
             const cstring_span<> span = tmp;
             CHECK(span.length() == 5);
@@ -605,7 +605,7 @@ SUITE(string_span_tests)
 
         // from non-const string_span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> tmp = vec;
             cstring_span<> span = tmp;
             CHECK(span.length() == 5);
@@ -623,7 +623,7 @@ SUITE(string_span_tests)
         // from const static array
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            const char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            const char ar[] = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = ar;
             CHECK(span.length() == 5);
 #endif
@@ -631,7 +631,7 @@ SUITE(string_span_tests)
 
         // from non-const static array
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = ar;
             CHECK(span.length() == 5);
         }
@@ -640,16 +640,16 @@ SUITE(string_span_tests)
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             const char* ptr = "Hello";
-            string_span<> span{ ptr, 5 };
+            string_span<> span{ptr, 5};
             CHECK(span.length() == 5);
 #endif
         }
 
         // from non-const ptr and length
         {
-            char ar[] = { 'H', 'e', 'l', 'l', 'o' };
+            char ar[] = {'H', 'e', 'l', 'l', 'o'};
             char* ptr = ar;
-            string_span<> span{ ptr, 5 };
+            string_span<> span{ptr, 5};
             CHECK(span.length() == 5);
         }
 
@@ -672,7 +672,7 @@ SUITE(string_span_tests)
         // from const vector
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = vec;
             CHECK(span.length() == 5);
 #endif
@@ -680,7 +680,7 @@ SUITE(string_span_tests)
 
         // from non-const vector
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = vec;
             CHECK(span.length() == 5);
         }
@@ -688,7 +688,7 @@ SUITE(string_span_tests)
         // from const span
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const span<const char> inner = vec;
             string_span<> span = inner;
             CHECK(span.length() == 5);
@@ -697,7 +697,7 @@ SUITE(string_span_tests)
 
         // from non-const span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             span<char> inner = vec;
             string_span<> span = inner;
             CHECK(span.length() == 5);
@@ -706,7 +706,7 @@ SUITE(string_span_tests)
         // from non-const span of non-const data from const vector
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const span<char> inner = vec;
             string_span<> span = inner;
             CHECK(span.length() == 5);
@@ -716,7 +716,7 @@ SUITE(string_span_tests)
         // from const string_span
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             cstring_span<> tmp = vec;
             string_span<> span = tmp;
             CHECK(span.length() == 5);
@@ -725,7 +725,7 @@ SUITE(string_span_tests)
 
         // from non-const string_span
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const string_span<> tmp = vec;
             const string_span<> span = tmp;
             CHECK(span.length() == 5);
@@ -734,7 +734,7 @@ SUITE(string_span_tests)
         // from non-const string_span from const vector
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            const std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            const std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> tmp = vec;
             string_span<> span = tmp;
             CHECK(span.length() == 5);
@@ -743,24 +743,29 @@ SUITE(string_span_tests)
 
         // from const string_span of non-const data
         {
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             const string_span<> tmp = vec;
             const string_span<> span = tmp;
             CHECK(span.length() == 5);
         }
     }
 
-    template<typename T>
-    T move_wrapper(T&& t)
+    template <typename T>
+    T move_wrapper(T && t)
     {
         return std::move(t);
     }
 
     template <class T>
-    T create() { return T{}; }
+    T create()
+    {
+        return T{};
+    }
 
     template <class T>
-    void use(basic_string_span<T, gsl::dynamic_extent>) {}
+    void use(basic_string_span<T, gsl::dynamic_extent>)
+    {
+    }
 
     TEST(MoveConstructors)
     {
@@ -817,14 +822,14 @@ SUITE(string_span_tests)
         // move container
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = std::move(vec);
             CHECK(span.length() == 5);
 #endif
         }
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
-            std::vector<char> vec = { 'H', 'e', 'l', 'l', 'o' };
+            std::vector<char> vec = {'H', 'e', 'l', 'l', 'o'};
             string_span<> span = move_wrapper<std::vector<char>>(std::move(vec));
             CHECK(span.length() == 5);
 #endif
@@ -840,7 +845,7 @@ SUITE(string_span_tests)
     {
 #ifdef CONFIRM_COMPILATION_ERRORS
         cstring_span<> span = "Hello";
-        cwstring_span<> wspan{ span };
+        cwstring_span<> wspan{span};
         CHECK(wspan.length() == 5);
 #endif
     }
@@ -850,8 +855,7 @@ SUITE(string_span_tests)
         Expects(span.size() > 1);
 
         int last = 0;
-        if (span.size() > 4)
-        {
+        if (span.size() > 4) {
             span[0] = 't';
             span[1] = 'm';
             span[2] = 'p';
@@ -860,7 +864,7 @@ SUITE(string_span_tests)
         span[last] = '\0';
 
         auto ret = span.subspan(0, 4);
-        return{ ret };
+        return {ret};
     }
 
     TEST(zstring)
@@ -871,7 +875,7 @@ SUITE(string_span_tests)
             char buf[1];
             buf[0] = '\0';
 
-            zstring_span<> zspan({ buf, 1 });
+            zstring_span<> zspan({buf, 1});
 
             CHECK(strlen(zspan.assume_z()) == 0);
             CHECK(zspan.as_string_span().size() == 0);
@@ -883,7 +887,7 @@ SUITE(string_span_tests)
             char buf[1];
             buf[0] = 'a';
 
-            auto workaround_macro = [&]() { zstring_span<> zspan({ buf, 1 }); };
+            auto workaround_macro = [&]() { zstring_span<> zspan({buf, 1}); };
             CHECK_THROW(workaround_macro(), fail_fast);
         }
 
@@ -891,15 +895,13 @@ SUITE(string_span_tests)
         {
             char buf[10];
 
-            auto name = CreateTempName({ buf, 10 });
-            if (!name.empty())
-            {
+            auto name = CreateTempName({buf, 10});
+            if (!name.empty()) {
                 czstring<> str = name.assume_z();
                 CHECK(strlen(str) == 3);
-                CHECK(*(str+3) == '\0');
+                CHECK(*(str + 3) == '\0');
             }
         }
-
     }
 
     cwzstring_span<> CreateTempNameW(wstring_span<> span)
@@ -907,8 +909,7 @@ SUITE(string_span_tests)
         Expects(span.size() > 1);
 
         int last = 0;
-        if (span.size() > 4)
-        {
+        if (span.size() > 4) {
             span[0] = L't';
             span[1] = L'm';
             span[2] = L'p';
@@ -917,7 +918,7 @@ SUITE(string_span_tests)
         span[last] = L'\0';
 
         auto ret = span.subspan(0, 4);
-        return{ ret };
+        return {ret};
     }
 
     TEST(wzstring)
@@ -928,7 +929,7 @@ SUITE(string_span_tests)
             wchar_t buf[1];
             buf[0] = L'\0';
 
-            wzstring_span<> zspan({ buf, 1 });
+            wzstring_span<> zspan({buf, 1});
 
             CHECK(wcsnlen(zspan.assume_z(), 1) == 0);
             CHECK(zspan.as_string_span().size() == 0);
@@ -940,7 +941,7 @@ SUITE(string_span_tests)
             wchar_t buf[1];
             buf[0] = L'a';
 
-            const auto workaround_macro = [&]() { wzstring_span<> zspan({ buf, 1 }); };
+            const auto workaround_macro = [&]() { wzstring_span<> zspan({buf, 1}); };
             CHECK_THROW(workaround_macro(), fail_fast);
         }
 
@@ -948,9 +949,8 @@ SUITE(string_span_tests)
         {
             wchar_t buf[10];
 
-            const auto name = CreateTempNameW({ buf, 10 });
-            if (!name.empty())
-            {
+            const auto name = CreateTempNameW({buf, 10});
+            if (!name.empty()) {
                 cwzstring<> str = name.assume_z();
                 CHECK(wcsnlen(str, 10) == 3);
                 CHECK(*(str + 3) == L'\0');
@@ -960,13 +960,10 @@ SUITE(string_span_tests)
 
     TEST(Issue305)
     {
-        std::map<gsl::cstring_span<>, int> foo = { { "foo", 0 },{ "bar", 1 } };
+        std::map<gsl::cstring_span<>, int> foo = {{"foo", 0}, {"bar", 1}};
         CHECK(foo["foo"] == 0);
         CHECK(foo["bar"] == 1);
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -15,23 +15,22 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <UnitTest++/UnitTest++.h>
+
 #include <gsl/gsl>
+
 #include <functional>
 
 using namespace gsl;
 
 SUITE(utils_tests)
 {
-    void f(int& i)
-    {
-        i += 1;
-    }
+    void f(int& i) { i += 1; }
 
     TEST(finally_lambda)
     {
         int i = 0;
         {
-            auto _ = finally([&]() {f(i);});
+            auto _ = finally([&]() { f(i); });
             CHECK(i == 0);
         }
         CHECK(i == 1);
@@ -41,7 +40,7 @@ SUITE(utils_tests)
     {
         int i = 0;
         {
-            auto _1 = finally([&]() {f(i);});
+            auto _1 = finally([&]() { f(i); });
             {
                 auto _2 = std::move(_1);
                 CHECK(i == 0);
@@ -113,7 +112,4 @@ SUITE(utils_tests)
     }
 }
 
-int main(int, const char *[])
-{
-    return UnitTest::RunAllTests();
-}
+int main(int, const char* []) { return UnitTest::RunAllTests(); }


### PR DESCRIPTION
Project files were not following the clang-format style. For people
using IDEs were clang-format is always run after a save this would
cause unwanted changes.

This commit only applies "clang-format -i" to files.

See #486