### PR TITLE
Fix warning 4996 on Microsoft compiler

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -121,6 +121,12 @@ namespace details
         using element_type_ = typename Span::element_type;
 
     public:
+
+#ifdef _MSC_VER
+        // Tell Microsoft standard library that span_iterators are checked.
+        using _Unchecked_type = typename Span::pointer;
+#endif
+
         using iterator_category = std::random_access_iterator_tag;
         using value_type = std::remove_cv_t<element_type_>;
         using difference_type = typename Span::index_type;


### PR DESCRIPTION
This addresses issue #621 in a more general way than pull request #622.  By adding `_Unchecked_type` to `span_iterator`, the Microsoft standard library will assume that `span_iterator` is checked, which it is.

Pull request #622 wraps the `span_iterator` in a `checked_array_iterator`, which is redundant because `span_iterator` is already checked.  Furthermore, #622 is only a very specific fix for `gsl::copy` in particular.  The change in this pull request will allow you to use `span_iterator` for any of the STL algorithms without warning.