### PR TITLE
Exporting MicrosoftGSL::GSL CMake target during library installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,8 @@ target_compile_definitions(GSL INTERFACE
 
 # add include folders to the library and targets that consume it
 target_include_directories(GSL INTERFACE
-    $<BUILD_INTERFACE:
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    >
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
 if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))
@@ -57,9 +56,9 @@ if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))
 
     # add natvis file to the library so it will automatically be loaded into Visual Studio
     if(VS_ADD_NATIVE_VISUALIZERS)
-        target_sources(GSL INTERFACE
-            ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
-        )
+    target_sources(GSL INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis>
+    )
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.1.3)
 project(GSL CXX)
 
 include(ExternalProject)
+include(GNUInstallDirs)
 find_package(Git)
 
 # creates a library GSL which is an interface (header files only)
@@ -62,13 +63,39 @@ if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))
     endif()
 endif()
 
-install(
-    DIRECTORY include/gsl
-    DESTINATION include
-)
-
 option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})
 if (GSL_TEST)
 	enable_testing()
 	add_subdirectory(tests)
 endif ()
+
+set(package_name "MicrosoftGSL")
+set(targets_export_name "${package_name}Targets")
+set(project_config "${package_name}Config.cmake")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+set(project_namespace "${package_name}::")
+install(
+    TARGETS GSL
+    EXPORT ${targets_export_name}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )
+
+install(
+    DIRECTORY include/gsl
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    EXPORT ${targets_export_name}
+    NAMESPACE ${project_namespace}
+    DESTINATION ${config_install_dir}
+    FILE ${project_config}
+)
+
+export(
+    EXPORT ${targets_export_name}
+    NAMESPACE ${project_namespace}
+    FILE ${project_config}
+)
+export(PACKAGE ${package_name})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.3)
-
-project(GSL CXX)
+cmake_policy(SET CMP0048 NEW) # allow VERSION in project() https://cmake.org/cmake/help/v3.0/policy/CMP0048.html
+project(GSL VERSION 1.0.0 LANGUAGES CXX)
 
 include(ExternalProject)
 include(GNUInstallDirs)
@@ -70,10 +70,21 @@ if (GSL_TEST)
 endif ()
 
 set(package_name "MicrosoftGSL")
+set(project_namespace "${package_name}::")
 set(targets_export_name "${package_name}Targets")
 set(project_config "${package_name}Config.cmake")
+set(version_config "${CMAKE_BINARY_DIR}/${package_name}ConfigVersion.cmake")
+set(pkg_config "${CMAKE_BINARY_DIR}/${package_name}.pc")
+set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
-set(project_namespace "${package_name}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+configure_file("cmake/MicrosoftGSL.pc.in" "${pkg_config}" @ONLY)
+
 install(
     TARGETS GSL
     EXPORT ${targets_export_name}
@@ -83,6 +94,16 @@ install(
 install(
     DIRECTORY include/gsl
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    FILES "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    FILES "${pkg_config}"
+    DESTINATION "${pkgconfig_install_dir}"
 )
 
 install(
@@ -97,5 +118,5 @@ export(
     NAMESPACE ${project_namespace}
     FILE ${project_config}
 )
-export(PACKAGE ${package_name})
 
+export(PACKAGE ${package_name})

--- a/README.md
+++ b/README.md
@@ -71,24 +71,53 @@ These steps assume the source code of this repository has been cloned into a dir
 All tests should pass - indicating your platform is fully supported and you are ready to use the GSL types!
 
 ## Using the libraries
-As the types are entirely implemented inline in headers, there are no linking requirements.
+* ### Copy headers to build tree
+    As the types are entirely implemented inline in headers, there are no linking requirements.
 
-You can copy the [gsl](./include/gsl) directory into your source tree so it is available
-to your compiler, then include the appropriate headers in your program.
+    You can copy the [gsl](./include/gsl) directory into your source tree so it is available to your compiler, then include the appropriate headers in your program.
 
-Alternatively set your compiler's *include path* flag to point to the GSL development folder (`c:\GSL\include` in the example above) or installation folder (after running the install). Eg.
+    Alternatively set your compiler's *include path* flag to point to the GSL development folder (`c:\GSL\include` in the example above) or installation folder (after running the install). Eg.
 
-MSVC++
+    MSVC++
 
-    /I c:\GSL\include
+        /I c:\GSL\include
 
-GCC/clang
+    GCC/clang
 
-    -I$HOME/dev/GSL/include
+        -I$HOME/dev/GSL/include
 
-Include the library using:
+    Include the library using:
 
-    #include <gsl/gsl>
+        #include <gsl/gsl>
+
+* ### Install GSL libraries and import MicrosoftGSL::GSL CMake target
+    In order to install GSL library into <prefix> path, create a directory to contain the build outputs for a particular architecture (we name it c:\GSL\build-x86 in this example).
+
+        cd GSL
+        md build-x86
+        cd build-x86
+
+    Configure CMake with existing installation path (we name it c:\GSL-INSTALL). If installation path is not given, system include/library ones are used.
+
+        cmake -DCMAKE_INSTALL_PREFIX=c:\GSL-INSTALL -DGSL_TEST=OFF c:\GSL
+
+    Install GSL library with CMake
+
+        cmake --build . --config Release --target install
+
+    In your CMake project search for MicrosoftGSL using find\_package. If GSL was installed to non-system path, you have to append it to CMake module search path. All your targets, which are using GSL, must be linked with MicrosoftGSL::GSL imported target.
+
+        project(my-awesome-project CXX)
+        find_package(MicrosoftGSL CONFIG REQUIRED c:\GSL-INSTALL)
+
+        add_executable(awesome-app main.cpp)
+        target_link_libraries(awesome-app PUBLIC
+            MicrosoftGSL::GSL
+        )
+
+    Include gsl library using:
+
+        #include <gsl/gsl>
 
 ## Debugging visualization support
 For Visual Studio users, the file [GSL.natvis](./GSL.natvis) in the root directory of the repository can be added to your project if you would like more helpful visualization of GSL types in the Visual Studio debugger than would be offered by default.

--- a/cmake/MicrosoftGSL.pc.in
+++ b/cmake/MicrosoftGSL.pc.in
@@ -1,0 +1,6 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: Guidelines Support Library 
+Version: @PROJECT_VERSION@

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.7)
-
+cmake_policy(SET CMP0048 NEW) # allow VERSION in project() https://cmake.org/cmake/help/v3.0/policy/CMP0048.html
 project(GSLTests CXX)
 
 # will make visual studio generated project group files


### PR DESCRIPTION
Modified cmake install process to support modular cmake architecture in project using GSL.

Changes allow to export GSL CMake target and its configuration into given prefix path. Currently gsl library has to be added to project using `include_directories`. After changes are merged it will be possible to do it with `find_package` and `target_link_libraries`. Example is added to readme.

*.natvis file support was added to cmake in version 3.7: https://cmake.org/cmake/help/v3.7/release/3.7.html#generators
