### PR TITLE
Fixes #798 : Dropping inclusion of `gsl/pointers` in `string_span`

### DIFF
--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -20,7 +20,6 @@
 #include <gsl/gsl_assert> // for Ensures, Expects
 #include <gsl/gsl_util>   // for narrow_cast
 #include <gsl/span>       // for operator!=, operator==, dynamic_extent
-#include <gsl/pointers>   // for not_null
 
 #include <algorithm> // for equal, lexicographical_compare
 #include <array>     // for array


### PR DESCRIPTION
This PR fixes issue #798  by  dropping inclusion of `gsl/pointers` in `string_span`.