### PR TITLE
Fixes conflict with max macro from windows.h

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -76,12 +76,6 @@ namespace gsl
 */
 namespace details
 {
-    template <typename SizeType>
-    struct SizeTypeTraits
-    {
-        static const SizeType max_value = (std::numeric_limits<SizeType>::max)();
-    };
-
     template <typename... Ts>
     class are_integral : public std::integral_constant<bool, true>
     {

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -79,7 +79,7 @@ namespace details
     template <typename SizeType>
     struct SizeTypeTraits
     {
-        static const SizeType max_value = std::numeric_limits<SizeType>::max();
+        static const SizeType max_value = (std::numeric_limits<SizeType>::max)();
     };
 
     template <typename... Ts>


### PR DESCRIPTION
The fix for conflict between std::numeric_limits<T>::max and 'max' macro defined in <windows.h>.

The following code cound reproduce compilation warning C4003.

```c++
#include <windows.h>
#include <gsl/gsl>

int main()
{
}
```
```
c:\sdk\gsl\include\gsl\multi_span(82): warning C4003: not enough actual parameters for macro 'max'
```
It fixes the following issues #291, #253, #275 without need to `#define NOMINMAX` before including windows.h

BTW, the gsl::detail::SizeTypeTraits structure from `multi_span` that caused this warning is not used anywhere in GSL. Is it possible to remove this structure from GSL if it is not used?

