### PR TITLE
Moves VS specific error handling to separate file

### DIFF
--- a/include/gsl/details/post
+++ b/include/gsl/details/post
@@ -1,0 +1,11 @@
+#ifdef _MSC_VER
+
+#if _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
+#endif // _MSC_VER < 1910
+
+#pragma warning(pop)
+#endif // _MSC_VER
+
+#undef GSL_NOEXCEPT

--- a/include/gsl/details/pre
+++ b/include/gsl/details/pre
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef _MSC_VER
+#pragma warning(push)
+
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(disable : 4127) // conditional expression is constant
+#pragma warning(disable : 4996) // unsafe use of std::copy_n
+#pragma warning(disable : 4702) // unreachable code
+
+// don't warn about function style casts in byte related operators
+#pragma warning(disable : 26493)
+
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+
+#if _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
+#endif                          // _MSC_VER < 1910
+
+#endif // _MSC_VER
+
+#ifdef GSL_THROW_ON_CONTRACT_VIOLATION
+#define GSL_NOEXCEPT /*noexcept*/
+#else
+#define GSL_NOEXCEPT noexcept
+#endif // GSL_THROW_ON_CONTRACT_VIOLATION

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -23,18 +23,7 @@
 
 #include <algorithm>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-
-// turn off some warnings that are noisy about our Expects statements
-#pragma warning(disable : 4127) // conditional expression is constant
-#pragma warning(disable : 4996) // unsafe use of std::copy_n
-
-// blanket turn off warnings from CppCoreCheck for now
-// so people aren't annoyed by them when running the tool.
-// more targeted suppressions will be added in a future update to the GSL
-#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
-#endif // _MSC_VER
+#include <gsl/details/pre>
 
 namespace gsl
 {
@@ -55,8 +44,6 @@ void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent>
 
 } // namespace gsl
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_ALGORITHM_H

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -23,10 +23,7 @@
 
 #ifdef _MSC_VER
 
-#pragma warning(push)
-
-// don't warn about function style casts in byte related operators
-#pragma warning(disable : 26493)
+#include <gsl/details/pre>
 
 #ifndef GSL_USE_STD_BYTE
 // this tests if we are under MSVC and the standard lib has std::byte and it is enabled
@@ -169,8 +166,6 @@ inline constexpr byte to_byte() noexcept
 
 } // namespace gsl
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_BYTE_H

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -26,16 +26,7 @@
 #include <type_traits>
 #include <utility>
 
-#if defined(_MSC_VER)
-
-#pragma warning(push)
-#pragma warning(disable : 4127) // conditional expression is constant
-
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-#endif                          // _MSC_VER < 1910
-#endif                          // _MSC_VER
+#include <gsl/details/pre>
 
 namespace gsl
 {
@@ -139,15 +130,6 @@ inline constexpr T at(const std::initializer_list<T> cont, const std::ptrdiff_t 
 
 } // namespace gsl
 
-#if defined(_MSC_VER)
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
-
-#pragma warning(pop)
-
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_UTIL_H

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -37,25 +37,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef _MSC_VER
-
-// turn off some warnings that are noisy about our Expects statements
-#pragma warning(push)
-#pragma warning(disable : 4127) // conditional expression is constant
-#pragma warning(disable : 4702) // unreachable code
-
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif                          // _MSC_VER < 1910
-#endif                          // _MSC_VER
-
-#ifdef GSL_THROW_ON_CONTRACT_VIOLATION
-#define GSL_NOEXCEPT /*noexcept*/
-#else
-#define GSL_NOEXCEPT noexcept
-#endif // GSL_THROW_ON_CONTRACT_VIOLATION
+#include <gsl/details/pre>
 
 namespace gsl
 {
@@ -2218,17 +2200,6 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 
 } // namespace gsl
 
-#undef GSL_NOEXCEPT
-
-#ifdef _MSC_VER
-#if _MSC_VER < 1910
-
-#undef constexpr
-#pragma pop_macro("constexpr")
-#endif // _MSC_VER < 1910
-
-#pragma warning(pop)
-
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_MULTI_SPAN_H

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -25,11 +25,7 @@
 #include <memory>
 #include <type_traits>
 
-#if defined(_MSC_VER) && _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif                          // defined(_MSC_VER) && _MSC_VER < 1910
+#include <gsl/details/pre>
 
 namespace gsl
 {
@@ -177,10 +173,6 @@ struct hash<gsl::not_null<T>>
 
 } // namespace std
 
-#if defined(_MSC_VER) && _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // defined(_MSC_VER) && _MSC_VER < 1910
+#include <gsl/details/post>
 
 #endif // GSL_POINTERS_H

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -31,30 +31,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-
-// turn off some warnings that are noisy about our Expects statements
-#pragma warning(disable : 4127) // conditional expression is constant
-#pragma warning(disable : 4702) // unreachable code
-
-// blanket turn off warnings from CppCoreCheck for now
-// so people aren't annoyed by them when running the tool.
-// more targeted suppressions will be added in a future update to the GSL
-#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
-
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif                          // _MSC_VER < 1910
-#endif                          // _MSC_VER
-
-#ifdef GSL_THROW_ON_CONTRACT_VIOLATION
-#define GSL_NOEXCEPT /*noexcept*/
-#else
-#define GSL_NOEXCEPT noexcept
-#endif // GSL_THROW_ON_CONTRACT_VIOLATION
+#include <gsl/details/pre>
 
 namespace gsl
 {
@@ -703,14 +680,6 @@ inline constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdif
 
 #undef GSL_NOEXCEPT
 
-#ifdef _MSC_VER
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
-
-#pragma warning(pop)
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_SPAN_H

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -27,20 +27,7 @@
 #include <cstring>
 #include <string>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-
-// blanket turn off warnings from CppCoreCheck for now
-// so people aren't annoyed by them when running the tool.
-// more targeted suppressions will be added in a future update to the GSL
-#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
-
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif // _MSC_VER < 1910
-#endif // _MSC_VER
+#include <gsl/details/pre>
 
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
@@ -710,14 +697,6 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
 
 #undef GSL_NOEXCEPT
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
-#endif // _MSC_VER
+#include <gsl/details/post>
 
 #endif // GSL_STRING_SPAN_H


### PR DESCRIPTION
Moves VS specific error handling to separate files gsl/detail/pre|post

Makes main code a bit easier to follow and centralizes warning/error suppression. One downside I see is that we might end up suppressing more than we should in certain files.