### PR TITLE
Iosfwd

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -21,7 +21,7 @@
 
 #include <gsl/gsl_assert>
 
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 #include <type_traits>
 

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -129,6 +129,38 @@ TEST_CASE("TestNotNullConstructors")
         std::make_shared<int>(10)); // shared_ptr<int> is nullptr assignable
 }
 
+template<typename T>
+void ostream_helper(T v)
+{
+    not_null<T*> p(&v);
+    {
+        std::ostringstream os;
+        std::ostringstream ref;
+        os << p;
+        ref << &v;
+        CHECK(os.str() == ref.str());
+    }
+    {
+        std::ostringstream os;
+        std::ostringstream ref;
+        os << *p;
+        ref << v;
+        CHECK(os.str() == ref.str());
+    }
+}
+
+TEST_CASE("TestNotNullostream")
+{
+    ostream_helper<int>(17);
+    ostream_helper<float>(21.5f);
+    ostream_helper<double>(3.4566e-7f);
+    ostream_helper<char>('c');
+    ostream_helper<uint16_t>(0x0123u);
+    ostream_helper<const char*>("cstring");
+    ostream_helper<std::string>("string");
+}
+
+
 TEST_CASE("TestNotNullCasting")
 {
     MyBase base;


### PR DESCRIPTION
Possible Solution to #576.

With restricting `gsl/pointer` to include `<iosfwd>` rather than `<iostream>` following application will no longer compile.
```
#include <gsl/gsl>
int main()
{
    int i;
    gsl::not_null<int*> p(&i);
    std::cout << p << std::endl;
}
```
Reason is simply because `gsl` no longer includes `<iostream>`, hence this needs to be done within the applications code as shown below.

```
#include <iostream>
#include <gsl/gsl>
int main()
{
    int i;
    gsl::not_null<int*> p(&i);
    std::cout << p << std::endl;
}
```
