### PR TITLE
Cmake version requirement updated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ contributing any changes that were necessary back to this project to benefit the
 ## Building the tests
 To build the tests, you will require the following:
 
-* [CMake](http://cmake.org), version 3.7 or later to be installed and in your PATH.
+* [CMake](http://cmake.org), version 3.1.3 or later to be installed and in your PATH.
 
 These steps assume the source code of this repository has been cloned into a directory named `c:\GSL`.
 


### PR DESCRIPTION
Reverted to the previous cmake version requirement. Some common Linux distributions still do not support cmake 3.7 (Mint, Ubuntu LTS).