### PR TITLE
Fix clang-tidy warning about wrong comment on closing namespace

### DIFF
--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -698,7 +698,7 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other) GSL_N
     return !(one < other);
 }
 #endif
-} // namespace GSL
+} // namespace gsl
 
 #undef GSL_NOEXCEPT
 


### PR DESCRIPTION
This changes fixes the warning

> ...\..\GSL\include\gsl/string_span:701:2: warning: namespace 'gsl' ends with a comment that refers to a wrong namespace 'GSL' [google-readability-namespace-comments]
} // namespace GSL
> ^~~~~~~~~~~~~~~~~
>   // namespace gsl