### PR TITLE
Explicitly check for availability of std::byte (fixes #713)

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -43,16 +43,23 @@
 
 #ifndef GSL_USE_STD_BYTE
 // this tests if we are under GCC or Clang with enough -std:c++1z power to get us std::byte
-#if defined(__cplusplus) && (__cplusplus >= 201703L)
+// also check if libc++ version is sufficient (> 5.0) or libstc++ actually contains std::byte
+#if defined(__cplusplus) && (__cplusplus >= 201703L) &&
+  (defined(__cpp_lib_byte) && (__cpp_lib_byte >= 201603)  || \
+   defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 5000))
 
 #define GSL_USE_STD_BYTE 1
 #include <cstddef>
 
-#else // defined(__cplusplus) && (__cplusplus >= 201703L)
+#else // defined(__cplusplus) && (__cplusplus >= 201703L) &&
+      //   (defined(__cpp_lib_byte) && (__cpp_lib_byte >= 201603)  ||
+      //    defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 5000))
 
 #define GSL_USE_STD_BYTE 0
 
 #endif //defined(__cplusplus) && (__cplusplus >= 201703L)
+       //   (defined(__cpp_lib_byte) && (__cpp_lib_byte >= 201603)  ||
+       //    defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 5000))
 #endif // GSL_USE_STD_BYTE
 
 #endif           // _MSC_VER

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -44,7 +44,7 @@
 #ifndef GSL_USE_STD_BYTE
 // this tests if we are under GCC or Clang with enough -std:c++1z power to get us std::byte
 // also check if libc++ version is sufficient (> 5.0) or libstc++ actually contains std::byte
-#if defined(__cplusplus) && (__cplusplus >= 201703L) &&
+#if defined(__cplusplus) && (__cplusplus >= 201703L) && \
   (defined(__cpp_lib_byte) && (__cpp_lib_byte >= 201603)  || \
    defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 5000))
 


### PR DESCRIPTION
Fix for #713:
GCC > 7.3 defines __cpp_lib_byte >= 201603 when std::byte is available.
On libc++ std::byte is available since version 5.0. This can be checked
with _LIBCPP_VERSION >= 5000.