### PR TITLE
Rename final_act in GSL.natvis

### DIFF
--- a/GSL.natvis
+++ b/GSL.natvis
@@ -11,7 +11,7 @@
     </Type>
 
     <!-- These types are from the gsl_util header. -->
-    <Type Name="gsl::final_act&lt;*&gt;">
+    <Type Name="gsl::final_action&lt;*&gt;">
         <DisplayString>{{ invoke = {invoke_}, action = {f_} }}</DisplayString>
         <Expand>
             <Item Name="[invoke]">invoke_</Item>


### PR DESCRIPTION
Commit 6e2e207c8d renamed final_act to final_action. Do this also in
GSL.natvis.