### PR TITLE
Compare span_iterators to the same data

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -136,13 +136,13 @@ namespace details
 
     private:
         constexpr span_iterator(const Span* span, typename Span::index_type idx) noexcept
-            : span_(span), index_(idx)
+            : base_(span->data()), index_(idx), size_(span->size())
         {}
     public:
 
         template<bool B, std::enable_if_t<!B && IsConst>* = nullptr>
         constexpr span_iterator(const span_iterator<Span, B>& other) noexcept
-            : span_iterator(other.span_, other.index_)
+            : base_(other.base_), index_(other.index_), size_(other.size_)
         {
         }
 
@@ -152,26 +152,24 @@ namespace details
         friend bool compatible(const span_iterator& lhs,
                                const span_iterator& rhs)
         {
-          return (!lhs.span_ && !rhs.span_)
-              || ( lhs.span_ &&  rhs.span_
-                && lhs.span_->data() == rhs.span_->data());
+            return (lhs.base_ == rhs.base_ && lhs.size_ == rhs.size_);
         }
 
         constexpr reference operator*() const
         {
-            Expects(index_ != span_->size());
-            return *(span_->data() + index_);
+            Expects(size_t(index_) != size_);
+            return *(base_ + index_);
         }
 
         constexpr pointer operator->() const
         {
-            Expects(index_ != span_->size());
-            return span_->data() + index_;
+            Expects(size_t(index_) != size_);
+            return base_ + index_;
         }
 
         constexpr span_iterator& operator++()
         {
-            Expects(0 <= index_ && index_ != span_->size());
+            Expects(0 <= index_ && size_t(index_) != size_);
             ++index_;
             return *this;
         }
@@ -185,7 +183,7 @@ namespace details
 
         constexpr span_iterator& operator--()
         {
-            Expects(index_ != 0 && index_ <= span_->size());
+            Expects(index_ != 0 && size_t(index_) <= size_);
             --index_;
             return *this;
         }
@@ -205,7 +203,7 @@ namespace details
 
         constexpr span_iterator& operator+=(difference_type n)
         {
-            Expects((index_ + n) >= 0 && (index_ + n) <= span_->size());
+            Expects((index_ + n) >= 0 && size_t(index_ + n) <= size_);
             index_ += n;
             return *this;
         }
@@ -268,8 +266,9 @@ namespace details
         }
 
     protected:
-        const Span* span_ = nullptr;
+        pointer        base_  = nullptr;
         std::ptrdiff_t index_ = 0;
+        std::size_t    size_  = 0;
     };
 
     template <class Span, bool IsConst>

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -136,7 +136,7 @@ namespace details
 
     private:
         constexpr span_iterator(const Span* span, typename Span::index_type idx) noexcept
-            : base_(span->data()), index_(idx), size_(span->size())
+            : base_(span->data()), index_(idx), size_(size_t(span->size()))
         {}
     public:
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -201,7 +201,9 @@ namespace details
 
         constexpr difference_type operator-(span_iterator rhs) const GSL_NOEXCEPT
         {
-            Expects(span_->data() == rhs.span_->data());
+            Expects(!span_ && !rhs.span_ 
+                  || span_ &&  rhs.span_ && span_->data() == rhs.span_->data());
+
             return index_ - rhs.index_;
         }
 
@@ -213,9 +215,11 @@ namespace details
         constexpr friend bool operator==(span_iterator lhs,
                                          span_iterator rhs) GSL_NOEXCEPT
         {
-            return lhs.span_->data() == rhs.span_->data()
-                && lhs.span_->size() == rhs.span_->size()
-                && lhs.index_        == rhs.index_;
+            return (!lhs.span_ && !rhs.span_
+                  || lhs.span_ &&  rhs.span_
+                    && lhs.span_->data() == rhs.span_->data()
+                    && lhs.span_->size() == rhs.span_->size())
+                && lhs.index_ == rhs.index_;
         }
 
         constexpr friend bool operator!=(span_iterator lhs,
@@ -227,7 +231,10 @@ namespace details
         constexpr friend bool operator<(span_iterator lhs,
                                         span_iterator rhs) GSL_NOEXCEPT
         {
-            Expects(lhs.span_->data() == rhs.span_->data());
+            Expects(!lhs.span_ && !rhs.span_
+                  || lhs.span_ &&  rhs.span_
+                    && lhs.span_->data() == rhs.span_->data());
+
             return lhs.index_ < rhs.index_;
         }
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -233,7 +233,7 @@ namespace details
         }
 
         constexpr friend bool operator<(span_iterator lhs,
-                                        span_iterator rhs) GSL_NOEXCEPT
+                                        span_iterator rhs)
         {
             Expects( (!lhs.span_ && !rhs.span_)
                   || ( lhs.span_ &&  rhs.span_
@@ -243,19 +243,19 @@ namespace details
         }
 
         constexpr friend bool operator<=(span_iterator lhs,
-                                         span_iterator rhs) GSL_NOEXCEPT
+                                         span_iterator rhs)
         {
             return !(rhs < lhs);
         }
 
         constexpr friend bool operator>(span_iterator lhs,
-                                        span_iterator rhs) GSL_NOEXCEPT
+                                        span_iterator rhs)
         {
             return rhs < lhs;
         }
 
         constexpr friend bool operator>=(span_iterator lhs,
-                                         span_iterator rhs) GSL_NOEXCEPT
+                                         span_iterator rhs)
         {
             return !(rhs > lhs);
         }

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -201,8 +201,9 @@ namespace details
 
         constexpr difference_type operator-(span_iterator rhs) const GSL_NOEXCEPT
         {
-            Expects(!span_ && !rhs.span_ 
-                  || span_ &&  rhs.span_ && span_->data() == rhs.span_->data());
+            Expects( (!span_ && !rhs.span_)
+                  || ( span_ &&  rhs.span_ 
+                    && span_->data() == rhs.span_->data()));
 
             return index_ - rhs.index_;
         }
@@ -215,10 +216,10 @@ namespace details
         constexpr friend bool operator==(span_iterator lhs,
                                          span_iterator rhs) GSL_NOEXCEPT
         {
-            return (!lhs.span_ && !rhs.span_
-                  || lhs.span_ &&  rhs.span_
+            return ( (!lhs.span_ && !rhs.span_)
+                  || ( lhs.span_ &&  rhs.span_
                     && lhs.span_->data() == rhs.span_->data()
-                    && lhs.span_->size() == rhs.span_->size())
+                    && lhs.span_->size() == rhs.span_->size()))
                 && lhs.index_ == rhs.index_;
         }
 
@@ -231,9 +232,9 @@ namespace details
         constexpr friend bool operator<(span_iterator lhs,
                                         span_iterator rhs) GSL_NOEXCEPT
         {
-            Expects(!lhs.span_ && !rhs.span_
-                  || lhs.span_ &&  rhs.span_
-                    && lhs.span_->data() == rhs.span_->data());
+            Expects( (!lhs.span_ && !rhs.span_)
+                  || ( lhs.span_ &&  rhs.span_
+                    && lhs.span_->data() == rhs.span_->data()));
 
             return lhs.index_ < rhs.index_;
         }

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -201,7 +201,7 @@ namespace details
 
         constexpr difference_type operator-(span_iterator rhs) const GSL_NOEXCEPT
         {
-            Expects(span_ == rhs.span_);
+            Expects(span_->data() == rhs.span_->data());
             return index_ - rhs.index_;
         }
 
@@ -213,7 +213,9 @@ namespace details
         constexpr friend bool operator==(span_iterator lhs,
                                          span_iterator rhs) GSL_NOEXCEPT
         {
-            return lhs.span_ == rhs.span_ && lhs.index_ == rhs.index_;
+            return lhs.span_->data() == rhs.span_->data()
+                && lhs.span_->size() == rhs.span_->size()
+                && lhs.index_        == rhs.index_;
         }
 
         constexpr friend bool operator!=(span_iterator lhs,
@@ -225,7 +227,7 @@ namespace details
         constexpr friend bool operator<(span_iterator lhs,
                                         span_iterator rhs) GSL_NOEXCEPT
         {
-            Expects(lhs.span_ == rhs.span_);
+            Expects(lhs.span_->data() == rhs.span_->data());
             return lhs.index_ < rhs.index_;
         }
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -134,16 +134,20 @@ namespace details
 
         span_iterator() = default;
 
+    private:
         constexpr span_iterator(const Span* span, typename Span::index_type idx) noexcept
             : span_(span), index_(idx)
         {}
+    public:
 
-        friend span_iterator<Span, true>;
         template<bool B, std::enable_if_t<!B && IsConst>* = nullptr>
         constexpr span_iterator(const span_iterator<Span, B>& other) noexcept
             : span_iterator(other.span_, other.index_)
         {
         }
+
+        friend Span;
+        friend span_iterator<Span, true>;
 
         constexpr reference operator*() const
         {

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -149,6 +149,14 @@ namespace details
         friend Span;
         friend span_iterator<Span, true>;
 
+        friend bool compatible(const span_iterator& lhs,
+                               const span_iterator& rhs)
+        {
+          return (!lhs.span_ && !rhs.span_)
+              || ( lhs.span_ &&  rhs.span_
+                && lhs.span_->data() == rhs.span_->data());
+        }
+
         constexpr reference operator*() const
         {
             Expects(index_ != span_->size());
@@ -212,10 +220,7 @@ namespace details
 
         constexpr difference_type operator-(span_iterator rhs) const
         {
-            Expects( (!span_ && !rhs.span_)
-                  || ( span_ &&  rhs.span_ 
-                    && span_->data() == rhs.span_->data()));
-
+            Expects(compatible(*this, rhs));
             return index_ - rhs.index_;
         }
 
@@ -225,17 +230,14 @@ namespace details
         }
 
         constexpr friend bool operator==(span_iterator lhs,
-                                         span_iterator rhs) noexcept
+                                         span_iterator rhs)
         {
-            return ( (!lhs.span_ && !rhs.span_)
-                  || ( lhs.span_ &&  rhs.span_
-                    && lhs.span_->data() == rhs.span_->data()
-                    && lhs.span_->size() == rhs.span_->size()))
-                && lhs.index_ == rhs.index_;
+            Expects(compatible(lhs, rhs));
+            return lhs.index_ == rhs.index_;
         }
 
         constexpr friend bool operator!=(span_iterator lhs,
-                                         span_iterator rhs) noexcept
+                                         span_iterator rhs)
         {
             return !(lhs == rhs);
         }
@@ -243,10 +245,7 @@ namespace details
         constexpr friend bool operator<(span_iterator lhs,
                                         span_iterator rhs)
         {
-            Expects( (!lhs.span_ && !rhs.span_)
-                  || ( lhs.span_ &&  rhs.span_
-                    && lhs.span_->data() == rhs.span_->data()));
-
+            Expects(compatible(lhs, rhs));
             return lhs.index_ < rhs.index_;
         }
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -957,6 +957,48 @@ TEST_CASE("iterator_comparisons")
         CHECK(it2 > cit);
         CHECK(it2 >= cit);
     }
+    {
+        span<int> s1 = a;
+        span<int> s2 = a;
+        span<int> s3 = s1.subspan(0, 3);
+
+        span<int>::iterator it1 = s1.begin();
+        auto it1a = it1 + 1;
+        span<int>::iterator it2 = s2.begin();
+        auto it2a = it2 + 1;
+        span<int>::iterator it3 = s3.begin();
+        auto it3a = it3 + 1;
+
+        CHECK(it1 == it2);
+        CHECK(it2 == it1);
+        CHECK(it1a == it2a);
+        CHECK(it2a == it1a);
+
+        CHECK(it1 != it3);
+        CHECK(it3 != it1);
+        CHECK(it1a != it3a);
+        CHECK(it3a != it1a);
+
+        CHECK(it1 < it1a);
+        CHECK(it1 < it2a);
+        CHECK(it1 < it3a);
+        CHECK(it2 < it1a);
+        CHECK(it2 < it2a);
+        CHECK(it2 < it3a);
+        CHECK(it3 < it1a);
+        CHECK(it3 < it2a);
+        CHECK(it3 < it3a);
+
+        CHECK(it1a - it1 == 1);
+        CHECK(it2a - it1 == 1);
+        CHECK(it3a - it1 == 1);
+        CHECK(it1a - it2 == 1);
+        CHECK(it2a - it2 == 1);
+        CHECK(it3a - it2 == 1);
+        CHECK(it1a - it3 == 1);
+        CHECK(it2a - it3 == 1);
+        CHECK(it3a - it3 == 1);
+    }
 }
 
 TEST_CASE("begin_end")


### PR DESCRIPTION
For example, when span1 and span2 refer to the same data, this allows you to use begin(span1) and end(span2) to form a valid range.  It's useful when you're creating identical temporary spans just for the purpose of getting the iterators out:

`copy(begin(make_span(weird_container), end(make_span(weird_container), begin(some_vector));`