### PR TITLE
Don't use clang's __builtin_assume as an optimizer hint

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -52,12 +52,10 @@
 //
 #ifdef _MSC_VER
 #define GSL_ASSUME(cond) __assume(cond)
-#elif defined(__clang__)
-#define GSL_ASSUME(cond) __builtin_assume(cond)
 #elif defined(__GNUC__)
 #define GSL_ASSUME(cond) ((cond) ? static_cast<void>(0) : __builtin_unreachable())
 #else
-#define GSL_ASSUME(cond) static_cast<void>(!!(cond))
+#define GSL_ASSUME(cond) static_cast<void>((cond) ? 0 : 0)
 #endif
 
 //


### PR DESCRIPTION
Fixes #607.

Drive-by: use '?:' to contextually convert to bool in the fallback definition of `GSL_ASSUME`