### PR TITLE
Add span::front and span::back. See #828.

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -513,13 +513,13 @@ public:
     constexpr reference at(index_type idx) const { return this->operator[](idx); }
     constexpr reference operator()(index_type idx) const { return this->operator[](idx); }
 
-    constexpr reference front() const
+    constexpr reference front() const noexcept
     {
         Expects(size() > 0);
         return data()[0];
     }
 
-    constexpr reference back() const
+    constexpr reference back() const noexcept
     {
         Expects(size() > 0);
         return data()[size() - 1];

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -512,6 +512,19 @@ public:
 
     constexpr reference at(index_type idx) const { return this->operator[](idx); }
     constexpr reference operator()(index_type idx) const { return this->operator[](idx); }
+
+    constexpr reference front() const
+    {
+        Expects(size() > 0);
+        return data()[0];
+    }
+
+    constexpr reference back() const
+    {
+        Expects(size() > 0);
+        return data()[size() - 1];
+    }
+
     constexpr pointer data() const noexcept { return storage_.data(); }
 
     // [span.iter], span iterator support

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1644,6 +1644,22 @@ TEST(span_test, from_array_constructor)
      EXPECT_FALSE((std::is_default_constructible<span<int, 42>>::value));
  }
 
+ TEST(span_test, front_back)
+ {
+    int arr[5] = {1,2,3,4,5};
+    span<int> s{arr};
+    EXPECT_TRUE(s.front() == 1);
+    EXPECT_TRUE(s.back() == 5);
+
+    std::set_terminate([] {
+        std::cerr << "Expected Death. front_back";
+        std::abort();
+    });
+    span<int> s2;
+    EXPECT_DEATH(s2.front(), deathstring);
+    EXPECT_DEATH(s2.back(), deathstring);
+ }
+
 #if __clang__ || __GNUC__
 #pragma GCC diagnostic pop
 #endif // __clang__ || __GNUC__


### PR DESCRIPTION
Re: #828.
This pr adds functions to gsl::span that are missing from the functions defined in std::span.

- span::front
- span::back

The goal is to reduce friction between usage of std::span and gsl::span.
