### PR TITLE
Solve MSVC warning C4668: __GNUC__ & __clang__ not defined

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -57,7 +57,7 @@
 #endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
-#if __clang__ || __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -2266,7 +2266,7 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 #pragma GCC diagnostic pop
 #endif // __GNUC__ > 6
 
-#if __clang__ || __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
MSVC compiler warning C4668:
` '__clang__' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'`

[TravisCI build 1312](https://travis-ci.org/github/microsoft/GSL/builds/672776982)


p.s. The check for `__clang__` is since LLVM/clang v10 no longer optional, the new flag `-fgnuc-version=0`  makes `__GNUC__` undefined. [[source]](https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flags)