### PR TITLE
fix ctad warning in llvm

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -119,13 +119,6 @@ private:
     T ptr_;
 };
 
-#if (defined(__cplusplus) && (__cplusplus >= 201703L))
-// deduction guide to prevent the ctad-maybe-unsupported warning
-template <class T>
-not_null(T ptr) -> not_null<T>;
-
-#endif // (defined(__cplusplus) && (__cplusplus >= 201703L))
-
 template <class T>
 auto make_not_null(T&& t) {
     return not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
@@ -278,6 +271,16 @@ template <class T>
 auto make_strict_not_null(T&& t) {
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
+
+#if (defined(__cplusplus) && (__cplusplus >= 201703L))
+
+// deduction guides to prevent the ctad-maybe-unsupported warning
+template <class T>
+not_null(T ptr) -> not_null<T>;
+template <class T>
+strict_not_null(T ptr) -> strict_not_null<T>;
+
+#endif // (defined(__cplusplus) && (__cplusplus >= 201703L))
 
 } // namespace gsl
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -124,7 +124,7 @@ private:
 template <class T>
 not_null(T ptr) -> not_null<T>;
 
-#endif (defined(__cplusplus) && (__cplusplus >= 201703L))
+#endif // (defined(__cplusplus) && (__cplusplus >= 201703L))
 
 template <class T>
 auto make_not_null(T&& t) {

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -100,7 +100,7 @@ public:
 
     constexpr operator T() const { return get(); }
     constexpr T operator->() const { return get(); }
-    constexpr decltype(auto) operator*() const { return *get(); } 
+    constexpr decltype(auto) operator*() const { return *get(); }
 
     // prevents compilation when someone attempts to assign a null pointer constant
     not_null(std::nullptr_t) = delete;
@@ -118,6 +118,13 @@ public:
 private:
     T ptr_;
 };
+
+#if (defined(__cplusplus) && (__cplusplus >= 201703L))
+// deduction guide to prevent the ctad-maybe-unsupported warning
+template <class T>
+not_null(T ptr) -> not_null<T>;
+
+#endif (defined(__cplusplus) && (__cplusplus >= 201703L))
 
 template <class T>
 auto make_not_null(T&& t) {

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -272,13 +272,13 @@ auto make_strict_not_null(T&& t) {
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#if ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
 
 // deduction guides to prevent the ctad-maybe-unsupported warning
 template <class T> not_null(T) -> not_null<T>;
 template <class T> strict_not_null(T) -> strict_not_null<T>;
 
-#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
 
 } // namespace gsl
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -272,15 +272,13 @@ auto make_strict_not_null(T&& t) {
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
-#if (defined(__cplusplus) && (__cplusplus >= 201703L))
+#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201907L))
 
 // deduction guides to prevent the ctad-maybe-unsupported warning
-template <class T>
-not_null(T ptr) -> not_null<T>;
-template <class T>
-strict_not_null(T ptr) -> strict_not_null<T>;
+template <class T> not_null(T) -> not_null<T>;
+template <class T> strict_not_null(T) -> strict_not_null<T>;
 
-#endif // (defined(__cplusplus) && (__cplusplus >= 201703L))
+#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201907L))
 
 } // namespace gsl
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -272,13 +272,13 @@ auto make_strict_not_null(T&& t) {
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201907L))
+#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 
 // deduction guides to prevent the ctad-maybe-unsupported warning
 template <class T> not_null(T) -> not_null<T>;
 template <class T> strict_not_null(T) -> strict_not_null<T>;
 
-#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201907L))
+#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 
 } // namespace gsl
 

--- a/tests/no_exception_ensure_tests.cpp
+++ b/tests/no_exception_ensure_tests.cpp
@@ -28,7 +28,7 @@ int operator_subscript_no_throw() noexcept
 
 void setup_termination_handler() noexcept
 {
-#if defined(_MSC_VER)
+#if defined(GSL_MSVC_USE_STL_NOEXCEPTION_WORKAROUND)
 
     auto& handler = gsl::details::get_terminate_handler();
     handler = &test_terminate;

--- a/tests/no_exception_throw_tests.cpp
+++ b/tests/no_exception_throw_tests.cpp
@@ -28,7 +28,7 @@ int narrow_no_throw()
 
 void setup_termination_handler() noexcept
 {
-#if defined(_MSC_VER)
+#if defined(GSL_MSVC_USE_STL_NOEXCEPTION_WORKAROUND)
 
     auto& handler = gsl::details::get_terminate_handler();
     handler = &test_terminate;


### PR DESCRIPTION
This fixes a couple warnings created during the LLVM build about lack of deduction guides for not_null and strict_not_null. 

LLVM builds are failing recently with this warning:
..\include\gsl/pointers(69,7): note: add a deduction guide to suppress this warning
class not_null
      ^
..\tests\notnull_tests.cpp(429,22): error: 'not_null' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]

Also:
I found while building with Clang on Windows that _MSC_VER is being defined by Clang, which causes compiler errors due to not being able to find gsl::details::get_terminate_handler. I aligned the preprocessor check to match the one defining get_terminate_handler.