### PR TITLE
Implement free-standing (c|r|cr)(begin|end) and ssize functions

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -774,6 +774,62 @@ constexpr ElementType& at(span<ElementType, Extent> s, index i)
     return s[i];
 }
 
+// [span.obs] Free observer functions
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::index_type ssize(const span<ElementType, Extent> &span) noexcept
+{
+    return span.size();
+}
+
+// [span.iter] Free functions for begin/end functions
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::iterator begin(const span<ElementType, Extent> &span) noexcept
+{
+    return span.begin();
+}
+
+template <class ElementType, std::ptrdiff_t Extent = dynamic_extent>
+constexpr typename span<ElementType, Extent>::iterator end(const span<ElementType, Extent> &span) noexcept
+{
+    return span.end();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::const_iterator cbegin(const span<ElementType, Extent> &span) noexcept
+{
+    return span.cbegin();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::const_iterator cend(const span<ElementType, Extent> &span) noexcept
+{
+    return span.cend();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::reverse_iterator rbegin(const span<ElementType, Extent> &span) noexcept
+{
+    return span.rbegin();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::reverse_iterator rend(const span<ElementType, Extent> &span) noexcept
+{
+    return span.rend();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::const_reverse_iterator crbegin(const span<ElementType, Extent> &span) noexcept
+{
+    return span.crbegin();
+}
+
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr typename span<ElementType, Extent>::const_reverse_iterator crend(const span<ElementType, Extent> &span) noexcept
+{
+    return span.crend();
+}
+
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1084,6 +1084,45 @@ TEST(span_test, from_array_constructor)
      EXPECT_TRUE(cit3 == s.cend());
  }
 
+ TEST(span_test, iterator_free_functions)
+ {
+     int a[] = {1, 2, 3, 4};
+     span<int> s{a};
+ 
+     EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
+ 
+     EXPECT_TRUE((std::is_same<decltype(s.cbegin()), decltype(cbegin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(s.cend()), decltype(cend(s))>::value));
+ 
+     EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
+ 
+     EXPECT_TRUE((std::is_same<decltype(s.crbegin()), decltype(crbegin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(s.crend()), decltype(crend(s))>::value));
+ 
+     EXPECT_TRUE(s.begin() == begin(s));
+     EXPECT_TRUE(s.end() == end(s));
+ 
+     EXPECT_TRUE(s.cbegin() == cbegin(s));
+     EXPECT_TRUE(s.cend() == cend(s));
+ 
+     EXPECT_TRUE(s.rbegin() == rbegin(s));
+     EXPECT_TRUE(s.rend() == rend(s));
+ 
+     EXPECT_TRUE(s.crbegin() == crbegin(s));
+     EXPECT_TRUE(s.crend() == crend(s));
+ }
+
+ TEST(span_test, ssize_free_function)
+ {
+     int a[] = {1, 2, 3, 4};
+     span<int> s{a};
+ 
+     EXPECT_TRUE((std::is_same<decltype(s.size()), decltype(ssize(s))>::value));
+     EXPECT_TRUE(s.size() == ssize(s));
+ }
+
  TEST(span_test, iterator_comparisons)
  {
      int a[] = {1, 2, 3, 4};


### PR DESCRIPTION
This issue implements the free-standing iterator and size function discussed in https://github.com/microsoft/GSL/issues/810.

Closes https://github.com/microsoft/GSL/issues/810