### PR TITLE
Fix wrong check of the CMAKE_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif ()
 
 # when minimum version required is 3.8.0 remove if below
 # both branches do exactly the same thing
-if (CMAKE_MAJOR_VERSION VERSION_LESS 3.7.9)
+if (CMAKE_VERSION VERSION_LESS 3.7.9)
     if (NOT MSVC)
         include(CheckCXXCompilerFlag)
         CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)


### PR DESCRIPTION
`CMAKE_VERSION_MAJOR` is just the first component of the CMake version (e.g. 3 for 3.10.1) which compares less than `3.7.9` if it is less than 3. The proper variable to compare is `CMAKE_VERSION` which contains the full version number.