### PR TITLE
Visual Studio Debug Visualizers support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.7)
 
 project(GSL CXX)
 
@@ -49,10 +49,18 @@ target_include_directories(GSL INTERFACE
     >
 )
 
+if (MSVC_IDE)
+    option(VS_ADD_NATIVE_VISUALIZERS "Configure project to use Visual Studio native visualizers" TRUE)
+else()
+    set(VS_ADD_NATIVE_VISUALIZERS FALSE CACHE INTERNAL "Native visualizers are Visual Studio extension" FORCE)
+endif()
+
 # add natvis file to the library so it will automatically be loaded into Visual Studio
-target_sources(GSL INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
-)
+if(VS_ADD_NATIVE_VISUALIZERS)
+    target_sources(GSL INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/GSL.natvis
+    )
+endif()
 
 install(
     DIRECTORY include/gsl

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ contributing any changes that were necessary back to this project to benefit the
 ## Building the tests
 To build the tests, you will require the following:
 
-* [CMake](http://cmake.org), version 3.1.3 or later to be installed and in your PATH.
+* [CMake](http://cmake.org), version 3.7 or later to be installed and in your PATH.
 
 These steps assume the source code of this repository has been cloned into a directory named `c:\GSL`.
 


### PR DESCRIPTION
changes:
    - minimal cmake version updated to 3.7(first version with .natvis file handling)
    - updated cmake version in readme file
    - GSL.natvis file is added only to VS projects

*.natvis file support was added to cmake in version 3.7: https://cmake.org/cmake/help/v3.7/release/3.7.html#generators