### PR TITLE
remove move constructor for not_null.

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -88,7 +88,6 @@ public:
     {
     }
 
-    not_null(not_null&& other) = default;
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
 

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -533,6 +533,3 @@ TEST(notnull_tests, TestMakeNotNull)
     }
 #endif
 }
-
-static_assert(std::is_nothrow_move_constructible<not_null<void*>>::value,
-              "not_null must be no-throw move constructible");

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -188,6 +188,3 @@ TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
 #endif
 }
 #endif // #if defined(__cplusplus) && (__cplusplus >= 201703L)
-
-static_assert(std::is_nothrow_move_constructible<strict_not_null<void*>>::value,
-              "strict_not_null must be no-throw move constructible");


### PR DESCRIPTION
Moving not_null will replace whatever pointer is stored within with null, which goes against the purpose of not_null.
This change removes the move constructor for not_null. 