### PR TITLE
=default

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -99,7 +99,7 @@ public:
     using reference = std::add_lvalue_reference_t<value_type>;
     using const_reference = std::add_lvalue_reference_t<std::add_const_t<value_type>>;
 
-    constexpr multi_span_index() GSL_NOEXCEPT {}
+    constexpr multi_span_index() GSL_NOEXCEPT = default;
 
     constexpr multi_span_index(const value_type (&values)[Rank]) GSL_NOEXCEPT
     {

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -276,7 +276,7 @@ namespace details
 
         static_assert(Ext >= 0, "A fixed-size span must be >= 0 in size.");
 
-        constexpr extent_type() GSL_NOEXCEPT {}
+        constexpr extent_type() GSL_NOEXCEPT = default;
 
         template <index_type Other>
         constexpr extent_type(extent_type<Other> ext)


### PR DESCRIPTION
clang tidy suggest making the two ctors with an empty body ("{}") "=default;".
I am not sure if there is any more benefit than being explicit.
And I hope it does not break anything (maybe only on some compilers or because of the combination with constexpr and noexcept).