### PR TITLE
Fixing typo "Guideline" as "Guidelines"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-## Contributing to the Guideline Support Library
+## Contributing to the Guidelines Support Library
 
-The Guideline Support Library (GSL) contains functions and types that are suggested for use by the
+The Guidelines Support Library (GSL) contains functions and types that are suggested for use by the
 [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines). GSL design changes are made only as a result of modifications to the Guidelines. 
 
 GSL is accepting contributions that improve or refine any of the types in this library as well as ports to other platforms. Changes should have an issue 

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -2,7 +2,7 @@
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-GSL: Guideline Support Library incorporates third party material from the projects listed below. The original copyright notice and the license under which Microsoft received such third party material are set forth below. Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
+GSL: Guidelines Support Library incorporates third party material from the projects listed below. The original copyright notice and the license under which Microsoft received such third party material are set forth below. Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
 
 
 1.	Catch (https://github.com/philsquared/Catch)


### PR DESCRIPTION
The library is the Guidelines Support Library, not the Guideline Support Library. 