### PR TITLE
Use std::byte when available.

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -37,10 +37,30 @@
 #pragma push_macro("noexcept")
 #define noexcept /*noexcept*/
 #endif           // _MSC_VER <= 1800
+
+#if _HAS_STD_BYTE 
+
+#define GSL_USE_STD_BYTE 1
+
+#else
+
+#define GSL_USE_STD_BYTE 0
+
+#endif // _HAS_STD_BYTE
+
 #endif           // _MSC_VER
 
 namespace gsl
 {
+#if GSL_USE_STD_BYTE
+
+#include <cstddef>
+
+using byte = std::byte;
+using std::to_integer;
+
+#else // GSL_USE_STD_BYTE
+
 // This is a simple definition for now that allows
 // use of byte within span<> to be standards-compliant
 enum class byte : unsigned char
@@ -108,6 +128,8 @@ inline constexpr IntegerType to_integer(byte b) noexcept
 {
     return static_cast<IntegerType>(b);
 }
+
+#endif // GSL_USE_STD_BYTE
 
 template <bool E, typename T>
 inline constexpr byte to_byte_impl(T t) noexcept

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -38,15 +38,29 @@
 #define noexcept /*noexcept*/
 #endif           // _MSC_VER <= 1800
 
-#if _HAS_STD_BYTE 
+// this tests if we are under MSVC and the standard lib has std::byte and it is enabled
+#if _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
 
 #define GSL_USE_STD_BYTE 1
 
-#else
+#else // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
 
 #define GSL_USE_STD_BYTE 0
 
-#endif // _HAS_STD_BYTE
+#endif // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
+
+#else // _MSC_VER
+
+// this tests if we are under GCC or Clang with enough -std:c++1z power to get us std::byte
+#if defined(__cplusplus) && (__cplusplus > 201703L)
+
+#define GSL_USE_STD_BYTE 1
+
+#else // defined(__cplusplus) && (__cplusplus > 201703L)
+
+#define GSL_USE_STD_BYTE 0
+
+#endif //defined(__cplusplus) && (__cplusplus > 201703L)
 
 #endif           // _MSC_VER
 
@@ -56,7 +70,7 @@ namespace gsl
 
 #include <cstddef>
 
-using byte = std::byte;
+using std::byte;
 using std::to_integer;
 
 #else // GSL_USE_STD_BYTE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(gsl_tests_config INTERFACE)
 target_compile_options(gsl_tests_config INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
         /EHsc
+        /std:c++latest
         /W4
         /WX
     >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(gsl_tests_config INTERFACE)
 target_compile_options(gsl_tests_config INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
         /EHsc
-        /std:c++latest
         /W4
         /WX
     >


### PR DESCRIPTION
This small change allows the GSL to use the std::byte implementation from MSVC when it is available.