### PR TITLE
Drop "Dummy" from enable_if in templates

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -213,7 +213,7 @@ private:
 
 struct static_bounds_dynamic_range_t
 {
-    template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
+    template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
     constexpr operator T() const GSL_NOEXCEPT
     {
         return narrow_cast<T>(-1);
@@ -230,25 +230,25 @@ constexpr bool operator!=(static_bounds_dynamic_range_t, static_bounds_dynamic_r
     return false;
 }
 
-template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 constexpr bool operator==(static_bounds_dynamic_range_t, T other) GSL_NOEXCEPT
 {
     return narrow_cast<T>(-1) == other;
 }
 
-template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 constexpr bool operator==(T left, static_bounds_dynamic_range_t right) GSL_NOEXCEPT
 {
     return right == left;
 }
 
-template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 constexpr bool operator!=(static_bounds_dynamic_range_t, T other) GSL_NOEXCEPT
 {
     return narrow_cast<T>(-1) != other;
 }
 
-template <typename T, typename Dummy = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 constexpr bool operator!=(T left, static_bounds_dynamic_range_t right) GSL_NOEXCEPT
 {
     return right != left;
@@ -1539,7 +1539,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator==(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1549,7 +1549,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator!=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1558,7 +1558,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator<(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1567,7 +1567,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator<=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1576,7 +1576,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator>(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1585,7 +1585,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t... OtherDimensions,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator>=(const multi_span<OtherValueType, OtherDimensions...>& other) const GSL_NOEXCEPT
@@ -1805,14 +1805,14 @@ public:
     template <typename OtherValueType, std::ptrdiff_t... Dimensions,
               bool Enabled1 = (sizeof...(Dimensions) == Rank),
               bool Enabled2 = std::is_convertible<OtherValueType*, ValueType*>::value,
-              typename Dummy = std::enable_if_t<Enabled1 && Enabled2>>
+              typename = std::enable_if_t<Enabled1 && Enabled2>>
     constexpr strided_span(multi_span<OtherValueType, Dimensions...> av, bounds_type bounds)
         : strided_span(av.data(), av.bounds().total_size(), std::move(bounds))
     {
     }
 
     // convertible
-    template <typename OtherValueType, typename Dummy = std::enable_if_t<std::is_convertible<
+    template <typename OtherValueType, typename = std::enable_if_t<std::is_convertible<
                                            OtherValueType (*)[], value_type (*)[]>::value>>
     constexpr strided_span(const strided_span<OtherValueType, Rank>& other)
         : data_(other.data_), bounds_(other.bounds_)
@@ -1900,7 +1900,7 @@ public:
     constexpr const_reverse_iterator crend() const { return const_reverse_iterator{cbegin()}; }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator==(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1910,7 +1910,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator!=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1919,7 +1919,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator<(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1928,7 +1928,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator<=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1937,7 +1937,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator>(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1946,7 +1946,7 @@ public:
     }
 
     template <typename OtherValueType, std::ptrdiff_t OtherRank,
-              typename Dummy = std::enable_if_t<std::is_same<
+              typename = std::enable_if_t<std::is_same<
                   std::remove_cv_t<value_type>, std::remove_cv_t<OtherValueType>>::value>>
     constexpr bool
     operator>=(const strided_span<OtherValueType, OtherRank>& other) const GSL_NOEXCEPT
@@ -1966,7 +1966,7 @@ private:
         return ret;
     }
 
-    template <bool Enabled = (Rank == 1), typename Dummy = std::enable_if_t<Enabled>>
+    template <bool Enabled = (Rank == 1), typename = std::enable_if_t<Enabled>>
     static index_type resize_stride(const index_type& strides, std::ptrdiff_t, void* = nullptr)
     {
         // Only strided arrays with regular strides can be resized
@@ -1975,7 +1975,7 @@ private:
         return strides;
     }
 
-    template <bool Enabled = (Rank > 1), typename Dummy = std::enable_if_t<Enabled>>
+    template <bool Enabled = (Rank > 1), typename = std::enable_if_t<Enabled>>
     static index_type resize_stride(const index_type& strides, std::ptrdiff_t d)
     {
         // Only strided arrays with regular strides can be resized

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -71,13 +71,13 @@ class not_null
 public:
     static_assert(std::is_assignable<T&, std::nullptr_t>::value, "T cannot be assigned nullptr.");
 
-    template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
     constexpr not_null(U&& u) : ptr_(std::forward<U>(u))
     {
         Expects(ptr_ != nullptr);
     }
 
-    template <typename U, typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
     constexpr not_null(const not_null<U>& other) : not_null(other.get())
     {
     }

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -491,7 +491,7 @@ bool operator!=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_N
 
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value &&
         !gsl::details::is_basic_string_span<T>::value>>
 bool operator!=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NOEXCEPT
@@ -511,7 +511,7 @@ bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_NO
 
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value &&
         !gsl::details::is_basic_string_span<T>::value>>
 bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NOEXCEPT
@@ -528,7 +528,7 @@ bool operator<(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NO
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -542,7 +542,7 @@ bool operator<(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_NO
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -565,7 +565,7 @@ bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_N
 
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value &&
         !gsl::details::is_basic_string_span<T>::value>>
 bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NOEXCEPT
@@ -581,7 +581,7 @@ bool operator<=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -594,7 +594,7 @@ bool operator<=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_N
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -616,7 +616,7 @@ bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_NO
 
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value &&
         !gsl::details::is_basic_string_span<T>::value>>
 bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NOEXCEPT
@@ -632,7 +632,7 @@ bool operator>(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NO
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -645,7 +645,7 @@ bool operator>(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_NO
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -667,7 +667,7 @@ bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_N
 
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         std::is_convertible<T, gsl::basic_string_span<std::add_const_t<CharT>, Extent>>::value &&
         !gsl::details::is_basic_string_span<T>::value>>
 bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_NOEXCEPT
@@ -683,7 +683,7 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,
@@ -696,7 +696,7 @@ bool operator>=(gsl::basic_string_span<CharT, Extent> one, const T& other) GSL_N
 template <
     typename CharT, std::ptrdiff_t Extent = gsl::dynamic_extent, typename T,
     typename DataType = typename T::value_type,
-    typename Dummy = std::enable_if_t<
+    typename = std::enable_if_t<
         !gsl::details::is_span<T>::value && !gsl::details::is_basic_string_span<T>::value &&
         std::is_convertible<DataType*, CharT*>::value &&
         std::is_same<std::decay_t<decltype(std::declval<T>().size(), *std::declval<T>().data())>,


### PR DESCRIPTION
From what I understand [from this discussion](https://github.com/Microsoft/GSL/pull/114) looks like Dummy was needed for VS2013. Since it seems like we don't support that anymore I removed the Dummies.