### PR TITLE
Remove VS2013 workarounds.

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -33,16 +33,6 @@
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
 
-// MSVC 2013 workarounds
-#if _MSC_VER <= 1800
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-
-// turn off some misguided warnings
-#pragma warning(push)
-#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-#endif                          // _MSC_VER <= 1800
 #endif                          // defined(_MSC_VER) && _MSC_VER < 1910
 
 namespace gsl
@@ -56,7 +46,6 @@ using std::shared_ptr;
 
 //
 // owner
-//
 //
 // owner<T> is designed as a bridge for code that must deal directly with owning pointers for some reason
 //
@@ -196,12 +185,6 @@ struct hash<gsl::not_null<T>>
 #undef constexpr
 #pragma pop_macro("constexpr")
 
-#if _MSC_VER <= 1800
-#undef noexcept
-#pragma pop_macro("noexcept")
-
-#pragma warning(pop)
-#endif // _MSC_VER <= 1800
 #endif // defined(_MSC_VER) && _MSC_VER < 1910
 
 #endif // GSL_GSL_H

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -22,21 +22,11 @@
 #include <type_traits>
 
 #ifdef _MSC_VER
+
 #pragma warning(push)
 
 // don't warn about function style casts in byte related operators
 #pragma warning(disable : 26493)
-
-// MSVC 2013 workarounds
-#if _MSC_VER <= 1800
-// constexpr is not understood
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-#endif           // _MSC_VER <= 1800
 
 // this tests if we are under MSVC and the standard lib has std::byte and it is enabled
 #if _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
@@ -176,14 +166,6 @@ inline constexpr byte to_byte() noexcept
 } // namespace gsl
 
 #ifdef _MSC_VER
-#if _MSC_VER <= 1800
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#undef noexcept
-#pragma pop_macro("noexcept")
-#endif // _MSC_VER <= 1800
-
 #pragma warning(pop)
 #endif // _MSC_VER
 

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -27,20 +27,13 @@
 #include <utility>
 
 #if defined(_MSC_VER)
+
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
 
 #if _MSC_VER < 1910
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
-// MSVC 2013 workarounds
-#if _MSC_VER <= 1800
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-// turn off some misguided warnings
-#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-#endif                          // _MSC_VER <= 1800
 #endif                          // _MSC_VER < 1910
 #endif                          // _MSC_VER
 
@@ -89,19 +82,11 @@ inline final_act<F> finally(F&& f) noexcept
 }
 
 // narrow_cast(): a searchable way to do narrowing casts of values
-#if defined(_MSC_VER) && _MSC_VER <= 1800
-template <class T, class U>
-inline constexpr T narrow_cast(U u) noexcept
-{
-    return static_cast<T>(u);
-}
-#else
 template <class T, class U>
 inline constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
-#endif
 
 struct narrowing_error : public std::exception
 {
@@ -159,12 +144,10 @@ inline constexpr T at(const std::initializer_list<T> cont, const std::ptrdiff_t 
 #undef constexpr
 #pragma pop_macro("constexpr")
 
-#if _MSC_VER <= 1800
-#undef noexcept
-#pragma pop_macro("noexcept")
-#endif // _MSC_VER <= 1800
 #endif // _MSC_VER < 1910
+
 #pragma warning(pop)
+
 #endif // _MSC_VER
 
 #endif // GSL_UTIL_H

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -38,6 +38,7 @@
 #include <utility>
 
 #ifdef _MSC_VER
+
 // turn off some warnings that are noisy about our Expects statements
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
@@ -47,19 +48,6 @@
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
 
-// VS 2013 workarounds
-#if _MSC_VER <= 1800
-#define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-#define GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-
-// turn off some misguided warnings
-#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-#pragma warning(disable : 4512) // warns that assignment op could not be generated
-#endif                          // _MSC_VER <= 1800
 #endif                          // _MSC_VER < 1910
 #endif                          // _MSC_VER
 
@@ -118,22 +106,11 @@ public:
         std::copy(values, values + Rank, elems);
     }
 
-#ifdef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-    template <
-        typename T, typename... Ts,
-        typename = std::enable_if_t<((sizeof...(Ts) + 1) == Rank) && std::is_integral<T>::value &&
-                                    details::are_integral<Ts...>::value>>
-    constexpr index(T t, Ts... ds)
-        : index({narrow_cast<value_type>(t), narrow_cast<value_type>(ds)...})
-    {
-    }
-#else
     template <typename... Ts, typename = std::enable_if_t<(sizeof...(Ts) == Rank) &&
                                                           details::are_integral<Ts...>::value>>
     constexpr index(Ts... ds) GSL_NOEXCEPT : elems{narrow_cast<value_type>(ds)...}
     {
     }
-#endif
 
     constexpr index(const index& other) GSL_NOEXCEPT = default;
 
@@ -1383,17 +1360,13 @@ public:
     {
     }
 
-// trivial copy and move
-#ifndef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-    constexpr multi_span(multi_span&&) = default;
-#endif
+    // trivial copy and move
     constexpr multi_span(const multi_span&) = default;
+    constexpr multi_span(multi_span&&) = default;
 
-// trivial assignment
-#ifndef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-    constexpr multi_span& operator=(multi_span&&) = default;
-#endif
+    // trivial assignment
     constexpr multi_span& operator=(const multi_span&) = default;
+    constexpr multi_span& operator=(multi_span&&) = default;
 
     // first() - extract the first Count elements into a new multi_span
     template <std::ptrdiff_t Count>
@@ -2249,19 +2222,13 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 
 #ifdef _MSC_VER
 #if _MSC_VER < 1910
-#if _MSC_VER <= 1800
-#undef noexcept
-#pragma pop_macro("noexcept")
-
-#undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-#undef GSL_MSVC_NO_SUPPORT_FOR_MOVE_CTOR_DEFAULT
-#endif // _MSC_VER <= 1800
 
 #undef constexpr
 #pragma pop_macro("constexpr")
 #endif // _MSC_VER < 1910
 
 #pragma warning(pop)
+
 #endif // _MSC_VER
 
 #endif // GSL_MULTI_SPAN_H

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -1,4 +1,3 @@
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Copyright (c) 2015 Microsoft Corporation. All rights reserved.
@@ -48,23 +47,6 @@
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
 
-// VS 2013 workarounds
-#if _MSC_VER <= 1800
-#define GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-#define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-#define GSL_MSVC_NO_CPP14_STD_EQUAL
-
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-
-#pragma push_macro("alignof")
-#define alignof __alignof
-
-// turn off some misguided warnings
-#pragma warning(disable : 4351) // warns about newly introduced aggregate initializer behavior
-#pragma warning(disable : 4512) // warns that assignment op could not be generated
-#endif                          // _MSC_VER <= 1800
 #endif                          // _MSC_VER < 1910
 #endif                          // _MSC_VER
 
@@ -423,11 +405,7 @@ public:
     }
 
     constexpr span(const span& other) GSL_NOEXCEPT = default;
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr span(span&& other) GSL_NOEXCEPT = default;
-#else
-    constexpr span(span&& other) GSL_NOEXCEPT : storage_(std::move(other.storage_)) {}
-#endif
 
     template <
         class OtherElementType, std::ptrdiff_t OtherExtent,
@@ -452,15 +430,8 @@ public:
     ~span() GSL_NOEXCEPT = default;
     constexpr span& operator=(const span& other) GSL_NOEXCEPT = default;
 
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr span& operator=(span&& other) GSL_NOEXCEPT = default;
-#else
-    constexpr span& operator=(span&& other) GSL_NOEXCEPT
-    {
-        storage_ = std::move(other.storage_);
-        return *this;
-    }
-#endif
+
     // [span.sub], span subviews
     template <std::ptrdiff_t Count>
     constexpr span<element_type, Count> first() const
@@ -566,11 +537,7 @@ template <class ElementType, std::ptrdiff_t FirstExtent, std::ptrdiff_t SecondEx
 inline constexpr bool operator==(const span<ElementType, FirstExtent>& l,
                                  const span<ElementType, SecondExtent>& r)
 {
-#ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
-    return (l.size() == r.size()) && std::equal(l.begin(), l.end(), r.begin());
-#else
     return std::equal(l.begin(), l.end(), r.begin(), r.end());
-#endif
 }
 
 template <class ElementType, std::ptrdiff_t Extent>
@@ -709,17 +676,6 @@ inline constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdif
 #undef constexpr
 #pragma pop_macro("constexpr")
 
-#if _MSC_VER <= 1800
-#undef noexcept
-#pragma pop_macro("noexcept")
-
-#undef alignof
-#pragma pop_macro("alignof")
-
-#undef GSL_MSVC_HAS_VARIADIC_CTOR_BUG
-#undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-#undef GSL_MSVC_NO_CPP14_STD_EQUAL
-#endif // _MSC_VER <= 1800
 #endif // _MSC_VER < 1910
 
 #pragma warning(pop)

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -39,17 +39,6 @@
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
 
-// VS 2013 workarounds
-#if _MSC_VER <= 1800
-#define GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
-#define GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
-#define GSL_MSVC_NO_CPP14_STD_EQUAL
-#define GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-
-// noexcept is not understood
-#pragma push_macro("noexcept")
-#define noexcept /*noexcept*/
-#endif           // _MSC_VER <= 1800
 #endif           // _MSC_VER < 1910
 #endif           // _MSC_VER
 
@@ -274,25 +263,13 @@ public:
     constexpr basic_string_span(const basic_string_span& other) GSL_NOEXCEPT = default;
 
 // move
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr basic_string_span(basic_string_span&& other) GSL_NOEXCEPT = default;
-#else
-    constexpr basic_string_span(basic_string_span&& other) : span_(std::move(other.span_)) {}
-#endif
 
     // assign
     constexpr basic_string_span& operator=(const basic_string_span& other) GSL_NOEXCEPT = default;
 
 // move assign
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr basic_string_span& operator=(basic_string_span&& other) GSL_NOEXCEPT = default;
-#else
-    constexpr basic_string_span& operator=(basic_string_span&& other) GSL_NOEXCEPT
-    {
-        span_ = std::move(other.span_);
-        return *this;
-    }
-#endif
 
     // from nullptr
     constexpr basic_string_span(std::nullptr_t ptr) GSL_NOEXCEPT : span_(ptr) {}
@@ -449,7 +426,6 @@ using cwstring_span = basic_string_span<const wchar_t, Extent>;
 //
 // to_string() allow (explicit) conversions from string_span to string
 //
-#ifndef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
 
 template <typename CharT, std::ptrdiff_t Extent>
 std::basic_string<typename std::remove_const<CharT>::type>
@@ -457,30 +433,6 @@ to_string(basic_string_span<CharT, Extent> view)
 {
     return {view.data(), static_cast<std::size_t>(view.length())};
 }
-
-#else
-
-inline std::string to_string(cstring_span<> view)
-{
-    return {view.data(), static_cast<std::size_t>(view.length())};
-}
-
-inline std::string to_string(string_span<> view)
-{
-    return {view.data(), static_cast<std::size_t>(view.length())};
-}
-
-inline std::wstring to_string(cwstring_span<> view)
-{
-    return {view.data(), static_cast<std::size_t>(view.length())};
-}
-
-inline std::wstring to_string(wstring_span<> view)
-{
-    return {view.data(), static_cast<std::size_t>(view.length())};
-}
-
-#endif
 
 template <typename CharT, typename Traits = typename std::char_traits<CharT>,
           typename Allocator = std::allocator<CharT>, typename gCharT, std::ptrdiff_t Extent>
@@ -517,25 +469,13 @@ public:
     constexpr basic_zstring_span(const basic_zstring_span& other) = default;
 
 // move
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr basic_zstring_span(basic_zstring_span&& other) = default;
-#else
-    constexpr basic_zstring_span(basic_zstring_span&& other) : span_(std::move(other.span_)) {}
-#endif
 
     // assign
     constexpr basic_zstring_span& operator=(const basic_zstring_span& other) = default;
 
 // move assign
-#ifndef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
     constexpr basic_zstring_span& operator=(basic_zstring_span&& other) = default;
-#else
-    constexpr basic_zstring_span& operator=(basic_zstring_span&& other)
-    {
-        span_ = std::move(other.span_);
-        return *this;
-    }
-#endif
 
     constexpr bool empty() const GSL_NOEXCEPT { return span_.size() == 0; }
 
@@ -573,11 +513,7 @@ template <class CharT, std::ptrdiff_t Extent, class T,
 bool operator==(const gsl::basic_string_span<CharT, Extent>& one, const T& other) GSL_NOEXCEPT
 {
     const gsl::basic_string_span<std::add_const_t<CharT>> tmp(other);
-#ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
-    return (one.size() == tmp.size()) && std::equal(one.begin(), one.end(), tmp.begin());
-#else
     return std::equal(one.begin(), one.end(), tmp.begin(), tmp.end());
-#endif
 }
 
 template <class CharT, std::ptrdiff_t Extent, class T,
@@ -587,11 +523,7 @@ template <class CharT, std::ptrdiff_t Extent, class T,
 bool operator==(const T& one, const gsl::basic_string_span<CharT, Extent>& other) GSL_NOEXCEPT
 {
     gsl::basic_string_span<std::add_const_t<CharT>> tmp(one);
-#ifdef GSL_MSVC_NO_CPP14_STD_EQUAL
-    return (tmp.size() == other.size()) && std::equal(tmp.begin(), tmp.end(), other.begin());
-#else
     return std::equal(tmp.begin(), tmp.end(), other.begin(), other.end());
-#endif
 }
 
 // operator !=
@@ -831,16 +763,6 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 #undef constexpr
 #pragma pop_macro("constexpr")
 
-// VS 2013 workarounds
-#if _MSC_VER <= 1800
-#undef noexcept
-#pragma pop_macro("noexcept")
-
-#undef GSL_MSVC_HAS_TYPE_DEDUCTION_BUG
-#undef GSL_MSVC_HAS_SFINAE_SUBSTITUTION_ICE
-#undef GSL_MSVC_NO_CPP14_STD_EQUAL
-#undef GSL_MSVC_NO_DEFAULT_MOVE_CTOR
-#endif // _MSC_VER <= 1800
 #endif // _MSC_VER < 1910
 #endif // _MSC_VER
 


### PR DESCRIPTION
As has been previously announced, we are no longer supporting VS 2013 for the GSL now that VS 2017 has been released (some time ago).