### PR TITLE
Make not_null work with move-only types like unique_ptr

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -82,6 +82,7 @@ public:
     {
     }
 
+    not_null(not_null&& other) = default;
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -68,7 +68,17 @@ using owner = T;
 template <class T>
 class not_null
 {
+private:
+    constexpr T & _get() const
+    {	    
+	Ensures(ptr_ != nullptr);
+	return const_cast<T&>(ptr_); // required to not propogate not-null constness to pointee
+    }
+    
 public:
+
+    using pointer = T;
+
     static_assert(std::is_assignable<T&, std::nullptr_t>::value, "T cannot be assigned nullptr.");
 
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
@@ -86,15 +96,16 @@ public:
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
 
-    constexpr T get() const
+    constexpr const T & get() const
     {
-        Ensures(ptr_ != nullptr);
-        return ptr_;
+	return _get();
     }
 
-    constexpr operator T() const { return get(); }
-    constexpr T operator->() const { return get(); }
-    constexpr decltype(auto) operator*() const { return *get(); } 
+    constexpr operator const T&() const { return _get(); }
+    constexpr operator T&() { return _get(); }
+    
+    constexpr T & operator->() const { return _get(); }
+    constexpr decltype(auto) operator*() const { return *_get(); } 
 
     // prevents compilation when someone attempts to assign a null pointer constant
     not_null(std::nullptr_t) = delete;

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -327,3 +327,5 @@ TEST_CASE("TestNotNullCustomPtrComparison")
     CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
     CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
 }
+
+static_assert(std::is_nothrow_move_constructible<not_null<void *>>::value, "not_null must be no-throw move constructible");

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -56,6 +56,7 @@ struct CustomPtr
 {
     CustomPtr(T* p) : p_(p) {}
     operator T*() { return p_; }
+    operator const T*() const { return p_; }
     bool operator!=(std::nullptr_t) const { return p_ != nullptr; }
     T* p_ = nullptr;
 };
@@ -326,6 +327,26 @@ TEST_CASE("TestNotNullCustomPtrComparison")
     CHECK((NotNull1(p1) >= NotNull1(p1)) == "true");
     CHECK((NotNull1(p1) >= NotNull2(p2)) == (p1 >= p2));
     CHECK((NotNull2(p2) >= NotNull1(p1)) == (p2 >= p1));
+}
+
+
+struct UniquePtrTestStruct {
+    int i = 0;
+};
+
+TEST_CASE("TestNotNullUniquePtr")
+{
+    {
+	not_null<unique_ptr<int>> up = std::make_unique<int>(4);
+	CHECK(*up == 4);
+	*up = 5;
+	CHECK(*up == 5);
+    }
+    {
+	not_null<unique_ptr<UniquePtrTestStruct>> up = std::make_unique<UniquePtrTestStruct>();
+	up->i = 1;
+	CHECK(up->i == 1);
+    }
 }
 
 static_assert(std::is_nothrow_move_constructible<not_null<void *>>::value, "not_null must be no-throw move constructible");


### PR DESCRIPTION
Changed so you can have a not_null<unique_ptr<T>>.   All existing unit tests pass except for CustomPtr which didn't allow dereferencing a const CustomPtr, which seemed incorrect, so I added that behavior to CustomPtr and now all tests pass.

Checked that returning references for primitive types doesn't impact performance:  

https://godbolt.org/g/32QkEX

exact same ASM generated between modified version and current version.  