### PR TITLE
Suppress warnings on VS

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -103,6 +103,10 @@ namespace details
 #if defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
     template <typename Exception>
+#if defined(__clang__) || defined(__GNUC__)
+#else
+    [[gsl::suppress(f.6)]]
+#endif
     [[noreturn]] void throw_exception(Exception&&)
     {
         gsl::details::terminate();

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -88,6 +88,10 @@ final_action<F> finally(F&& f) noexcept
 
 // narrow_cast(): a searchable way to do narrowing casts of values
 template <class T, class U>
+#if defined(__clang__) || defined(__GNUC__)
+#else
+[[gsl::suppress(type.1)]]
+#endif
 constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
@@ -108,6 +112,10 @@ namespace details
 
 // narrow() : a checked version of narrow_cast() that throws if the cast changed the value
 template <class T, class U>
+#if defined(__clang__) || defined(__GNUC__)
+#else
+[[gsl::suppress(type.1)]]
+#endif
 T narrow(U u)
 {
     T t = narrow_cast<T>(u);
@@ -121,6 +129,10 @@ T narrow(U u)
 // at() - Bounds-checked way of accessing builtin arrays, std::array, std::vector
 //
 template <class T, std::size_t N>
+#if defined(__clang__) || defined(__GNUC__)
+#else
+[[gsl::suppress(type.1,bounds.2,bounds.4)]]
+#endif
 constexpr T& at(T (&arr)[N], const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(N));
@@ -128,6 +140,10 @@ constexpr T& at(T (&arr)[N], const index i)
 }
 
 template <class Cont>
+#if defined(__clang__) || defined(__GNUC__)
+#else
+[[gsl::suppress(type.1,bounds.4)]]
+#endif
 constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));


### PR DESCRIPTION
For this short code snippet
```
#include <gsl/gsl_util>
#include <vector>

void pr642()
{
	short buf[3];
	std::vector<short> vec(3);
	gsl::at(buf, 2) = gsl::narrow<short>(42);
	gsl::at(vec, 2) = gsl::narrow<short>(42);
}

```
VS 15.6.2 code analysis generates annoying warnings.
> ...\gsl\include\gsl\gsl_util(93) : warning C26472 : Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow (type.1).
> ...\gsl\include\gsl\gsl_util(127) : warning C26472 : Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow (type.1).
> ...\gsl\include\gsl\gsl_util(127) : warning C26482 : Only index into arrays using constant expressions(bounds.2).
> ...\gsl\include\gsl\gsl_util(127) : warning C26446 : Prefer to use gsl::at() instead of unchecked subscript operator (bounds.4).
> ...\gsl\include\gsl\gsl_util(114) : warning C26472 : Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow (type.1).
> ...\gsl\include\gsl\gsl_util(135) : warning C26472 : Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow (type.1).
> ...\gsl\include\gsl\gsl_util(135) : warning C26446 : Prefer to use gsl::at() instead of unchecked subscript operator (bounds.4).
> ...\gsl\include\gsl\gsl_assert(106) : warning C26440 : Function 'gsl::details::throw_exception<gsl::narrowing_error>' can be declared 'noexcept' (f.6).

gsl::narrow, gsl::narrow_cast and gsl::at are the safe variants suggested by CppCoreGuideline. It does not make sense to let VS warn inside the implementation of these functions that unsafe static_cast is used and that the safe variants shall be used.