### PR TITLE
Fix GCC8 warnings 'useless cast to type'.

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -602,7 +602,7 @@ public:
     }
 
     constexpr static_bounds(std::initializer_list<size_type> il)
-        : m_ranges(static_cast<const std::ptrdiff_t*>(il.begin()))
+        : m_ranges(il.begin())
     {
         // Size of the initializer list must match the rank of the array
         Expects((MyRanges::DynamicNum == 0 && il.size() == 1 && *il.begin() == static_size) ||
@@ -1676,7 +1676,7 @@ constexpr auto as_multi_span(multi_span<byte, Dimensions...> s) GSL_NOEXCEPT
     static_assert(
         std::is_trivial<std::decay_t<U>>::value &&
             (ByteSpan::bounds_type::static_size == dynamic_range ||
-             ByteSpan::bounds_type::static_size % static_cast<std::size_t>(sizeof(U)) == 0),
+             ByteSpan::bounds_type::static_size % sizeof(U) == 0),
         "Target type must be a trivial type and its size must match the byte array size");
 
     Expects((s.size_bytes() % sizeof(U)) == 0);


### PR DESCRIPTION
It fixes the warnings I get with g++ 8.0.1:
```
In file included from ./GSL/include/gsl/gsl:24,
                 from src/array_copy.cpp:10:
./GSL/include/gsl/multi_span: In constructor ‘constexpr gsl::static_bounds<FirstRange, RestRanges ...>::static_bounds(std::initializer_list<long int>)’:
./GSL/include/gsl/multi_span:605:65: error: useless cast to type ‘const ptrdiff_t*’ {aka ‘const long int*’} [-Werror=useless-cast]
         : m_ranges(static_cast<const std::ptrdiff_t*>(il.begin()))
                                                                 ^
./GSL/include/gsl/multi_span: In function ‘constexpr gsl::multi_span<U, narrow_cast<long int>(((typename gsl::multi_span<std::byte, Dimensions ...>::bounds_type::static_size != gsl::dynamic_range) ? (static_cast<long unsigned int>(typename gsl::multi_span<std::byte, Dimensions ...>::bounds_type::static_size) / sizeof (U)) : gsl::dynamic_range))> gsl::as_multi_span(gsl::multi_span<std::byte, Dimensions ...>)’:
./GSL/include/gsl/multi_span:1679:85: error: useless cast to type ‘std::size_t’ {aka ‘long unsigned int’} [-Werror=useless-cast]
              ByteSpan::bounds_type::static_size % static_cast<std::size_t>(sizeof(U)) == 0),
                                                                                     ^
cc1plus: all warnings being treated as errors
```