### PR TITLE
Allow users to override GSL_USE_STD_BYTE

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -28,19 +28,22 @@
 // don't warn about function style casts in byte related operators
 #pragma warning(disable : 26493)
 
+#ifndef GSL_USE_STD_BYTE
 // this tests if we are under MSVC and the standard lib has std::byte and it is enabled
-#if _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
+#if _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE)
 
 #define GSL_USE_STD_BYTE 1
 
-#else // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
+#else // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE)
 
 #define GSL_USE_STD_BYTE 0
 
-#endif // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE) 
+#endif // _MSC_VER >= 1911 && (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE)
+#endif // GSL_USE_STD_BYTE
 
 #else // _MSC_VER
 
+#ifndef GSL_USE_STD_BYTE
 // this tests if we are under GCC or Clang with enough -std:c++1z power to get us std::byte
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
 
@@ -52,6 +55,7 @@
 #define GSL_USE_STD_BYTE 0
 
 #endif //defined(__cplusplus) && (__cplusplus >= 201703L)
+#endif // GSL_USE_STD_BYTE
 
 #endif           // _MSC_VER
 


### PR DESCRIPTION
Because the comment "this tests if we are under GCC or Clang with enough -std:c++1z power to get us `std::byte`" is wrong: the correlation between compiler and standard library versions is at best loose in the open source world. There is no reasonable way for a third party library to determine if the implementation supports `std::byte`, so users must be able to override our guess when it is wrong.

Of course `byte` isn't implementable as a pure library feature in C++, so the fallback implementation is not portable. It would probably be better - at least the behavior would be portable - for the library to use `unsigned char` in place of `byte` absent implementation support for `std::byte`.