### PR TITLE
Fix for: issue #471 Adds gsl::joining_thread (replaces original PR #509)

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -20,6 +20,7 @@
 #include <gsl/gsl_algorithm> // copy
 #include <gsl/gsl_assert>    // Ensures/Expects
 #include <gsl/gsl_byte>      // byte
+#include <gsl/gsl_thread>    // joining_thread
 #include <gsl/gsl_util>      // finally()/narrow()/narrow_cast()...
 #include <gsl/multi_span>    // multi_span, strided_span...
 #include <gsl/pointers>      // owner, not_null

--- a/include/gsl/gsl_thread
+++ b/include/gsl/gsl_thread
@@ -1,0 +1,104 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef GSL_THREAD_H
+#define GSL_THREAD_H
+
+#include <thread>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(disable : 4127) // conditional expression is constant
+
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+#endif // _MSC_VER
+
+namespace gsl
+{
+
+class joining_thread
+{
+    friend void swap(joining_thread& t1, joining_thread& t2) noexcept;
+
+public:
+    joining_thread() noexcept = default;
+
+    joining_thread(joining_thread const&) = delete;
+    joining_thread(joining_thread&& other) : t(std::move(other.t)) {}
+
+    joining_thread(std::thread const&) = delete;
+    joining_thread(std::thread&& other) noexcept : t(std::move(other)) {}
+
+    joining_thread& operator=(joining_thread const&) = delete;
+    joining_thread& operator=(joining_thread&& other) noexcept
+    {
+        t = std::move(other.t);
+        return *this;
+    }
+
+    joining_thread& operator=(std::thread const&) = delete;
+    joining_thread& operator=(std::thread&& other) noexcept
+    {
+        t = std::move(other);
+        return *this;
+    }
+
+    template <typename Callable, typename... Args>
+    explicit joining_thread(Callable&& f, Args&&... args)
+        : t(std::forward<Callable>(f), std::forward<Args>(args)...)
+    {
+    }
+
+    ~joining_thread() { if (t.joinable()) t.join(); }
+
+    bool joinable() const { return t.joinable(); }
+
+    std::thread::id get_id() const noexcept { return t.get_id(); }
+
+    std::thread::native_handle_type native_handle() { return t.native_handle(); }
+
+    void join() { t.join(); }
+
+    void swap(joining_thread& other) noexcept
+    {
+        using std::swap;
+        swap(t, other.t);
+    }
+
+private:
+    std::thread t;
+};
+
+void swap(joining_thread& t1, joining_thread& t2) noexcept
+{
+    using std::swap;
+    swap(t1.t, t2.t);
+}
+
+} // namespace gsl
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
+#endif // GSL_THREAD_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,10 @@ target_link_libraries(gsl_tests_config INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:
         -pthread
     >
+    
+    $<$<CXX_COMPILER_ID:Clang>:
+        -pthread
+    >
 )
 
 # for tests to find the catch header

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(gsl_tests_config INTERFACE
     >
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:
         -fno-strict-aliasing
+        -pthread
         -Wall
         -Wcast-align
         -Wconversion
@@ -54,7 +55,7 @@ target_compile_options(gsl_tests_config INTERFACE
 )
 
 target_link_libraries(gsl_tests_config INTERFACE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:
+    $<$<CXX_COMPILER_ID:GNU>:
         -pthread
     >
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,12 @@ target_compile_options(gsl_tests_config INTERFACE
     >
 )
 
+target_link_libraries(gsl_tests_config INTERFACE
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:
+        -pthread
+    >
+)
+
 # for tests to find the catch header
 target_include_directories(gsl_tests_config INTERFACE
     ${CMAKE_BINARY_DIR}/external/include
@@ -101,3 +107,4 @@ add_gsl_test(utils_tests)
 add_gsl_test(owner_tests)
 add_gsl_test(byte_tests)
 add_gsl_test(algorithm_tests)
+add_gsl_test(thread_tests)

--- a/tests/thread_tests.cpp
+++ b/tests/thread_tests.cpp
@@ -1,0 +1,140 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <UnitTest++/UnitTest++.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gsl/gsl_assert>
+#include <gsl/gsl_thread>
+
+using std::chrono::steady_clock;
+using std::this_thread::sleep_for;
+
+const auto t_100ms = std::chrono::milliseconds(100);
+
+SUITE(raii_thread_tests)
+{
+    TEST(raii_thread_same_scope_clock_test)
+    {
+        auto start_time = steady_clock::now();
+
+        gsl::joining_thread t{[&]{ sleep_for(t_100ms); }};
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time < t_100ms);
+    }
+
+    TEST(raii_thread_different_scope_clock_test)
+    {
+        auto start_time = steady_clock::now();
+
+        {
+            gsl::joining_thread t{[&]{ sleep_for(t_100ms); }};
+        }
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time >= t_100ms);
+    }
+
+    TEST(raii_thread_ctor_test)
+    {
+        auto start_time = steady_clock::now();
+
+        gsl::joining_thread t1{[&]{ sleep_for(t_100ms); }};
+
+        {
+            gsl::joining_thread t2{std::move(t1)};
+        }
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time >= t_100ms);
+    }
+
+    TEST(raii_thread_assign_test)
+    {
+        auto start_time = steady_clock::now();
+
+        gsl::joining_thread t1{[&]{ sleep_for(t_100ms); }};
+
+        {
+            gsl::joining_thread t2;
+            t2 = std::move(t1);
+        }
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time >= t_100ms);
+    }
+
+    TEST(raii_thread_std_thread_ctor_test)
+    {
+        auto start_time = steady_clock::now();
+
+        std::thread t1{[&]{ sleep_for(t_100ms); }};
+
+        {
+            gsl::joining_thread t2{std::move(t1)};
+        }
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time >= t_100ms);
+    }
+
+    TEST(raii_thread_std_thread_assign_test)
+    {
+        auto start_time = steady_clock::now();
+
+        std::thread t1{[&]{ sleep_for(t_100ms); }};
+
+        {
+            gsl::joining_thread t2;
+            t2 = std::move(t1);
+        }
+
+        auto end_time = steady_clock::now();
+
+        CHECK(end_time - start_time >= t_100ms);
+    }
+
+    TEST(raii_thread_swap_test)
+    {
+        gsl::joining_thread t1{[&]{ sleep_for(t_100ms); }};
+        gsl::joining_thread t2{[&]{ sleep_for(t_100ms); }};
+
+        auto id1 = t1.get_id();
+        auto id2 = t2.get_id();
+
+        std::swap(t1, t2);
+
+        CHECK(t1.get_id() == id2);
+        CHECK(t2.get_id() == id1);
+
+        t1.swap(t2);
+
+        CHECK(t1.get_id() == id1);
+        CHECK(t2.get_id() == id2);
+    }
+}
+
+int main() { return UnitTest::RunAllTests(); }
+

--- a/tests/thread_tests.cpp
+++ b/tests/thread_tests.cpp
@@ -28,9 +28,9 @@ using std::this_thread::sleep_for;
 
 const auto t_100ms = std::chrono::milliseconds(100);
 
-SUITE(raii_thread_tests)
+SUITE(joining_thread_tests)
 {
-    TEST(raii_thread_same_scope_clock_test)
+    TEST(joining_thread_same_scope_clock_test)
     {
         auto start_time = steady_clock::now();
 
@@ -41,7 +41,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time < t_100ms);
     }
 
-    TEST(raii_thread_different_scope_clock_test)
+    TEST(joining_thread_different_scope_clock_test)
     {
         auto start_time = steady_clock::now();
 
@@ -54,7 +54,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(raii_thread_ctor_test)
+    TEST(joining_thread_ctor_test)
     {
         auto start_time = steady_clock::now();
 
@@ -69,7 +69,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(raii_thread_assign_test)
+    TEST(joining_thread_assign_test)
     {
         auto start_time = steady_clock::now();
 
@@ -85,7 +85,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(raii_thread_std_thread_ctor_test)
+    TEST(joining_thread_std_thread_ctor_test)
     {
         auto start_time = steady_clock::now();
 
@@ -100,7 +100,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(raii_thread_std_thread_assign_test)
+    TEST(joining_thread_std_thread_assign_test)
     {
         auto start_time = steady_clock::now();
 
@@ -116,7 +116,7 @@ SUITE(raii_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(raii_thread_swap_test)
+    TEST(joining_thread_swap_test)
     {
         gsl::joining_thread t1{[&]{ sleep_for(t_100ms); }};
         gsl::joining_thread t2{[&]{ sleep_for(t_100ms); }};

--- a/tests/thread_tests.cpp
+++ b/tests/thread_tests.cpp
@@ -14,7 +14,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <UnitTest++/UnitTest++.h>
+#include <catch/catch.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -28,9 +28,9 @@ using std::this_thread::sleep_for;
 
 const auto t_100ms = std::chrono::milliseconds(100);
 
-SUITE(joining_thread_tests)
+TEST_CASE("joining_thread_tests")
 {
-    TEST(joining_thread_same_scope_clock_test)
+    SECTION("joining_thread_same_scope_clock_test")
     {
         auto start_time = steady_clock::now();
 
@@ -41,7 +41,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time < t_100ms);
     }
 
-    TEST(joining_thread_different_scope_clock_test)
+    SECTION("joining_thread_different_scope_clock_test")
     {
         auto start_time = steady_clock::now();
 
@@ -54,7 +54,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(joining_thread_ctor_test)
+    SECTION("joining_thread_ctor_test")
     {
         auto start_time = steady_clock::now();
 
@@ -69,7 +69,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(joining_thread_assign_test)
+    SECTION("joining_thread_assign_test")
     {
         auto start_time = steady_clock::now();
 
@@ -85,7 +85,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(joining_thread_std_thread_ctor_test)
+    SECTION("joining_thread_std_thread_ctor_test")
     {
         auto start_time = steady_clock::now();
 
@@ -100,7 +100,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(joining_thread_std_thread_assign_test)
+    SECTION("joining_thread_std_thread_assign_test")
     {
         auto start_time = steady_clock::now();
 
@@ -116,7 +116,7 @@ SUITE(joining_thread_tests)
         CHECK(end_time - start_time >= t_100ms);
     }
 
-    TEST(joining_thread_swap_test)
+    SECTION("joining_thread_swap_test")
     {
         gsl::joining_thread t1{[&]{ sleep_for(t_100ms); }};
         gsl::joining_thread t2{[&]{ sleep_for(t_100ms); }};
@@ -136,5 +136,4 @@ SUITE(joining_thread_tests)
     }
 }
 
-int main() { return UnitTest::RunAllTests(); }
 


### PR DESCRIPTION
This PR adds <gsl/gsl_thread> and tests/thread_tests.cpp

As per discussion in CppCoreGuidelines https://github.com/isocpp/CppCoreGuidelines/issues/925

This PR provides `gsl::joining_thread` (gsl::detached_thread was removed)

(This PR is a cleaned up version of PR #509 - deleted)