### PR TITLE
Compiler warning suppression for tests to CMake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,10 +98,18 @@ else()
           $<$<CXX_COMPILER_VERSION:5.0.2>:-Wno-undefined-func-template>
         >
         $<$<CXX_COMPILER_ID:GNU>:
+          -Wdouble-promotion # float implicit to double
+          -Wlogical-op # suspicious uses of logical operators
           $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6>>:
+            -Wduplicated-cond # duplicated if-else conditions
+            -Wmisleading-indentation
+            -Wnull-dereference
             $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
               -Wno-unused-variable
             >
+          >
+          $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,7>>:
+            -Wduplicated-branches # identical if-else branches
           >
         >
     )
@@ -193,6 +201,22 @@ else()
           -Wno-missing-prototypes
           -Wno-unknown-attributes
           -Wno-weak-vtables
+        >
+        $<$<CXX_COMPILER_ID:GNU>:
+          -Wdouble-promotion # float implicit to double
+          -Wlogical-op # suspicious uses of logical operators
+          -Wuseless-cast # casting to its own type
+          $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6>>:
+            -Wduplicated-cond # duplicated if-else conditions
+            -Wmisleading-indentation
+            -Wnull-dereference
+          >
+          $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,7>>:
+            -Wduplicated-branches # identical if-else branches
+          >
+          $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,8>>:
+            -Wcast-align=strict # increase alignment (i.e. char* to int*)
+          >
         >
     )
 endif(MSVC)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,21 @@ if(MSVC) # MSVC or simulating MSVC
         /EHsc
         /W4
         /WX
+        $<$<CXX_COMPILER_ID:MSVC>:
+          /wd4996  # Use of function or classes marked [[deprecated]]
+          /wd26409 # CppCoreCheck - GTest
+          /wd26426 # CppCoreCheck - GTest
+          /wd26440 # CppCoreCheck - GTest
+          /wd26446 # CppCoreCheck - prefer gsl::at()
+          /wd26472 # CppCoreCheck - use gsl::narrow(_cast)
+          /wd26481 # CppCoreCheck - use span instead of pointer arithmetic
+          $<$<VERSION_LESS:$<CXX_COMPILER_VERSION>,1920>: # VS2015
+            /wd4189 # variable is initialized but not referenced
+            $<$<NOT:$<CONFIG:Debug>>: # Release, RelWithDebInfo
+              /wd4702 # Unreachable code
+            >
+          >
+        >
         $<$<CXX_COMPILER_ID:Clang>:
           -Weverything
           -Wno-c++98-compat
@@ -172,6 +187,8 @@ if(MSVC) # MSVC or simulating MSVC
         $<$<CXX_COMPILER_ID:MSVC>:
           /wd4577
           /wd4702
+          /wd26440 # CppCoreCheck - GTest
+          /wd26446 # CppCoreCheck - prefer gsl::at()
         >
         $<$<CXX_COMPILER_ID:Clang>:
           -Weverything

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,9 +57,11 @@ if(MSVC) # MSVC or simulating MSVC
           -Wno-missing-prototypes
           -Wno-shift-sign-overflow # GTest gtest-port.h
           -Wno-undef # GTest
-          -Wno-unused-variable
           -Wno-used-but-marked-unused # GTest EXPECT_DEATH
-          $<$<EQUAL:${GSL_CXX_STANDARD},14>:-Wno-unused-member-function>
+          $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
+            -Wno-unused-member-function
+            -Wno-unused-variable
+          >
         >
     )
 else()
@@ -85,16 +87,22 @@ else()
           -Wno-missing-prototypes
           -Wno-padded
           -Wno-unknown-attributes
-          -Wno-unused-variable
           -Wno-used-but-marked-unused # GTest EXPECT_DEATH
-          $<$<EQUAL:${GSL_CXX_STANDARD},14>:-Wno-unused-member-function>
           -Wno-weak-vtables
+          $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
+            -Wno-unused-member-function
+            -Wno-unused-variable
+          >
         >
         $<$<CXX_COMPILER_ID:Clang>:
           $<$<CXX_COMPILER_VERSION:5.0.2>:-Wno-undefined-func-template>
         >
         $<$<CXX_COMPILER_ID:GNU>:
-          -Wno-unused-variable
+          $<$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6>>:
+            $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
+              -Wno-unused-variable
+            >
+          >
         >
     )
 endif(MSVC)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,9 +49,16 @@ if(MSVC) # MSVC or simulating MSVC
           -Weverything
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
+          -Wno-covered-switch-default # GTest
+          -Wno-deprecated-declarations # Allow tests for [[deprecated]] elements
+          -Wno-global-constructors # GTest
+          -Wno-language-extension-token # GTest gtest-port.h
           -Wno-missing-braces
           -Wno-missing-prototypes
-          -Wno-unknown-attributes
+          -Wno-shift-sign-overflow # GTest gtest-port.h
+          -Wno-undef # GTest
+          -Wno-unused-variable
+          -Wno-used-but-marked-unused # GTest EXPECT_DEATH
           $<$<EQUAL:${GSL_CXX_STANDARD},14>:-Wno-unused-member-function>
         >
     )
@@ -67,19 +74,27 @@ else()
         -Wpedantic
         -Wshadow
         -Wsign-conversion
+        -Wno-deprecated-declarations # Allow tests for [[deprecated]] elements
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
           -Wno-missing-braces
+          -Wno-covered-switch-default # GTest
+          -Wno-global-constructors # GTest
           -Wno-missing-prototypes
           -Wno-padded
           -Wno-unknown-attributes
+          -Wno-unused-variable
+          -Wno-used-but-marked-unused # GTest EXPECT_DEATH
           $<$<EQUAL:${GSL_CXX_STANDARD},14>:-Wno-unused-member-function>
           -Wno-weak-vtables
         >
         $<$<CXX_COMPILER_ID:Clang>:
           $<$<CXX_COMPILER_VERSION:5.0.2>:-Wno-undefined-func-template>
+        >
+        $<$<CXX_COMPILER_ID:GNU>:
+          -Wno-unused-variable
         >
     )
 endif(MSVC)

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -20,19 +20,6 @@
 #pragma warning(disable : 26440 26426) // from catch
 #endif
 
-#if __clang__ || __GNUC__
-// disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_algorithm> // for copy
 #include <gsl/span>          // for span
@@ -244,7 +231,3 @@ TEST(algorithm_tests, small_destination_span)
     copy(src_span_static, dst_span_static);
 #endif
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -14,12 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-#endif
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_algorithm> // for copy
 #include <gsl/span>          // for span

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -20,19 +20,6 @@
 #pragma warning(disable : 26440 26426) // from catch
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_assert> // for fail_fast (ptr only), Ensures, Expects
 
@@ -78,7 +65,3 @@ TEST(assertion_tests, ensures)
     EXPECT_TRUE(g(2) == 3);
     EXPECT_DEATH(g(9), deathstring);
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -14,12 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-#endif
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_assert> // for fail_fast (ptr only), Ensures, Expects
 

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -20,19 +20,6 @@
 #pragma warning(disable : 26440 26426) // from catch
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_util> // for at
@@ -152,7 +139,3 @@ static constexpr bool test_constexpr()
 
 static_assert(test_constexpr(), "FAIL");
 #endif
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -14,12 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_util> // for at

--- a/tests/bounds_tests.cpp
+++ b/tests/bounds_tests.cpp
@@ -14,13 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-#pragma warning(disable : 4996)  // use of function or classes marked [[deprecated]]
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/multi_span> // for static_bounds, static_bounds_dynamic_range_t

--- a/tests/bounds_tests.cpp
+++ b/tests/bounds_tests.cpp
@@ -21,21 +21,6 @@
 #pragma warning(disable : 4996)  // use of function or classes marked [[deprecated]]
 #endif
 
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-//disable warnings from gtest
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/multi_span> // for static_bounds, static_bounds_dynamic_range_t
@@ -122,7 +107,3 @@ TEST(bounds_tests, bounds_convertible)
 #ifdef CONFIRM_COMPILATION_ERRORS
 copy(src_span_static, dst_span_static);
 #endif
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -14,12 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426)
-#endif // _MSC_VER
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte> // for to_byte, to_integer, byte, operator&, ope...

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -20,19 +20,6 @@
 #pragma warning(disable : 26440 26426)
 #endif // _MSC_VER
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte> // for to_byte, to_integer, byte, operator&, ope...
@@ -146,7 +133,3 @@ TEST(byte_tests, aliasing)
 #ifdef CONFIRM_COMPILATION_ERRORS
 copy(src_span_static, dst_span_static);
 #endif
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -14,14 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-#pragma warning(disable : 4996) // multi_span is in the process of being deprecated.
-                                // Suppressing warnings until it is completely removed
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte>   // for byte

--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -22,21 +22,6 @@
                                 // Suppressing warnings until it is completely removed
 #endif
 
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-//disable warnings from gtest
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte>   // for byte
@@ -1884,7 +1869,3 @@ TEST(multi_span_test, iterator)
 #ifdef CONFIRM_COMPILATION_ERRORS
 copy(src_span_static, dst_span_static);
 #endif
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -23,19 +23,6 @@
 #pragma warning(disable : 4702) // unreachable code
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/pointers> // for not_null, operator<, operator<=, operator>
@@ -558,7 +545,3 @@ TEST(notnull_tests, TestMakeNotNull)
 
 static_assert(std::is_nothrow_move_constructible<not_null<void*>>::value,
               "not_null must be no-throw move constructible");
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -14,15 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-
-// Fix VS2015 build breaks in Release
-#pragma warning(disable : 4702) // unreachable code
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/pointers> // for not_null, operator<, operator<=, operator>

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -14,13 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/pointers> // for owner

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -21,19 +21,6 @@
 
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/pointers> // for owner
@@ -61,7 +48,3 @@ TEST(owner_tests, check_pointer_constraint)
     }
     #endif
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -20,21 +20,6 @@
 #pragma warning(disable : 26440 26426 26497 4189 4996)
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte> // for byte
@@ -1698,7 +1683,3 @@ TEST(span_test, from_array_constructor)
     EXPECT_DEATH(s2.front(), deathstring);
     EXPECT_DEATH(s2.back(), deathstring);
  }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -14,12 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426 26497 4189 4996)
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_byte> // for byte

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1287,7 +1287,11 @@ TEST(span_test, from_array_constructor)
 
          auto beyond = s.rend();
          EXPECT_TRUE(it != beyond);
-         EXPECT_DEATH(auto _ = *beyond , deathstring);
+#if (__cplusplus > 201402L)
+        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond , deathstring);
+#else
+        EXPECT_DEATH(auto _ = *beyond , deathstring);
+#endif
 
          EXPECT_TRUE(beyond - first == 4);
          EXPECT_TRUE(first - first == 0);
@@ -1332,7 +1336,11 @@ TEST(span_test, from_array_constructor)
 
          auto beyond = s.crend();
          EXPECT_TRUE(it != beyond);
-         EXPECT_DEATH(auto _ = *beyond, deathstring);
+#if (__cplusplus > 201402L)
+        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond, deathstring);
+#else
+        EXPECT_DEATH(auto _ = *beyond, deathstring);
+#endif
 
          EXPECT_TRUE(beyond - first == 4);
          EXPECT_TRUE(first - first == 0);

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -14,15 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-
-// Fix VS2015 build breaks in Release
-#pragma warning(disable : 4702) // unreachable code
-#endif
-
 #include <gtest/gtest.h>
 #include <gsl/pointers>           // for not_null, operator<, operator<=, operator>
 

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -23,19 +23,6 @@
 #pragma warning(disable : 4702) // unreachable code
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 #include <gsl/pointers>           // for not_null, operator<, operator<=, operator>
 
@@ -213,7 +200,3 @@ TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
 
 static_assert(std::is_nothrow_move_constructible<strict_not_null<void*>>::value,
               "strict_not_null must be no-throw move constructible");
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/strided_span_tests.cpp
+++ b/tests/strided_span_tests.cpp
@@ -22,20 +22,6 @@
                                 // Suppressing warnings until it is completely removed
 #endif
 
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-//disable warnings from gtest
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_byte>   // for byte
 #include <gsl/gsl_util>   // for narrow_cast
@@ -810,7 +796,3 @@ TEST(strided_span_tests, strided_span_conversion)
         i++;
     }
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/strided_span_tests.cpp
+++ b/tests/strided_span_tests.cpp
@@ -14,14 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch deprecated
-#pragma warning(disable : 4996) // strided_span is in the process of being deprecated.
-                                // Suppressing warnings until it is completely removed
-#endif
-
 #include <gtest/gtest.h>
 #include <gsl/gsl_byte>   // for byte
 #include <gsl/gsl_util>   // for narrow_cast

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -14,13 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_assert>  // for Expects, fail_fast (ptr only)

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -21,19 +21,6 @@
 
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_assert>  // for Expects, fail_fast (ptr only)
@@ -1235,7 +1222,3 @@ TEST(string_span_tests, as_writeable_bytes)
     EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
     EXPECT_TRUE(bs.size() == s.size_bytes());
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -14,13 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// blanket turn off warnings from CppCoreCheck from catch
-// so people aren't annoyed by them when running the tool.
-#pragma warning(disable : 26440 26426) // from catch
-
-#endif
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_util> // for narrow, finally, narrow_cast, narrowing_e...

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -21,20 +21,6 @@
 
 #endif
 
-#if __clang__ || __GNUC__
-//disable warnings from gtest
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#endif // __clang__ || __GNUC__
-
-#if __clang__
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-#pragma GCC diagnostic ignored "-Wused-but-marked-unused"
-#pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#pragma GCC diagnostic ignored "-Winconsistent-missing-destructor-override"
-#endif // __clang__
-
-
 #include <gtest/gtest.h>
 
 #include <gsl/gsl_util> // for narrow, finally, narrow_cast, narrowing_e...
@@ -154,7 +140,3 @@ TEST(utils_tests, narrow)
 #endif
 
 }
-
-#if __clang__ || __GNUC__
-#pragma GCC diagnostic pop
-#endif // __clang__ || __GNUC__


### PR DESCRIPTION
Only for the test suite. Remove the `#pragma`'s used to suppress compiler warnings.

This brings all the compile flags together in the `tests/CMakeLists.txt`.
In addition compiler/os/version selection is made a bit more specific and unnecessary suppression flags are removed.

A disadvantage is the lack for a clean way in CMake to set flags for specific files.
Thus, some flags are disabled with a wider scope then before.