### PR TITLE
Span can be constructed from empty std::array safely

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -409,13 +409,21 @@ public:
 
     template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
     constexpr span(std::array<ArrayElementType, N>& arr) noexcept
+#if (defined(__cplusplus) && (__cplusplus >= 201703L))
+        : storage_(std::data(arr), details::extent_type<N>())
+#else
         : storage_(arr.data(), details::extent_type<N>())
+#endif
     {
     }
 
     template <std::size_t N>
     constexpr span(const std::array<std::remove_const_t<element_type>, N>& arr) noexcept
+#if (defined(__cplusplus) && (__cplusplus >= 201703L))
+        : storage_(std::data(arr), details::extent_type<N>())
+#else
         : storage_(arr.data(), details::extent_type<N>())
+#endif
     {
     }
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -394,17 +394,27 @@ public:
         : storage_(KnownNotNull{std::addressof(arr[0])}, details::extent_type<N>())
     {}
 
-    template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
-    // GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute // TODO: parser bug
-    constexpr span(std::array<ArrayElementType, N>& arr) noexcept
-        : storage_(arr.data(), details::extent_type<N>())
-    {}
+    template <std::size_t N, class = std::enable_if_t<(N > 0)>>
+    constexpr span(std::array<std::remove_const_t<element_type>, N>& arr) noexcept
+        : storage_(KnownNotNull{arr.data()}, details::extent_type<N>())
+    {
+    }
 
-    template <std::size_t N>
-    // GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute // TODO: parser bug
+    constexpr span(std::array<std::remove_const_t<element_type>, 0>&) noexcept
+        : storage_(static_cast<pointer>(nullptr), details::extent_type<0>())
+    {
+    }
+
+    template <std::size_t N, class = std::enable_if_t<(N > 0)>>
     constexpr span(const std::array<std::remove_const_t<element_type>, N>& arr) noexcept
-        : storage_(arr.data(), details::extent_type<N>())
-    {}
+        : storage_(KnownNotNull{arr.data()}, details::extent_type<N>())
+    {
+    }
+
+    constexpr span(const std::array<std::remove_const_t<element_type>, 0>&) noexcept
+        : storage_(static_cast<pointer>(nullptr), details::extent_type<0>())
+    {
+    }
 
     // NB: the SFINAE here uses .data() as a incomplete/imperfect proxy for the requirement
     // on Container to be a contiguous sequence container.

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -409,13 +409,13 @@ public:
 
     template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
     constexpr span(std::array<ArrayElementType, N>& arr) noexcept
-        : storage_(&arr[0], details::extent_type<N>())
+        : storage_(arr.data(), details::extent_type<N>())
     {
     }
 
     template <std::size_t N>
     constexpr span(const std::array<std::remove_const_t<element_type>, N>& arr) noexcept
-        : storage_(&arr[0], details::extent_type<N>())
+        : storage_(arr.data(), details::extent_type<N>())
     {
     }
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -419,6 +419,12 @@ TEST_CASE("from_std_array_constructor")
         CHECK((cs.size() == narrow_cast<ptrdiff_t>(arr.size()) && cs.data() == arr.data()));
     }
 
+    {
+        std::array<int, 0> empty_arr{};
+        span<int> s{empty_arr};
+        CHECK((s.size() == 0 && s.empty()));
+    }
+
 #ifdef CONFIRM_COMPILATION_ERRORS
     {
         span<int, 2> s{arr};


### PR DESCRIPTION
- Fixes runtime issues when constructing from an empty std::array (Issue #685)