### PR TITLE
Dev/annagrin/make not null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ matrix:
         apt:
           packages:
             - clang-5.0
-            - g++-5
+            - g++-7
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-5.0
@@ -134,13 +134,19 @@ matrix:
     - env: COMPILER=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang50
 
+    - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang50
+
+    - env: COMPILER=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang50
+
     # Clang 6.0
     - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang60
         apt:
           packages:
             - clang-6.0
-            - g++-6
+            - g++-7
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
@@ -150,13 +156,12 @@ matrix:
     - env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang60
 
-    # Does not work due to #695
     # Clang 6.0 c++17
-    #- env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-    #  addons: *clang60
+    - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang60
 
-    #- env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-    #  addons: *clang60
+    - env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang60
 
     ##########################################################################
     # GCC on Linux

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -120,6 +120,11 @@ private:
 };
 
 template <class T>
+auto make_not_null(T&&t) {
+    return gsl::not_null<std::remove_cv_t<std::remove_reference_t<T>>>{t};
+}
+
+template <class T>
 std::ostream& operator<<(std::ostream& os, const not_null<T>& val)
 {
     os << val.get();

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -387,4 +387,59 @@ TEST_CASE("TestNotNullConstructorTypeDeduction")
 }
 #endif // #if defined(__cplusplus) && (__cplusplus >= 201703L)
 
+TEST_CASE("TestMakeNotNull")
+{
+    {
+        int i = 42;
+
+        auto x = make_not_null(&i);
+        helper(make_not_null(&i));
+        helper_const(make_not_null(&i));
+
+        CHECK(*x == 42);
+    }
+
+    {
+        int i = 42;
+        int* p = &i;
+
+        auto x = make_not_null(p);
+        helper(make_not_null(p));
+        helper_const(make_not_null(p));
+
+        CHECK(*x == 42);
+    }
+
+    {
+        auto workaround_macro = []() {
+            int* p1 = nullptr;
+            auto x = make_not_null(p1);
+        };
+        CHECK_THROWS_AS(workaround_macro(), fail_fast);
+    }
+
+    {
+        auto workaround_macro = []() {
+            const int* p1 = nullptr;
+            auto x = make_not_null(p1);
+        };
+        CHECK_THROWS_AS(workaround_macro(), fail_fast);
+    }
+
+    {
+        int* p = nullptr;
+
+        CHECK_THROWS_AS(helper(make_not_null(p)), fail_fast);
+        CHECK_THROWS_AS(helper_const(make_not_null(p)), fail_fast);
+    }
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        CHECK_THROWS_AS(make_not_null(nullptr), fail_fast);
+        CHECK_THROWS_AS(helper(make_not_null(nullptr)), fail_fast);
+        CHECK_THROWS_AS(helper_const(make_not_null(nullptr)), fail_fast);
+    }
+#endif
+}
+
 static_assert(std::is_nothrow_move_constructible<not_null<void *>>::value, "not_null must be no-throw move constructible");


### PR DESCRIPTION
Following suggestion from [@kivadiu](https://github.com/kivadiu), added `make_not_null` helper to create a `not_null`
    
Introduction of explicit `not_null` constructor made it cumbersome to create `not_null`s, especially in before c++17. Adding `make_not_null` helper. Usage (see tests):
    
```
    int i = 42;
    
    auto x = make_not_null(&i);
    helper(make_not_null(&i));
    helper_const(make_not_null(&i));
```

See #699
