### PR TITLE
add constexpr and noexcept in multi_span

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -1052,7 +1052,7 @@ struct dim_t<dynamic_range>
 {
     static const std::ptrdiff_t value = dynamic_range;
     const std::ptrdiff_t dvalue;
-    dim_t(std::ptrdiff_t size) : dvalue(size) {}
+    constexpr dim_t(std::ptrdiff_t size) GSL_NOEXCEPT : dvalue(size) {}
 };
 
 template <std::ptrdiff_t N, class = std::enable_if_t<(N >= 0)>>


### PR DESCRIPTION
Prevents MSVC code analysis warning
...\gsl\include\gsl\multi_span(1055): warning C26440: Function 'gsl::dim_t<-1>::dim_t<-1>' can be declared 'noexcept' (f.6: http://go.microsoft.com/fwlink/?linkid=853927).