### PR TITLE
Remove pragma once

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_GSL_H
-#define GSL_GSL_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_H
+#define GUIDELINE_SUPPORT_LIBRARY_H
 
 #include <gsl/gsl_assert>  // Ensures/Expects
 #include <gsl/gsl_util>    // finally()/narrow()/narrow_cast()...
@@ -26,4 +24,4 @@
 #include <gsl/string_span> // zstring, string_span, zstring_builder...
 #include <gsl/pointers>    // owner, not_null
 
-#endif // GSL_GSL_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_H

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_ALGORITHM_H
-#define GSL_ALGORITHM_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_ALGORITHM_H
+#define GUIDELINE_SUPPORT_LIBRARY_ALGORITHM_H
 
 #include <gsl/span>
 
@@ -59,4 +57,4 @@ void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent>
 #pragma warning(pop)
 #endif // _MSC_VER
 
-#endif // GSL_ALGORITHM_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_ALGORITHM_H

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_CONTRACTS_H
-#define GSL_CONTRACTS_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_CONTRACTS_H
+#define GUIDELINE_SUPPORT_LIBRARY_CONTRACTS_H
 
 #include <exception>
 #include <stdexcept>
@@ -94,4 +92,4 @@ struct fail_fast : public std::logic_error
 #define Expects(cond) GSL_CONTRACT_CHECK("Precondition", cond)
 #define Ensures(cond) GSL_CONTRACT_CHECK("Postcondition", cond)
 
-#endif // GSL_CONTRACTS_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_CONTRACTS_H

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_BYTE_H
-#define GSL_BYTE_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_BYTE_H
+#define GUIDELINE_SUPPORT_LIBRARY_BYTE_H
 
 #include <type_traits>
 
@@ -173,4 +171,4 @@ inline constexpr byte to_byte() noexcept
 #pragma warning(pop)
 #endif // _MSC_VER
 
-#endif // GSL_BYTE_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_BYTE_H

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_UTIL_H
-#define GSL_UTIL_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_UTIL_H
+#define GUIDELINE_SUPPORT_LIBRARY_UTIL_H
 
 #include <gsl/gsl_assert> // Ensures/Expects
 
@@ -150,4 +148,4 @@ inline constexpr T at(const std::initializer_list<T> cont, const std::ptrdiff_t 
 
 #endif // _MSC_VER
 
-#endif // GSL_UTIL_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_UTIL_H

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_MULTI_SPAN_H
-#define GSL_MULTI_SPAN_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_MULTI_SPAN_H
+#define GUIDELINE_SUPPORT_LIBRARY_MULTI_SPAN_H
 
 #include <gsl/gsl_assert>
 #include <gsl/gsl_byte>
@@ -2231,4 +2229,4 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 
 #endif // _MSC_VER
 
-#endif // GSL_MULTI_SPAN_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_MULTI_SPAN_H

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_POINTERS_H
-#define GSL_POINTERS_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_POINTERS_H
+#define GUIDELINE_SUPPORT_LIBRARY_POINTERS_H
 
 #include <gsl/gsl_assert>
 
@@ -183,4 +181,4 @@ struct hash<gsl::not_null<T>>
 
 #endif // defined(_MSC_VER) && _MSC_VER < 1910
 
-#endif // GSL_POINTERS_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_POINTERS_H

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_SPAN_H
-#define GSL_SPAN_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_SPAN_H
+#define GUIDELINE_SUPPORT_LIBRARY_SPAN_H
 
 #include <gsl/gsl_assert>
 #include <gsl/gsl_byte>
@@ -713,4 +711,4 @@ inline constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdif
 #pragma warning(pop)
 #endif // _MSC_VER
 
-#endif // GSL_SPAN_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_SPAN_H

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -14,10 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
-#ifndef GSL_STRING_SPAN_H
-#define GSL_STRING_SPAN_H
+#ifndef GUIDELINE_SUPPORT_LIBRARY_STRING_SPAN_H
+#define GUIDELINE_SUPPORT_LIBRARY_STRING_SPAN_H
 
 #include <gsl/gsl_assert>
 #include <gsl/gsl_util>
@@ -720,4 +718,4 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 #endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
-#endif // GSL_STRING_SPAN_H
+#endif // GUIDELINE_SUPPORT_LIBRARY_STRING_SPAN_H


### PR DESCRIPTION
Remove pragmas and expanded guards to reduce chance of collision