### PR TITLE
Fix catch installation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 CMakeFiles
 build
-include/catch
 tests/CMakeFiles
 tests/Debug
 *.opensdf

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ project(GSLTests CXX)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 list(APPEND CATCH_CMAKE_ARGS
-    "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}"
+    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external"
     "-DNO_SELFTEST=true"
 )
 
@@ -46,6 +46,11 @@ target_compile_options(gsl_tests_config INTERFACE
         -Wshadow
         -Wsign-conversion
     >
+)
+
+# for tests to find the catch header
+target_include_directories(gsl_tests_config INTERFACE
+    ${CMAKE_BINARY_DIR}/external/include
 )
 
 # set definitions for tests


### PR DESCRIPTION
Catch was being installed to the root of the cmake project. This
violated the source code tree itself and would not work at all if GSL
was being consumed with add_subdirectory.

CMake will now install catch to the build tree under /dependencies.

This fixes #538