### PR TITLE
joining_thread implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(GSL CXX)
 
 include(ExternalProject)
 find_package(Git)
-
+find_package(Threads REQUIRED)
 # creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
 
@@ -46,6 +46,10 @@ target_include_directories(GSL INTERFACE
     $<BUILD_INTERFACE:
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     >
+)
+
+target_link_libraries(GSL INTERFACE
+    Threads::Threads
 )
 
 if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))

--- a/include/gsl/joining_thread
+++ b/include/gsl/joining_thread
@@ -39,8 +39,8 @@ public:
     {
     }
 
-    joining_thread(const joining_thread&) = delete;
-    joining_thread& operator=(const joining_thread&) = delete;
+    joining_thread(const joining_thread&) = default;
+    joining_thread& operator=(const joining_thread&) = default;
 
     joining_thread(joining_thread&&) noexcept = default;
     joining_thread& operator=(joining_thread&&) noexcept = default;

--- a/include/gsl/joining_thread
+++ b/include/gsl/joining_thread
@@ -1,0 +1,78 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef GSL_JOINING_THREAD_H
+#define GSL_JOINING_THREAD_H
+
+#include <memory>
+#include <thread>
+#include <utility>
+
+namespace gsl
+{
+/**
+ * RAII wrapper for std::thread.
+ * It's guaranteed that joining_thread will join when destructed.
+ */
+class joining_thread
+{
+    using JoiningThreadUPtr = std::unique_ptr<std::thread, std::function<void(std::thread*)>>;
+    template <typename... Args>
+    JoiningThreadUPtr create_thread_with_joining_deleter(Args&&... args)
+    {
+        return {new std::thread(std::forward<Args>(args)...), [](auto* th) { th->join(); }};
+    }
+
+public:
+    template <class Function, class... Args>
+    explicit joining_thread(Function&& function, Args&&... args)
+        : thread{create_thread_with_joining_deleter(std::forward<Function>(function),
+                                                    std::forward<Args>(args)...)}
+    {
+    }
+
+    std::thread::id get_id() const noexcept { return (*thread).get_id(); }
+
+    std::thread::native_handle_type native_handle() { return (*thread).native_handle(); }
+
+    static unsigned int hardware_concurrency() noexcept
+    {
+        return std::thread::hardware_concurrency();
+    }
+
+    void swap(joining_thread&& other) noexcept
+    {
+        using std::swap;
+        swap(thread, other.thread);
+    }
+
+private:
+    JoiningThreadUPtr thread;
+};
+}
+
+namespace std
+{
+inline void swap(gsl::joining_thread& x, gsl::joining_thread& y) noexcept { x.swap(std::move(y)); }
+
+inline void swap(gsl::joining_thread&& x, gsl::joining_thread& y) noexcept { x.swap(std::move(y)); }
+
+inline void swap(gsl::joining_thread& x, gsl::joining_thread&& y) noexcept { x.swap(std::move(y)); }
+}
+
+#endif

--- a/include/gsl/joining_thread
+++ b/include/gsl/joining_thread
@@ -19,7 +19,6 @@
 #ifndef GSL_JOINING_THREAD_H
 #define GSL_JOINING_THREAD_H
 
-#include <memory>
 #include <thread>
 #include <utility>
 
@@ -27,28 +26,33 @@ namespace gsl
 {
 /**
  * RAII wrapper for std::thread.
- * It's guaranteed that joining_thread will join when destructed.
+ * It's guaranteed that joining_thread will join started thread when destroyed.
  */
 class joining_thread
 {
-    using JoiningThreadUPtr = std::unique_ptr<std::thread, std::function<void(std::thread*)>>;
-    template <typename... Args>
-    JoiningThreadUPtr create_thread_with_joining_deleter(Args&&... args)
-    {
-        return {new std::thread(std::forward<Args>(args)...), [](auto* th) { th->join(); }};
-    }
-
 public:
+    joining_thread() noexcept {};
+
     template <class Function, class... Args>
     explicit joining_thread(Function&& function, Args&&... args)
-        : thread{create_thread_with_joining_deleter(std::forward<Function>(function),
-                                                    std::forward<Args>(args)...)}
+        : thread(std::forward<Function>(function), std::forward<Args>(args)...)
     {
     }
 
-    std::thread::id get_id() const noexcept { return (*thread).get_id(); }
+    joining_thread(const joining_thread&) = delete;
+    joining_thread& operator=(const joining_thread&) = delete;
 
-    std::thread::native_handle_type native_handle() { return (*thread).native_handle(); }
+    joining_thread(joining_thread&&) noexcept = default;
+    joining_thread& operator=(joining_thread&&) noexcept = default;
+
+    ~joining_thread()
+    {
+        if (thread.joinable()) { thread.join(); }
+    }
+
+    std::thread::id get_id() const noexcept { return thread.get_id(); }
+
+    std::thread::native_handle_type native_handle() { return thread.native_handle(); }
 
     static unsigned int hardware_concurrency() noexcept
     {
@@ -62,7 +66,7 @@ public:
     }
 
 private:
-    JoiningThreadUPtr thread;
+    std::thread thread;
 };
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,7 +101,12 @@ add_gsl_test(utils_tests)
 add_gsl_test(owner_tests)
 add_gsl_test(byte_tests)
 add_gsl_test(algorithm_tests)
-
+add_gsl_test(joining_thread_tests)
+if(WIN32)
+add_gsl_test(joining_thread_native_handle_windows_tests)
+else()
+add_gsl_test(joining_thread_native_handle_posix_tests)
+endif()
 
 # No exception tests
 

--- a/tests/joining_thread_native_handle_posix_tests.cpp
+++ b/tests/joining_thread_native_handle_posix_tests.cpp
@@ -14,17 +14,14 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef GSL_GSL_H
-#define GSL_GSL_H
+#include <catch/catch.hpp>
+#include <gsl/joining_thread>
 
-#include <gsl/gsl_algorithm>  // copy
-#include <gsl/gsl_assert>     // Ensures/Expects
-#include <gsl/gsl_byte>       // byte
-#include <gsl/gsl_util>       // finally()/narrow()/narrow_cast()...
-#include <gsl/joining_thread> // joining_thread
-#include <gsl/multi_span>     // multi_span, strided_span...
-#include <gsl/pointers>       // owner, not_null
-#include <gsl/span>           // span
-#include <gsl/string_span>    // zstring, string_span, zstring_builder...
-
-#endif // GSL_GSL_H
+TEST_CASE("joining_thread native_handle posix")
+{
+    gsl::joining_thread thread([]() {});
+    sched_param sch{};
+    int policy{};
+    auto result = pthread_getschedparam(thread.native_handle(), &policy, &sch);
+    REQUIRE(result != ESRCH);
+}

--- a/tests/joining_thread_native_handle_windows_tests.cpp
+++ b/tests/joining_thread_native_handle_windows_tests.cpp
@@ -14,17 +14,13 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef GSL_GSL_H
-#define GSL_GSL_H
+#include <catch/catch.hpp>
+#include <gsl/joining_thread>
+#include <windows.h>
 
-#include <gsl/gsl_algorithm>  // copy
-#include <gsl/gsl_assert>     // Ensures/Expects
-#include <gsl/gsl_byte>       // byte
-#include <gsl/gsl_util>       // finally()/narrow()/narrow_cast()...
-#include <gsl/joining_thread> // joining_thread
-#include <gsl/multi_span>     // multi_span, strided_span...
-#include <gsl/pointers>       // owner, not_null
-#include <gsl/span>           // span
-#include <gsl/string_span>    // zstring, string_span, zstring_builder...
-
-#endif // GSL_GSL_H
+TEST_CASE("joining_thread native_handle windows")
+{
+    gsl::joining_thread thread([]() {});
+    auto result = GetThreadPriority(thread.native_handle());
+    REQUIRE(result != THREAD_PRIORITY_ERROR_RETURN);
+}

--- a/tests/joining_thread_tests.cpp
+++ b/tests/joining_thread_tests.cpp
@@ -1,0 +1,106 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <catch/catch.hpp>
+#include <gsl/joining_thread>
+#include <string>
+
+TEST_CASE("joining_thread construction")
+{
+    gsl::joining_thread t1{[]() {}};
+    std::string text{"joining_thread example"};
+    gsl::joining_thread t2{[](std::string) {}, text};
+    gsl::joining_thread t3{[](const std::string&) {}, text};
+    gsl::joining_thread t4{[](const std::string&) {}, std::ref(text)};
+    gsl::joining_thread t5{[](std::string&&) {}, text};
+    gsl::joining_thread t6{[](std::string&&) {}, std::move(text)};
+    std::string other_text{"second gsl::joining_thread example"};
+    gsl::joining_thread t7{[](std::string) {}, std::move(other_text)};
+    gsl::joining_thread t8{std::move(t1)};
+    gsl::joining_thread t9 = std::move(t5);
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        gsl::joining_thread t10{};    // should not compile - no default c-tor
+        gsl::joining_thread t11 = t6; // should not compile - no copy assigment
+        gsl::joining_thread t12(t7);  // should not compile - no copy c-tor
+    }
+#endif
+}
+
+TEST_CASE("joining_thread get_id")
+{
+    std::thread::id currentThreadId{};
+    std::thread::id joiningThreadId{};
+    {
+        gsl::joining_thread thread{
+            [&currentThreadId]() { currentThreadId = std::this_thread::get_id(); }};
+        joiningThreadId = thread.get_id();
+    }
+    REQUIRE(currentThreadId == joiningThreadId);
+}
+
+TEST_CASE("joining_thread hardware_concurrency")
+{
+    auto stdThreadHardwareConcurrency = std::thread::hardware_concurrency();
+    auto joiningThreadHardwareConcurrency = gsl::joining_thread::hardware_concurrency();
+    REQUIRE(joiningThreadHardwareConcurrency == stdThreadHardwareConcurrency);
+}
+
+TEST_CASE("joining_thread swap")
+{
+    {
+        gsl::joining_thread t1{[]() {}};
+        gsl::joining_thread t2{[]() {}};
+        auto t1BeforeSwapId = t1.get_id();
+        auto t2BeforeSwapId = t2.get_id();
+        std::swap(t1, t2);
+        REQUIRE(t1.get_id() == t2BeforeSwapId);
+        REQUIRE(t2.get_id() == t1BeforeSwapId);
+    }
+    {
+        gsl::joining_thread t1{[]() {}};
+        auto t1BeforeSwapId = t1.get_id();
+        std::swap(t1, gsl::joining_thread([]() {}));
+        REQUIRE(t1.get_id() != t1BeforeSwapId);
+    }
+    {
+        gsl::joining_thread t1{[]() {}};
+        auto t1BeforeSwapId = t1.get_id();
+        std::swap(gsl::joining_thread([]() {}), t1);
+        REQUIRE(t1.get_id() != t1BeforeSwapId);
+    }
+}
+
+TEST_CASE("check if joining_thread is running functor in seperate thread")
+{
+    struct Mock
+    {
+        bool called{false};
+        std::thread::id calledFrom{};
+    };
+    Mock mock{};
+    std::thread::id joiningThreadId{};
+    {
+        gsl::joining_thread t{[&mock]() {
+            mock.called = true;
+            mock.calledFrom = std::this_thread::get_id();
+        }};
+        joiningThreadId = t.get_id();
+    }
+    REQUIRE(mock.called);
+    REQUIRE(mock.calledFrom == joiningThreadId);
+    REQUIRE(joiningThreadId != std::this_thread::get_id());
+}

--- a/tests/joining_thread_tests.cpp
+++ b/tests/joining_thread_tests.cpp
@@ -31,9 +31,9 @@ TEST_CASE("joining_thread construction")
     gsl::joining_thread t7{[](std::string) {}, std::move(other_text)};
     gsl::joining_thread t8{std::move(t1)};
     gsl::joining_thread t9 = std::move(t5);
+    gsl::joining_thread t10;
 #ifdef CONFIRM_COMPILATION_ERRORS
     {
-        gsl::joining_thread t10{};    // should not compile - no default c-tor
         gsl::joining_thread t11 = t6; // should not compile - no copy assigment
         gsl::joining_thread t12(t7);  // should not compile - no copy c-tor
     }


### PR DESCRIPTION
Partial fix for issue: https://github.com/Microsoft/GSL/issues/471 Only `joining_thread` is added. It's possible to create joining_thread as global object, it'll behave like detached thread.

https://github.com/isocpp/CppCoreGuidelines/issues/925

I also took into account @hsutter comment from previous attempt: 
"The main thing is to get raii_thread whose destructor unconditionally joins, which is what std::thread should have done. That part looks fine. Then we can recommend using raii_thread everywhere."
https://github.com/Microsoft/GSL/pull/481