### PR TITLE
Suppress Warnings in GSL Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,21 @@ target_compile_definitions(GSL INTERFACE
 )
 
 # add include folders to the library and targets that consume it
-target_include_directories(GSL INTERFACE
-    $<BUILD_INTERFACE:
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    >
-)
+# the SYSTEM keyword suppresses warnings for users of the library
+if(GSL_STANDALONE_PROJECT)
+    target_include_directories(GSL INTERFACE
+        $<BUILD_INTERFACE:
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        >
+    )
+else()
+    target_include_directories(GSL SYSTEM INTERFACE
+        $<BUILD_INTERFACE:
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        >
+    )
+endif()
+
 
 if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))
     if (MSVC_IDE)


### PR DESCRIPTION
This fixes the issue raised in PR #465. While the proposed solution in #465 depended on compiler-specific macros, this patch uses a build-system feature and therefore does not depend on compiler-specific behaviour.
Additionally, it treats the headers only as system headers for non-standalone builds, so that GSL-developers are still able to see and fix legitimate warnings.