### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ These steps assume the source code of this repository has been cloned into a dir
 
 All tests should pass - indicating your platform is fully supported and you are ready to use the GSL types!
 
+## Building GSL - Using vcpkg
+
+You can download and install GSL using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install gsl
+
+The GSL port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Using the libraries
 As the types are entirely implemented inline in headers, there are no linking requirements.
 


### PR DESCRIPTION
`GSL `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `GSL` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `GSL`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/gsl/portfile.cmake). We try to keep the library maintained as close as possible to the original library.