### PR TITLE
Allow #include <gsl/...> without repeating gsl

### DIFF
--- a/include/gsl/algorithm
+++ b/include/gsl/algorithm
@@ -1,0 +1,22 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ALGORITHM_H
+#define ALGORITHM_H
+
+#include <gsl/gsl_algorithm>
+
+#endif // ALGORITHM_H

--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -1,0 +1,22 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ASSERT_H
+#define ASSERT_H
+
+#include <gsl/gsl_assert>
+
+#endif // ASSERT_H

--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -1,0 +1,22 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BYTE_H
+#define BYTE_H
+
+#include <gsl/gsl_byte>
+
+#endif // BYTE_H

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -1,0 +1,22 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <gsl/gsl_util>
+
+#endif // UTIL_H


### PR DESCRIPTION
Headers are named inconsistently: algorithm, assert, byte and util
headers are prefixed with gsl_. This is to avoid name clash with
standard headers for people including directly from the gsl directory.

However, for people including from the parent directory of gsl, in
addition to looking inconsistent, this also looks redundant:
#include <gsl/gsl_assert>

This adds algorithm, assert, byte and util headers that just forward to
gsl_ headers. It is then possible to include like this:
#include <gsl/assert>

Fixes #71