### PR TITLE
Fix throw_exception() for GSL_UNENFORCED_ON_CONTRACT_VIOLATION

### DIFF
--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -128,15 +128,7 @@ namespace details
 #endif
     }
 
-#if defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
-
-    template <typename Exception>
-    [[noreturn]] void throw_exception(Exception&&) noexcept
-    {
-        gsl::details::terminate();
-    }
-
-#else
+#if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
 
     template <typename Exception>
     [[noreturn]] void throw_exception(Exception&& exception)
@@ -144,7 +136,23 @@ namespace details
         throw std::forward<Exception>(exception);
     }
 
-#endif // GSL_TERMINATE_ON_CONTRACT_VIOLATION
+#elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
+
+    template <typename Exception>
+    [[noreturn]] void throw_exception(Exception&&) noexcept
+    {
+        gsl::details::terminate();
+    }
+
+#elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
+
+    template <typename Exception>
+    void throw_exception(Exception&&) noexcept
+    {
+        return;
+    }
+
+#endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
 } // namespace details
 } // namespace gsl

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -117,7 +117,12 @@ GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recogn
 #if GSL_CONSTEXPR_NARROW
 constexpr
 #endif
-T narrow(U u) noexcept(false)
+T narrow(U u)
+#if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
+noexcept(false)
+#else
+noexcept
+#endif
 {
     T t = narrow_cast<T>(u);
     if (static_cast<U>(t) != u) gsl::details::throw_exception(narrowing_error());


### PR DESCRIPTION
There are three configuration options for when conditions are violated.
When GSL_UNENFORCED_ON_CONTRACT_VIOLATION is selected, nothing
should happen, but throw_exception()'s behavior is not consistent
with this.

The ifdefs for the three config options (throw, terminate, unenforced)
have been reordered to be consistent with the order they appear in
the documentaton at the start of the header as well as the definition
of GSL_CONTRACT_CHECK right below these changes

#818

 Properly define noexcept specification for narrow() depending on the selected contract violation configuration

#818