### PR TITLE
add const in string_span

### DIFF
--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -98,7 +98,7 @@ namespace details
     {
         if (str == nullptr || n <= 0) return 0;
 
-        span<const CharT> str_span{str, n};
+        const span<const CharT> str_span{str, n};
 
         std::ptrdiff_t len = 0;
         while (len < n && str_span[len]) len++;


### PR DESCRIPTION
Resolves compiler code analysis warning ...\gsl\include\gsl\string_span(101): warning C26496: The variable 'str_span' is assigned only once, mark it as const (con.4: https://go.microsoft.com/fwlink/p/?LinkID=784969).