### PR TITLE
Fix incorrect package name for vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can download and install GSL using the [vcpkg](https://github.com/Microsoft/
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    vcpkg install gsl
+    vcpkg install ms-gsl
 
 The GSL port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 


### PR DESCRIPTION
The package indicated in README.md corresponded to the GNU Scientific Library https://www.gnu.org/software/gsl/