### PR TITLE
Use system version of the Catch test framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.1.3)
 project(GSL CXX)
 
 include(ExternalProject)
-find_package(Git REQUIRED)
+find_package(Git)
 
 # creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,16 +10,21 @@ list(APPEND CATCH_CMAKE_ARGS
     "-DNO_SELFTEST=true"
 )
 
-# add catch
-ExternalProject_Add(
-    catch
-    PREFIX ${CMAKE_BINARY_DIR}/catch
-    GIT_REPOSITORY https://github.com/philsquared/Catch.git
-    GIT_TAG v1.9.6    
-    CMAKE_ARGS ${CATCH_CMAKE_ARGS}
-    LOG_DOWNLOAD 1
-    UPDATE_DISCONNECTED 1
-)
+if(GIT_FOUND)
+    # add catch
+    ExternalProject_Add(
+        catch
+        PREFIX ${CMAKE_BINARY_DIR}/catch
+        GIT_REPOSITORY https://github.com/philsquared/Catch.git
+        GIT_TAG v1.9.6
+        CMAKE_ARGS ${CATCH_CMAKE_ARGS}
+        LOG_DOWNLOAD 1
+        UPDATE_DISCONNECTED 1
+    )
+else()
+    # assume catch is installed in a system directory
+    add_custom_target(catch)
+endif()
 
 # this interface adds compile options to how the tests are run
 # please try to keep entries ordered =)


### PR DESCRIPTION
This removes dependency on Git for tests. This eliminates CMake errors in environments without installed Git. Also an user can force to use the Catch library which is installed in `/usr/include` or something, if (s)he defines the _CMAKE_DISABLE_FIND_PACKAGE_Git_ variable for CMake invocation. Like this

    cmake /path/to/GSL -DCMAKE_DISABLE_FIND_PACKAGE_Git=1