### PR TITLE
Fix return type of templated span.subspan()

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -345,7 +345,7 @@ public:
 
     using size_type = index_type;
 
-#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND>)
+#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
     static constexpr const index_type extent { Extent };
 #else
     static constexpr index_type extent { Extent };

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -345,11 +345,8 @@ public:
 
     using size_type = index_type;
 
-#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
-    enum : index_type { extent = Extent };
-#else
     static constexpr index_type extent { Extent };
-#endif
+
     // [span.cons], span constructors, copy, assignment, and destructor
     template <bool Dependent = false,
               // "Dependent" is needed to make "std::enable_if_t<Dependent || Extent <= 0>" SFINAE,
@@ -549,6 +546,11 @@ private:
         return { data() + offset,  count, true };
     }
 };
+
+#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::index_type span<ElementType, Extent>::extent;
+#endif
 
 
 // [span.comparison], span comparison operators

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -45,8 +45,17 @@
 #if _MSC_VER < 1910
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
+#define USE_STATIC_CONSTEXPR_WORKAROUND
 
 #endif                          // _MSC_VER < 1910
+#else                           // _MSC_VER
+
+// See if we have enough C++17 power to use a static constexpr data member
+// without needing an out-of-line definition
+#if !(defined(__cplusplus) && (__cplusplus >= 201703L))
+#define GSL_USE_STATIC_CONSTEXPR_WORKAROUND
+#endif // !(defined(__cplusplus) && (__cplusplus >= 201703L))
+
 #endif                          // _MSC_VER
 
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
@@ -309,6 +318,12 @@ namespace details
     private:
         index_type size_;
     };
+
+    template <class ElementType, std::ptrdiff_t Extent, std::ptrdiff_t Offset, std::ptrdiff_t Count>
+    struct calculate_subspan_type
+    {
+      using type = span<ElementType, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset - 1 : Extent)>;
+    };
 } // namespace details
 
 // [span], class template span
@@ -330,8 +345,11 @@ public:
 
     using size_type = index_type;
 
-    constexpr static const index_type extent = Extent;
-
+#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
+    enum { extent = Extent };
+#else
+    static constexpr index_type extent { Extent };
+#endif
     // [span.cons], span constructors, copy, assignment, and destructor
     template <bool Dependent = false,
               // "Dependent" is needed to make "std::enable_if_t<Dependent || Extent <= 0>" SFINAE,
@@ -432,12 +450,12 @@ public:
     }
 
     template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent>
-    constexpr span<element_type, Count> subspan() const
+    constexpr auto subspan() const -> typename details::calculate_subspan_type<ElementType, Extent, Offset, Count>::type
     {
         Expects((Offset >= 0 && size() - Offset >= 0) &&
                 (Count == dynamic_extent || (Count >= 0 && Offset + Count <= size())));
 
-        return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
+        return {data() + Offset, Count == dynamic_extent ? size() - Offset - 1 : Count};
     }
 
     constexpr span<element_type, dynamic_extent> first(index_type count) const

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -345,7 +345,11 @@ public:
 
     using size_type = index_type;
 
+#if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND>)
+    static constexpr const index_type extent { Extent };
+#else
     static constexpr index_type extent { Extent };
+#endif
 
     // [span.cons], span constructors, copy, assignment, and destructor
     template <bool Dependent = false,
@@ -549,7 +553,7 @@ private:
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
 template <class ElementType, std::ptrdiff_t Extent>
-constexpr typename span<ElementType, Extent>::index_type span<ElementType, Extent>::extent;
+constexpr const typename span<ElementType, Extent>::index_type span<ElementType, Extent>::extent;
 #endif
 
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -45,7 +45,7 @@
 #if _MSC_VER < 1910
 #pragma push_macro("constexpr")
 #define constexpr /*constexpr*/
-#define USE_STATIC_CONSTEXPR_WORKAROUND
+#define GSL_USE_STATIC_CONSTEXPR_WORKAROUND
 
 #endif                          // _MSC_VER < 1910
 #else                           // _MSC_VER
@@ -322,7 +322,7 @@ namespace details
     template <class ElementType, std::ptrdiff_t Extent, std::ptrdiff_t Offset, std::ptrdiff_t Count>
     struct calculate_subspan_type
     {
-      using type = span<ElementType, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset - 1 : Extent)>;
+      using type = span<ElementType, Count != dynamic_extent ? Count : (Extent != dynamic_extent ? Extent - Offset : Extent)>;
     };
 } // namespace details
 
@@ -346,7 +346,7 @@ public:
     using size_type = index_type;
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
-    enum { extent = Extent };
+    enum : index_type { extent = Extent };
 #else
     static constexpr index_type extent { Extent };
 #endif
@@ -442,7 +442,7 @@ public:
         Expects((Offset >= 0 && size() - Offset >= 0) &&
                 (Count == dynamic_extent || (Count >= 0 && Offset + Count <= size())));
 
-        return {data() + Offset, Count == dynamic_extent ? size() - Offset - 1 : Count};
+        return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
     }
 
     constexpr span<element_type, dynamic_extent> first(index_type count) const

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -809,8 +809,8 @@ TEST_CASE("subspan")
 
     {
         span<int, 5> av = arr;
-        CHECK((av.subspan<1>().size() == 3));
-        CHECK(decltype(av.subspan<1>())::extent == 3);    
+        CHECK((av.subspan<1>().size() == 4));
+        CHECK(decltype(av.subspan<1>())::extent == 4);    
     }
 
     {

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -776,6 +776,7 @@ TEST_CASE("subspan")
     {
         span<int, 5> av = arr;
         CHECK((av.subspan<2, 2>().size() == 2));
+        CHECK(decltype(av.subspan<2, 2>())::extent == 2);
         CHECK(av.subspan(2, 2).size() == 2);
         CHECK(av.subspan(2, 3).size() == 3);
     }
@@ -783,13 +784,16 @@ TEST_CASE("subspan")
     {
         span<int, 5> av = arr;
         CHECK((av.subspan<0, 0>().size() == 0));
+        CHECK(decltype(av.subspan<0,0>())::extent == 0);
         CHECK(av.subspan(0, 0).size() == 0);
     }
 
     {
         span<int, 5> av = arr;
         CHECK((av.subspan<0, 5>().size() == 5));
+        CHECK(decltype(av.subspan<0, 5>())::extent == 5);
         CHECK(av.subspan(0, 5).size() == 5);
+
         CHECK_THROWS_AS(av.subspan(0, 6).size(), fail_fast);
         CHECK_THROWS_AS(av.subspan(1, 5).size(), fail_fast);
     }
@@ -797,14 +801,22 @@ TEST_CASE("subspan")
     {
         span<int, 5> av = arr;
         CHECK((av.subspan<4, 0>().size() == 0));
+        CHECK(decltype(av.subspan<4, 0>())::extent == 0);
         CHECK(av.subspan(4, 0).size() == 0);
         CHECK(av.subspan(5, 0).size() == 0);
         CHECK_THROWS_AS(av.subspan(6, 0).size(), fail_fast);
     }
 
     {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<1>().size() == 3));
+        CHECK(decltype(av.subspan<1>())::extent == 3);    
+    }
+
+    {
         span<int> av;
         CHECK((av.subspan<0, 0>().size() == 0));
+        CHECK((decltype(av.subspan<0, 0>())::extent == 0));
         CHECK(av.subspan(0, 0).size() == 0);
         CHECK_THROWS_AS((av.subspan<1, 0>().size()), fail_fast);
     }


### PR DESCRIPTION
This PR modifies the return type of the templated version of `span::subspan()` so that it returns a fixed-sized span wherever possible. This is important for encouraging optimization of code that uses `subspan()`.

Writing the tests for this made me actually use `span::extent` which made me realize that it does not work unless you are using a C++17-compliant compiler, so I also added a workaround to make `span::extent` available on C++11/14 compilers until we can all live in the better world of C++17. ;-)