### PR TITLE
not_null no longer requires a copyable pointer type

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -84,6 +84,7 @@ public:
 
     not_null(not_null&& other) = default;
     not_null(const not_null& other) = default;
+    not_null& operator=(not_null&& other) = default;
     not_null& operator=(const not_null& other) = default;
 
     constexpr T const & get() const

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -86,14 +86,14 @@ public:
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
 
-    constexpr T get() const
+    constexpr T const & get() const
     {
         Ensures(ptr_ != nullptr);
         return ptr_;
     }
 
-    constexpr operator T() const { return get(); }
-    constexpr T operator->() const { return get(); }
+    constexpr operator T const & () const { return get(); }
+    constexpr T const & operator->() const { return get(); }
     constexpr decltype(auto) operator*() const { return *get(); } 
 
     // prevents compilation when someone attempts to assign a null pointer constant

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -71,14 +71,8 @@ class not_null
 public:
     static_assert(std::is_assignable<T&, std::nullptr_t>::value, "T cannot be assigned nullptr.");
 
-    template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
+    template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value && !std::is_same<std::nullptr_t, T>::value>>
     constexpr not_null(U&& u) : ptr_(std::forward<U>(u))
-    {
-        Expects(ptr_ != nullptr);
-    }
-
-    template <typename = std::enable_if_t<!std::is_same<std::nullptr_t, T>::value>>
-    constexpr not_null(T u) : ptr_(u)
     {
         Expects(ptr_ != nullptr);
     }
@@ -119,6 +113,11 @@ public:
 private:
     T ptr_;
 };
+
+#if defined(__cplusplus) && (__cplusplus >= 201703L)
+template<class T>
+not_null(T) -> not_null<T>;
+#endif // #if defined(__cplusplus) && (__cplusplus >= 201703L)
 
 template <class T>
 auto make_not_null(T&& t) {

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -440,7 +440,7 @@ TEST_CASE("TestNotNullUniquePtrComparison") {
         CHECK(p->i == NotNull1(std::make_unique<UniquePointerTestStruct>())->i);
     }
 }
-static_assert(!std::is_assignable<not_null<std::unique_ptr<int>>, std::unique_ptr<int>>::value, "not_null<std::unique_ptr> must be non assignable from std:unique_ptr");
+static_assert(!std::is_assignable<not_null<std::unique_ptr<int>>, std::unique_ptr<int>&>::value, "not_null<std::unique_ptr> must be non assignable from std:unique_ptr lvalues");
 static_assert(!std::is_copy_constructible<not_null<std::unique_ptr<int>>>::value, "not_null<std::unique_ptr> must be non copy constructible");
 static_assert(!std::is_copy_assignable<not_null<std::unique_ptr<int>>>::value, "not_null<std::unique_ptr> must be non copy assignable");
 static_assert(std::is_nothrow_move_constructible<not_null<std::unique_ptr<int>>>::value, "not_null<std::unique_ptr> must be no-throw move constructible");
@@ -492,7 +492,7 @@ TEST_CASE("TestNotNullSharedPtrValueComparison") {
         CHECK(p->i == NotNull1(std::make_shared<UniquePointerTestStruct>())->i);
     }
 }
-static_assert(!std::is_assignable<not_null<std::shared_ptr<int>>, std::shared_ptr<int>>::value, "not_null<std::shared_ptr> must be non assignable from std::shared_ptr");
+static_assert(std::is_assignable<not_null<std::shared_ptr<int>>, std::shared_ptr<int>>::value, "not_null<std::shared_ptr> must be assignable from std::shared_ptr");
 static_assert(std::is_copy_constructible<not_null<std::shared_ptr<int>>>::value, "not_null<std::shared_ptr> must be copy constructible");
 static_assert(std::is_copy_assignable<not_null<std::shared_ptr<int>>>::value, "not_null<std::shared_ptr> must be copy assignable");
 static_assert(std::is_nothrow_move_constructible<not_null<std::shared_ptr<int>>>::value, "not_null<std::shared_ptr> must be no-throw move constructible");

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -56,6 +56,7 @@ struct CustomPtr
 {
     CustomPtr(T* p) : p_(p) {}
     operator T*() { return p_; }
+    operator T*() const { return p_; }
     bool operator!=(std::nullptr_t) const { return p_ != nullptr; }
     T* p_ = nullptr;
 };
@@ -329,3 +330,23 @@ TEST_CASE("TestNotNullCustomPtrComparison")
 }
 
 static_assert(std::is_nothrow_move_constructible<not_null<void *>>::value, "not_null must be no-throw move constructible");
+
+struct UniquePointerTestStruct {
+    int i = 0;
+};
+
+TEST_CASE("TestNotNullUniquePtrComparison") {
+
+    {
+        using NotNull1 = not_null<std::unique_ptr<int>>;
+
+        // values are the same
+        CHECK((*NotNull1(std::make_unique<int>(42)) == *NotNull1(std::make_unique<int>(42))));
+    }
+    {
+        using NotNull1 = not_null<std::unique_ptr<UniquePointerTestStruct>>;
+
+        // values are the same
+        CHECK((NotNull1(std::make_unique<UniquePointerTestStruct>())->i == NotNull1(std::make_unique<UniquePointerTestStruct>())->i));
+    }
+}


### PR DESCRIPTION
allows support of supporting std::unique_ptr
based on @xaxxon's work

fixes #89
fixes #550
fixes #651

From the Core Guidelines:

http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#note-61

> Note not_null is not just for built-in pointers. It works for unique_ptr, shared_ptr, and other pointer-like types.