### PR TITLE
Fix MSVC min/max macro collision with numeric_limits.

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -83,7 +83,7 @@ namespace details
     template <typename SizeType>
     struct [[deprecated]] SizeTypeTraits
     {
-        static const SizeType max_value = std::numeric_limits<SizeType>::max();
+        static const SizeType max_value = (std::numeric_limits<SizeType>::max)();
     };
 
     template <typename... Ts>

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -114,8 +114,8 @@ TEST_CASE("narrow")
     n = 300;
     CHECK_THROWS_AS(narrow<char>(n), narrowing_error);
 
-    const auto int32_max = std::numeric_limits<int32_t>::max();
-    const auto int32_min = std::numeric_limits<int32_t>::min();
+    const auto int32_max = (std::numeric_limits<int32_t>::max)();
+    const auto int32_min = (std::numeric_limits<int32_t>::min)();
 
     CHECK(narrow<uint32_t>(int32_t(0)) == 0);
     CHECK(narrow<uint32_t>(int32_t(1)) == 1);


### PR DESCRIPTION
Related issue: https://github.com/microsoft/GSL/issues/816

Wraps all usages of `std::numeric_limits<T>::max` and `std::numeric_limits<T>::min` in parenthesis to prevent function-style macro expansion.