### PR TITLE
fix requirement on not_null template

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -69,7 +69,7 @@ template <class T>
 class not_null
 {
 public:
-    static_assert(std::is_assignable<T&, std::nullptr_t>::value, "T cannot be assigned nullptr.");
+    static_assert(std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value, "T cannot be compared to nullptr.");
 
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
     constexpr explicit not_null(U&& u) : ptr_(std::forward<U>(u))


### PR DESCRIPTION
it should be comparable to nullptr, it does not have to be assignable

http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#gslview-views says

> not_null<T> // T is usually a pointer type (e.g., not_null<int*> and not_null<owner<Foo*>>) that may not be nullptr. T can be any type for which ==nullptr is meaningful