### PR TITLE
Restore disabling of exceptions for MSVC in "no exception tests"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,9 @@ endforeach(flag_var)
 # please try to keep entries ordered =)
 add_library(gsl_tests_config_noexcept INTERFACE)
 if(MSVC) # MSVC or simulating MSVC
+    target_compile_definitions(gsl_tests_config_noexcept INTERFACE
+        _HAS_EXCEPTIONS=0 # disable exceptions in the Microsoft STL
+    )
     target_compile_options(gsl_tests_config_noexcept INTERFACE
         ${GSL_CPLUSPLUS_OPT}
         /W4

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,7 +135,6 @@ add_library(gsl_tests_config_noexcept INTERFACE)
 if(MSVC) # MSVC or simulating MSVC
     target_compile_options(gsl_tests_config_noexcept INTERFACE
         ${GSL_CPLUSPLUS_OPT}
-        /EHsc
         /W4
         /WX
         $<$<CXX_COMPILER_ID:MSVC>:


### PR DESCRIPTION
Somewhere along the line exceptions where enabled for the test that should be executed without exceptions.
This restores the original configuration.