### PR TITLE
Add __may_alias__ attribute to gsl::byte

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -57,6 +57,13 @@
 
 #endif           // _MSC_VER
 
+// Use __may_alias__ attribute on gcc and clang
+#if defined __clang__ || (__GNUC__ > 5)
+#define byte_may_alias __attribute__((__may_alias__))
+#else // defined __clang__ || defined __GNUC__
+#define byte_may_alias
+#endif // defined __clang__ || defined __GNUC__
+
 namespace gsl
 {
 #if GSL_USE_STD_BYTE
@@ -69,7 +76,7 @@ using std::to_integer;
 
 // This is a simple definition for now that allows
 // use of byte within span<> to be standards-compliant
-enum class byte : unsigned char
+enum class byte_may_alias byte : unsigned char
 {
 };
 


### PR DESCRIPTION
C++20 defines `std::byte*` to have the same aliasing properties as
`char*`. Hence, we mark it with the `__may_alias__` attribute under gcc
and clang.

Fixes #663 

(Actually couldn't find whether this requirement is already in C++17 or not but gcc and clang already implement this in the compiler, trusting Niall on this part)