### PR TITLE
Fixes CMAKE_VERSION check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
 endif()
 
 
-if ((CMAKE_VERSION GREATER 3.7.9) OR (CMAKE_VERSION EQUAL 3.7.9))
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.7.9)
     if (MSVC_IDE)
         option(VS_ADD_NATIVE_VISUALIZERS "Configure project to use Visual Studio native visualizers" TRUE)
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
 endif()
 
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.7.9)
+if (CMAKE_VERSION VERSION_GREATER 3.7.8)
     if (MSVC_IDE)
         option(VS_ADD_NATIVE_VISUALIZERS "Configure project to use Visual Studio native visualizers" TRUE)
     else()


### PR DESCRIPTION
Fixes #758 by using the correct comparison operator for a version
See documentation at https://cmake.org/cmake/help/latest/command/if.html
Thanks to this change, gsl natvis is properly included in a visual studio solution