### PR TITLE
Deprecate span::at & span::operator(). See #828.

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -510,8 +510,12 @@ public:
         return data()[idx];
     }
 
+    // at and operator() are deprecated to align to the public member functions of std::span
+    [[deprecated("Use operator[]")]]
     constexpr reference at(index_type idx) const { return this->operator[](idx); }
+    [[deprecated("Use operator[]")]]
     constexpr reference operator()(index_type idx) const { return this->operator[](idx); }
+
     constexpr pointer data() const noexcept { return storage_.data(); }
 
     // [span.iter], span iterator support

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -18,17 +18,14 @@
 // blanket turn off warnings from CppCoreCheck from catch
 // so people aren't annoyed by them when running the tool.
 #pragma warning(disable : 26440 26426 26497 4189 4996)
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+#endif 
 
 #if __clang__ || __GNUC__
 //disable warnings from gtest
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundef"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif // __clang__ || __GNUC__
 
 #if __clang__

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -17,8 +17,11 @@
 #ifdef _MSC_VER
 // blanket turn off warnings from CppCoreCheck from catch
 // so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426 26497 4189) // from catch
+#pragma warning(disable : 26440 26426 26497 4189 4996)
 
+#if __clang__ || __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #if __clang__ || __GNUC__


### PR DESCRIPTION
Re: #828. 
This pr deprecates functions from gsl::span that do not exist in std::span. 
- span::at
- span::operator()

The goal is to reduce friction between usage of std::span and gsl::span. 
These can be removed later. 