### PR TITLE
Make gsl::details::throw_exception not copy exception object

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -113,7 +113,7 @@ namespace details
     template <typename Exception>
     [[noreturn]] void throw_exception(Exception&& exception)
     {
-        throw exception;
+        throw std::forward<Exception>(exception);
     }
 
 #endif


### PR DESCRIPTION
This fixes the build with clang 7 which introduces a new warning
`-Wreturn-std-move` which warns about needless copies when a move
operation is available (see https://reviews.llvm.org/rL329914).

We take the exception object by uref so we should throw the forwarded
version.