### PR TITLE
Add Clang 7.0.0 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The test suite that exercises GSL has been built and passes successfully on the 
 * Windows using Clang/LLVM 3.6
 * Windows using GCC 5.1
 * Windows using Intel C++ Compiler 18.0
+* GNU/Linux using Clang/LLVM 3.12.3
 * GNU/Linux using Clang/LLVM 3.6
 * GNU/Linux using GCC 5.1
 * OS X Yosemite using Xcode with Apple Clang 7.0.0.7000072

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The test suite that exercises GSL has been built and passes successfully on the 
 * Windows using Clang/LLVM 3.6
 * Windows using GCC 5.1
 * Windows using Intel C++ Compiler 18.0
-* GNU/Linux using Clang/LLVM 3.12.3
+* GNU/Linux using Clang/LLVM 7.0.0
 * GNU/Linux using Clang/LLVM 3.6
 * GNU/Linux using GCC 5.1
 * OS X Yosemite using Xcode with Apple Clang 7.0.0.7000072


### PR DESCRIPTION
Test project /GSL
      Start  1: span_tests
 1/15 Test  #1: span_tests .......................   Passed    0.01 sec
      Start  2: multi_span_tests
 2/15 Test  #2: multi_span_tests .................   Passed    0.02 sec
      Start  3: strided_span_tests
 3/15 Test  #3: strided_span_tests ...............   Passed    0.01 sec
      Start  4: string_span_tests
 4/15 Test  #4: string_span_tests ................   Passed    0.01 sec
      Start  5: at_tests
 5/15 Test  #5: at_tests .........................   Passed    0.00 sec
      Start  6: bounds_tests
 6/15 Test  #6: bounds_tests .....................   Passed    0.01 sec
      Start  7: notnull_tests
 7/15 Test  #7: notnull_tests ....................   Passed    0.01 sec
      Start  8: assertion_tests
 8/15 Test  #8: assertion_tests ..................   Passed    0.01 sec
      Start  9: utils_tests
 9/15 Test  #9: utils_tests ......................   Passed    0.01 sec
      Start 10: owner_tests
10/15 Test #10: owner_tests ......................   Passed    0.00 sec
      Start 11: byte_tests
11/15 Test #11: byte_tests .......................   Passed    0.01 sec
      Start 12: algorithm_tests
12/15 Test #12: algorithm_tests ..................   Passed    0.00 sec
      Start 13: sloppy_notnull_tests
13/15 Test #13: sloppy_notnull_tests .............   Passed    0.00 sec
      Start 14: no_exception_throw_tests
14/15 Test #14: no_exception_throw_tests .........   Passed    0.00 sec
      Start 15: no_exception_ensure_tests
15/15 Test #15: no_exception_ensure_tests ........   Passed    0.00 sec

100% tests passed, 0 tests failed out of 15

Total Test time (real) =   0.11 sec

Arch Linux w/ Clang 7.0.0