### PR TITLE
Dev/annagrin/failfast in noexcept mode windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ matrix:
         apt:
           packages:
             - clang-5.0
-            - g++-5
+            - g++-7
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-5.0
@@ -134,13 +134,19 @@ matrix:
     - env: COMPILER=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang50
 
+    - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang50
+
+    - env: COMPILER=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang50
+
     # Clang 6.0
     - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang60
         apt:
           packages:
             - clang-6.0
-            - g++-6
+            - g++-7
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
@@ -150,13 +156,12 @@ matrix:
     - env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang60
 
-    # Does not work due to #695
     # Clang 6.0 c++17
-    #- env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-    #  addons: *clang60
+    - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang60
 
-    #- env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-    #  addons: *clang60
+    - env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang60
 
     ##########################################################################
     # GCC on Linux

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -26,6 +26,8 @@
 //
 #if defined(_MSC_VER) && defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS
 #define GSL_MSVC_USE_STL_NOEXCEPTION_WORKAROUND
+#include <intrin.h>
+#define RANGE_CHECKS_FAILURE 0
 #endif
 
 //
@@ -82,10 +84,15 @@ namespace details
 #if defined(GSL_MSVC_USE_STL_NOEXCEPTION_WORKAROUND)
 
     typedef void  (__cdecl *terminate_handler)();
+    
+    [[noreturn]] inline void __cdecl default_terminate_handler()
+    {
+        __fastfail(RANGE_CHECKS_FAILURE);
+    }
 
     inline gsl::details::terminate_handler& get_terminate_handler() noexcept
     {
-        static terminate_handler handler = &abort;
+        static terminate_handler handler = &default_terminate_handler;
         return handler;
     }
 


### PR DESCRIPTION
Made `gsl::terminate` call `__fastfail` in no-exception mode by default (msvc only, this is a better variant of default behavior for windows code that does not use exceptions, for example, kernel)