### PR TITLE
Fixed check if std::byte is available

### DIFF
--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -56,6 +56,7 @@
 #else // _MSC_VER
 
 #ifndef GSL_USE_STD_BYTE
+#include <cstddef> /* __cpp_lib_byte */
 // this tests if we are under GCC or Clang with enough -std:c++1z power to get us std::byte
 // also check if libc++ version is sufficient (> 5.0) or libstc++ actually contains std::byte
 #if defined(__cplusplus) && (__cplusplus >= 201703L) && \
@@ -63,7 +64,6 @@
    defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 5000))
 
 #define GSL_USE_STD_BYTE 1
-#include <cstddef>
 
 #else // defined(__cplusplus) && (__cplusplus >= 201703L) &&
       //   (defined(__cpp_lib_byte) && (__cpp_lib_byte >= 201603)  ||


### PR DESCRIPTION
The check for std::byte existance fails on gcc 8.2. According to https://en.cppreference.com/w/cpp/utility/feature_test it is necessary to `#include <cstddef>` before checking `__cpp_lib_byte`.