### PR TITLE
Travis fixes/upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,101 +22,42 @@ matrix:
     # so leave this first for the overall build to be faster
     ##########################################################################
 
-    # XCode 8.3
-    - env: COMPILER=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode8.3
-      compiler: clang
-
-    - env: COMPILER=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode8.3
-      compiler: clang
-
     # XCode 9.1
     - env: COMPILER=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       os: osx
-      osx_image: xcode9.1
+      osx_image: xcode9.4.1
       compiler: clang
 
     - env: COMPILER=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=14
       os: osx
-      osx_image: xcode9.1
+      osx_image: xcode9.4.1
+      compiler: clang
+
+    # XCode 10.3
+    - env: COMPILER=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=14
+      os: osx
+      osx_image: xcode10.3
+      compiler: clang
+
+    - env: COMPILER=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=14
+      os: osx
+      osx_image: xcode10.3
+      compiler: clang
+
+    # XCode 11.3
+    - env: COMPILER=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=14
+      os: osx
+      osx_image: xcode11.3
+      compiler: clang
+
+    - env: COMPILER=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=14
+      os: osx
+      osx_image: xcode11.3
       compiler: clang
 
     ##########################################################################
     # Clang on Linux
     ##########################################################################
-
-    # Clang 3.6
-    - env: COMPILER=clang++-3.6 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang36
-        apt:
-          packages:
-            - clang-3.6
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-
-    - env: COMPILER=clang++-3.6 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang36
-
-    # Clang 3.7
-    - env: COMPILER=clang++-3.7 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang37
-        apt:
-          packages:
-            - clang-3.7
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-
-    - env: COMPILER=clang++-3.7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang37
-
-    # Clang 3.8
-    - env: COMPILER=clang++-3.8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang38
-        apt:
-          packages:
-            - clang-3.8
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-
-    - env: COMPILER=clang++-3.8 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang38
-
-    # Clang 3.9
-    - env: COMPILER=clang++-3.9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang39
-        apt:
-          packages:
-            - clang-3.9
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
-
-    - env: COMPILER=clang++-3.9 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang39
-
-    # Clang 4.0
-    - env: COMPILER=clang++-4.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang40
-        apt:
-          packages:
-            - clang-4.0
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-
-    - env: COMPILER=clang++-4.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang40
 
     # Clang 5.0
     - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
@@ -222,7 +163,7 @@ matrix:
     - env: COMPILER=g++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *gcc7
 
-    # GCC 7 c++17 
+    # GCC 7 c++17
     - env: COMPILER=g++-7 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
       addons: *gcc7
 
@@ -288,7 +229,7 @@ before_script:
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir build && cd build
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGSL_CXX_STANDARD=$GSL_CXX_STANDARD
-  
+
 script:
   # build and run tests
   - cmake --build . -- -j${JOBS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 
 # Use Linux unless specified otherwise
 os: linux
-dist: trusty
+dist: bionic
 
 cache:
   directories:
@@ -58,6 +58,20 @@ matrix:
     ##########################################################################
     # Clang on Linux
     ##########################################################################
+    # Clang 4.0
+
+    - env: COMPILER=clang++-4.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
+      addons: &clang40
+        apt:
+          packages:
+            - clang-4.0
+            - g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - env: COMPILER=clang++-4.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
+      addons: *clang40
 
     # Clang 5.0
     - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
@@ -115,7 +129,6 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-7
 
-
     - env: COMPILER=clang++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang70
 
@@ -125,6 +138,46 @@ matrix:
 
     - env: COMPILER=clang++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=17
       addons: *clang70
+
+    # Clang 8.0
+    - env: COMPILER=clang++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
+      addons: &clang80
+        apt:
+          packages:
+            - clang-8
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
+
+    - env: COMPILER=clang++-8 BUILD_TYPE=Release GSL_CXX_STANDARD=14
+      addons: *clang80
+
+    - env: COMPILER=clang++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang80
+
+    - env: COMPILER=clang++-8 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang80
+
+    # Clang 9.0
+    - env: COMPILER=clang++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
+      addons: &clang90
+        apt:
+          packages:
+            - clang-9
+            - g++-9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-9
+
+    - env: COMPILER=clang++-9 BUILD_TYPE=Release GSL_CXX_STANDARD=14
+      addons: *clang90
+
+    - env: COMPILER=clang++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
+      addons: *clang90
+
+    - env: COMPILER=clang++-9 BUILD_TYPE=Release GSL_CXX_STANDARD=17
+      addons: *clang90
 
     ##########################################################################
     # GCC on Linux
@@ -204,11 +257,6 @@ install:
     LLVM_INSTALL=${DEPS_DIR}/llvm/install
     # if in linux and compiler clang and llvm not installed
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "${CXX%%+*}" == "clang" && -n "$(ls -A ${LLVM_INSTALL})" ]]; then
-      if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
-      elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
-      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
-      fi
       LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
       LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
       LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,7 @@ matrix:
             - g++-7
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - llvm-toolchain-bionic-5.0
 
     - env: COMPILER=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang50
@@ -104,9 +102,7 @@ matrix:
             - g++-7
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - llvm-toolchain-bionic-6.0
 
     - env: COMPILER=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang60
@@ -127,7 +123,7 @@ matrix:
             - g++-7
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-bionic-7
 
     - env: COMPILER=clang++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang70
@@ -148,7 +144,7 @@ matrix:
             - g++-8
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-8
+            - llvm-toolchain-bionic-8
 
     - env: COMPILER=clang++-8 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang80
@@ -168,7 +164,7 @@ matrix:
             - g++-9
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-9
+            - llvm-toolchain-bionic-9
 
     - env: COMPILER=clang++-9 BUILD_TYPE=Release GSL_CXX_STANDARD=14
       addons: *clang90

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -30,7 +30,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -30,7 +30,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -30,7 +30,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/bounds_tests.cpp
+++ b/tests/bounds_tests.cpp
@@ -33,7 +33,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -30,7 +30,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -34,7 +34,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -33,7 +33,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -31,7 +31,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -32,7 +32,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>
@@ -1088,28 +1090,28 @@ TEST(span_test, from_array_constructor)
  {
      int a[] = {1, 2, 3, 4};
      span<int> s{a};
- 
+
      EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
- 
+
      EXPECT_TRUE((std::is_same<decltype(s.cbegin()), decltype(cbegin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.cend()), decltype(cend(s))>::value));
- 
+
      EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
- 
+
      EXPECT_TRUE((std::is_same<decltype(s.crbegin()), decltype(crbegin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.crend()), decltype(crend(s))>::value));
- 
+
      EXPECT_TRUE(s.begin() == begin(s));
      EXPECT_TRUE(s.end() == end(s));
- 
+
      EXPECT_TRUE(s.cbegin() == cbegin(s));
      EXPECT_TRUE(s.cend() == cend(s));
- 
+
      EXPECT_TRUE(s.rbegin() == rbegin(s));
      EXPECT_TRUE(s.rend() == rend(s));
- 
+
      EXPECT_TRUE(s.crbegin() == crbegin(s));
      EXPECT_TRUE(s.crend() == crend(s));
  }
@@ -1118,7 +1120,7 @@ TEST(span_test, from_array_constructor)
  {
      int a[] = {1, 2, 3, 4};
      span<int> s{a};
- 
+
      EXPECT_TRUE((std::is_same<decltype(s.size()), decltype(ssize(s))>::value));
      EXPECT_TRUE(s.size() == ssize(s));
  }

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -33,7 +33,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/strided_span_tests.cpp
+++ b/tests/strided_span_tests.cpp
@@ -33,7 +33,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -31,7 +31,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 #include <gtest/gtest.h>

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -31,7 +31,9 @@
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wused-but-marked-unused"
 #pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#if __clang_major__ > 4
 #pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
+#endif // __clang_major__ > 4
 #endif // __clang__
 
 


### PR DESCRIPTION
Changes to the Travis matrix:

Upgrading the distro from Trusty to Bionic because Trusty is EOL.
Upgrading XCode to the latest versions from XCode 9, 10, and 11
Removing Clang 3.6 - 3.9
Adding Clang 8 and 9.

Changes to the test files:
The diagnostic inconsistent-missing-destructor-override is missing in Clang 4 and earlier. I added major version detection to the warning suppression to only add this flag to versions that support it.

