### PR TITLE
narrowing_error with more information

### DIFF
--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -23,7 +23,10 @@
 #include <cstddef>          // for ptrdiff_t, size_t
 #include <exception>        // for exception
 #include <initializer_list> // for initializer_list
+#include <sstream>          // for ostringstream
+#include <string>           // for string
 #include <type_traits>      // for is_signed, integral_constant
+#include <typeinfo>         // for typeid
 #include <utility>          // for forward
 
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -100,8 +103,48 @@ constexpr T narrow_cast(U&& u) noexcept
     return static_cast<T>(std::forward<U>(u));
 }
 
+namespace details
+{
+    template <class S, class T>
+    struct is_streamable	// Can't be class because of gcc -Werror=ctor-dtor-privacy
+    {
+        template <typename SS, typename TT>
+        static auto test(SS&& s, TT&& t) -> decltype(s << t);
+
+        struct dummy_t
+        {
+        };
+        static dummy_t test(...);
+
+        using return_type = decltype(test(std::declval<S>(), std::declval<T>()));
+
+    public:
+        static const bool value = !std::is_same<return_type, dummy_t>::value;
+    };
+} // namespace details
+
 struct narrowing_error : public std::exception
 {
+    narrowing_error(std::string&& what) : _what(what) {}
+
+    template <class T, class U>
+    static narrowing_error create(const U &u)
+    {
+        static_cast<void>(u);	// to simulate [[maybe_unused]]
+        std::ostringstream strm;
+        strm << typeid(U).name();
+#if defined(__cpp_if_constexpr)
+        if constexpr (details::is_streamable<std::ostringstream, const U&>::value)
+			strm << ' ' << u;
+#endif
+		strm << " to " << typeid(T).name();
+        return narrowing_error{strm.str()};
+    }
+
+    const char* what() const noexcept override { return _what.c_str(); }
+
+private:
+    std::string _what;
 };
 
 namespace details
@@ -123,9 +166,9 @@ constexpr
 T narrow(U u) noexcept(false)
 {
     T t = narrow_cast<T>(u);
-    if (static_cast<U>(t) != u) gsl::details::throw_exception(narrowing_error());
+    if (static_cast<U>(t) != u) gsl::details::throw_exception(narrowing_error::create<T, U>(u));
     if (!details::is_same_signedness<T, U>::value && ((t < T{}) != (u < U{})))
-        gsl::details::throw_exception(narrowing_error());
+        gsl::details::throw_exception(narrowing_error::create<T, U>(u));
     return t;
 }
 


### PR DESCRIPTION
- added type trait is_streamable
- added what to narrowing_error (not optimized for MSVC, just standard C++ stuff)
- instead of "Unknown exception" we now get either "<type_from> <value> to <type_to>" or "<type_from> to <type_to>"

This is done to provide as much debug information as possible in case of a narrowing_error exception.
I am not very experienced with type traits, so any idea how to do it better is very welcome. I took the code for is_streamable from https://stackoverflow.com/a/22759368/1023911.
I tested the code given this short program (output is given in the comments):
```
#include <iostream>
#include <typeinfo>

#define GSL_THROW_ON_CONTRACT_VIOLATION
#include <gsl/gsl_util>

struct INT {
	INT() :_x(0) {}
	INT(int x) :_x(x) {}
	operator int() noexcept { return _x; }

	int _x;
};

int main()
{
	try {
		gsl::narrow<char>(4200);
		gsl::narrow<char>(INT{ 4200 });
	}
	catch (const std::exception &e) {
		// Exception struct gsl::narrowing_error: Unknown exception
		// Exception struct gsl::narrowing_error: int 4200 to char
		// Exception struct gsl::narrowing_error: struct INT to char
		std::cout << "Exception " << typeid(e).name() << ": " << e.what() << std::endl;
	}

	return 0;
}
```