### PR TITLE
final_action move assignment operator =delete against C26432

### DIFF
--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -60,6 +60,7 @@ public:
 
     final_action(const final_action&) = delete;
     final_action& operator=(const final_action&) = delete;
+    final_action& operator=(final_action&&) = delete;
 
     ~final_action() noexcept
     {


### PR DESCRIPTION
This suppresses warning C26432 on VS2017. Fixes issue #653.