### PR TITLE
Suppress GCC 8 "-Warray-bounds" warning

### DIFF
--- a/tests/multi_span_tests.cpp
+++ b/tests/multi_span_tests.cpp
@@ -1043,7 +1043,7 @@ TEST(multi_span_test, subspan)
         EXPECT_TRUE(av.subspan(4).length() == 1);
         EXPECT_TRUE(av.subspan(5).length() == 0);
         // Disabled test instead of fixing since multi_span is deprecated. (PR#835)
-#if !(defined(__GNUC__) && __GNUC__ == 8 && __GNUC_MINOR__ == 3)
+#if !(defined(__GNUC__) && __GNUC__ == 8)
         EXPECT_DEATH(av.subspan(6).length(), deathstring);
 #endif
         auto av2 = av.subspan(1);


### PR DESCRIPTION
Modification of commit 5e21831494ea1a140bee47d0a95fc7b0af6c0c3c.

The new release of GCC 8.4 shows the same issue as 8.3, therefor this PR disables the test triggering the warning for the full GCC 8 branch.

[TravicCI build 1313](https://travis-ci.org/github/microsoft/GSL/builds/672782652)