### PR TITLE
rename final_act to final_action

### DIFF
--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -41,22 +41,22 @@ namespace gsl
 // GSL.util: utilities
 //
 
-// final_act allows you to ensure something gets run at the end of a scope
+// final_action allows you to ensure something gets run at the end of a scope
 template <class F>
-class final_act
+class final_action
 {
 public:
-    explicit final_act(F f) noexcept : f_(std::move(f)), invoke_(true) {}
+    explicit final_action(F f) noexcept : f_(std::move(f)), invoke_(true) {}
 
-    final_act(final_act&& other) noexcept : f_(std::move(other.f_)), invoke_(other.invoke_)
+    final_action(final_action&& other) noexcept : f_(std::move(other.f_)), invoke_(other.invoke_)
     {
         other.invoke_ = false;
     }
 
-    final_act(const final_act&) = delete;
-    final_act& operator=(const final_act&) = delete;
+    final_action(const final_action&) = delete;
+    final_action& operator=(const final_action&) = delete;
 
-    ~final_act() noexcept
+    ~final_action() noexcept
     {
         if (invoke_) f_();
     }
@@ -66,17 +66,17 @@ private:
     bool invoke_;
 };
 
-// finally() - convenience function to generate a final_act
+// finally() - convenience function to generate a final_action
 template <class F>
-inline final_act<F> finally(const F& f) noexcept
+inline final_action<F> finally(const F& f) noexcept
 {
-    return final_act<F>(f);
+    return final_action<F>(f);
 }
 
 template <class F>
-inline final_act<F> finally(F&& f) noexcept
+inline final_action<F> finally(F&& f) noexcept
 {
-    return final_act<F>(std::forward<F>(f));
+    return final_action<F>(std::forward<F>(f));
 }
 
 // narrow_cast(): a searchable way to do narrowing casts of values


### PR DESCRIPTION
Should fix #128. There is an old PR #129 that does the same, but it never got merged and now has merge conflicts.

So if this gets merged we should probably close #128 and #129.