### PR TITLE
gsl::index bug fix

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -135,7 +135,7 @@ public:
         return std::equal(elems, elems + rank, rhs.elems);
     }
 
-    constexpr bool operator!=(const index& rhs) const GSL_NOEXCEPT { return !(this == rhs); }
+    constexpr bool operator!=(const index& rhs) const GSL_NOEXCEPT { return !(*this == rhs); }
 
     constexpr index operator+() const GSL_NOEXCEPT { return *this; }
 


### PR DESCRIPTION
Fixing a bug in the != operator in the gsl::index class