### PR TITLE
turning off warning

### DIFF
--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -28,6 +28,7 @@
 
 // turn off some warnings that are noisy about our Expects statements
 #pragma warning(disable : 4127) // conditional expression is constant
+#pragma warning(disable : 4996) // unsafe use of std::copy_n
 
 // blanket turn off warnings from CppCoreCheck for now
 // so people aren't annoyed by them when running the tool.


### PR DESCRIPTION
using the GSL with MSVC 2017 causes the following warning"
`'std::copy_n::_Unchecked_iterators::_Deprecate': Call to 'std::copy_n'`

This patch removes this since the point of this code is to deal with this issue.