### PR TITLE
* adding cancel to final_action

### DIFF
--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -68,6 +68,12 @@ public:
     final_action& operator=(const final_action&) = delete;
     final_action& operator=(final_action&&) = delete;
 
+    // cancel action
+    void cancel() noexcept
+    {
+        invoke_ = false;
+    }
+
     GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // terminate if throws
     ~final_action() noexcept
     {

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -51,6 +51,18 @@ TEST_CASE("finally_lambda")
     CHECK(i == 1);
 }
 
+TEST_CASE("finally_lambda_cancel")
+{
+    int i = 0;
+    {
+        auto fin = finally([&]() { f(i); });
+        CHECK(i == 0);
+
+        fin.cancel();
+    }
+    CHECK(i == 0);
+}
+
 TEST_CASE("finally_lambda_move")
 {
     int i = 0;


### PR DESCRIPTION
There are scenarios where it would be useful to allow a final_action to be cancelled. The mechanism already exists to support moves -- this patch exposes it with a new public method 'cancel'.