### PR TITLE
Fixed memory leaks and out of bound access

### DIFF
--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -1220,6 +1220,8 @@ TEST_CASE("md_access")
             expected += 3;
         }
     }
+
+    delete[] image_ptr;
 }
 
 GSL_SUPPRESS(con.4) // NO-FORMAT: attribute
@@ -1616,6 +1618,8 @@ TEST_CASE("span_structure_size")
     multi_span<const double, dynamic_range, 6, 4> av2 =
         as_multi_span(av1, dim(5), dim<6>(), dim<4>());
     (void) av2;
+
+    delete[] arr;
 }
 
 GSL_SUPPRESS(con.4) // NO-FORMAT: attribute

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -234,8 +234,8 @@ void ostream_helper(T v)
     {
         std::ostringstream os;
         std::ostringstream ref;
-        os << p;
-        ref << &v;
+        os << static_cast<void*>(p);
+        ref << static_cast<void*>(&v);
         CHECK(os.str() == ref.str());
     }
     {


### PR DESCRIPTION
I looked through all tests with `valgrind --leak-check=full --leak-kinds=all` and found some memory errors. So this PR is just minor fixes of ones.

--------
Fixes #737. Actually this issue gave me an idea to run valgrind on all files. So thanks to @stayprivates. It's been over a year since this issue is on hold, so i don't know why he/she doesn't PR the solution already.