### PR TITLE
make TypeListIndexer constexpr

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -517,31 +517,31 @@ namespace details
     struct TypeListIndexer
     {
         const TypeChain& obj_;
-        TypeListIndexer(const TypeChain& obj) : obj_(obj) {}
+        constexpr TypeListIndexer(const TypeChain& obj) : obj_(obj) {}
 
         template <std::size_t N>
-        const TypeChain& getObj(std::true_type)
+        constexpr const TypeChain& getObj(std::true_type)
         {
             return obj_;
         }
 
         template <std::size_t N, typename MyChain = TypeChain,
                   typename MyBase = typename MyChain::Base>
-        auto getObj(std::false_type)
+        constexpr auto getObj(std::false_type)
             -> decltype(TypeListIndexer<MyBase>(static_cast<const MyBase&>(obj_)).template get<N>())
         {
             return TypeListIndexer<MyBase>(static_cast<const MyBase&>(obj_)).template get<N>();
         }
 
         template <std::size_t N>
-        auto get() -> decltype(getObj<N - 1>(std::integral_constant<bool, N == 0>()))
+        constexpr auto get() -> decltype(getObj<N - 1>(std::integral_constant<bool, N == 0>()))
         {
             return getObj<N - 1>(std::integral_constant<bool, N == 0>());
         }
     };
 
     template <typename TypeChain>
-    TypeListIndexer<TypeChain> createTypeListIndexer(const TypeChain& obj)
+    constexpr TypeListIndexer<TypeChain> createTypeListIndexer(const TypeChain& obj)
     {
         return TypeListIndexer<TypeChain>(obj);
     }


### PR DESCRIPTION
Is there a reason `TypeListIndexer` cannot be made constexpr?

```
// requires constexpr createTypeListIndexer
static_assert(static_bounds<3,2>{}.extent<0>() == 3,"");
static_assert(static_bounds<3,2>{}.extent<1>() == 2,"");
static_assert(static_bounds<3,2>{}.extent(0) == 3,"");
static_assert(static_bounds<3,2>{}.extent(1) == 2,"");
```