### PR TITLE
Make CheckRange constexpr

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -544,7 +544,7 @@ public:
 #endif // _MSC_VER
 
 private:
-    static bool CheckRange(index_type idx, index_type size) noexcept
+    static constexpr bool CheckRange(index_type idx, index_type size) noexcept
     {
         // Optimization:
         //


### PR DESCRIPTION
Added support for `constexpr` range checking to allow for `constexpr span::operator[]` to work in a constant expression.