### PR TITLE
implement LWG3320

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -403,9 +403,7 @@ public:
     using difference_type = std::ptrdiff_t;
 
     using iterator = details::span_iterator<ElementType>;
-    using const_iterator = details::span_iterator<const ElementType>;
     using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
     static constexpr const size_type extent{Extent};
@@ -594,30 +592,8 @@ public:
         return {data, endData, endData};
     }
 
-    constexpr const_iterator cbegin() const noexcept
-    {
-        const auto data = storage_.data();
-        return {data, data + size(), data};
-    }
-
-    constexpr const_iterator cend() const noexcept
-    {
-        const auto data = storage_.data();
-        const auto endData = data + storage_.size();
-        return {data, endData, endData};
-    }
-
     constexpr reverse_iterator rbegin() const noexcept { return reverse_iterator{end()}; }
     constexpr reverse_iterator rend() const noexcept { return reverse_iterator{begin()}; }
-
-    constexpr const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator{cend()};
-    }
-    constexpr const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator{cbegin()};
-    }
 
 #ifdef _MSC_VER
     // Tell MSVC how to unwrap spans in range-based-for

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -152,20 +152,6 @@ end(const span<ElementType, Extent>& s) noexcept
 }
 
 template <class ElementType, std::size_t Extent>
-constexpr typename span<ElementType, Extent>::const_iterator
-cbegin(const span<ElementType, Extent>& s) noexcept
-{
-    return s.cbegin();
-}
-
-template <class ElementType, std::size_t Extent>
-constexpr typename span<ElementType, Extent>::const_iterator
-cend(const span<ElementType, Extent>& s) noexcept
-{
-    return s.cend();
-}
-
-template <class ElementType, std::size_t Extent>
 constexpr typename span<ElementType, Extent>::reverse_iterator
 rbegin(const span<ElementType, Extent>& s) noexcept
 {
@@ -177,20 +163,6 @@ constexpr typename span<ElementType, Extent>::reverse_iterator
 rend(const span<ElementType, Extent>& s) noexcept
 {
     return s.rend();
-}
-
-template <class ElementType, std::size_t Extent>
-constexpr typename span<ElementType, Extent>::const_reverse_iterator
-crbegin(const span<ElementType, Extent>& s) noexcept
-{
-    return s.crbegin();
-}
-
-template <class ElementType, std::size_t Extent>
-constexpr typename span<ElementType, Extent>::const_reverse_iterator
-crend(const span<ElementType, Extent>& s) noexcept
-{
-    return s.crend();
 }
 
 } // namespace gsl

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -165,6 +165,34 @@ rend(const span<ElementType, Extent>& s) noexcept
     return s.rend();
 }
 
+template <class ElementType, std::size_t Extent>
+constexpr typename span<ElementType, Extent>::iterator
+cbegin(const span<ElementType, Extent>& s) noexcept
+{
+    return s.begin();
+}
+
+template <class ElementType, std::size_t Extent = dynamic_extent>
+constexpr typename span<ElementType, Extent>::iterator
+cend(const span<ElementType, Extent>& s) noexcept
+{
+    return s.end();
+}
+
+template <class ElementType, std::size_t Extent>
+constexpr typename span<ElementType, Extent>::reverse_iterator
+crbegin(const span<ElementType, Extent>& s) noexcept
+{
+    return s.rbegin();
+}
+
+template <class ElementType, std::size_t Extent>
+constexpr typename span<ElementType, Extent>::reverse_iterator
+crend(const span<ElementType, Extent>& s) noexcept
+{
+    return s.rend();
+}
+
 } // namespace gsl
 
 #endif // GSL_SPAN_EXT_H

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -186,9 +186,7 @@ public:
 
     using size_type = typename impl_type::size_type;
     using iterator = typename impl_type::iterator;
-    using const_iterator = typename impl_type::const_iterator;
     using reverse_iterator = typename impl_type::reverse_iterator;
-    using const_reverse_iterator = typename impl_type::const_reverse_iterator;
 
     // default (empty)
     constexpr basic_string_span() noexcept = default;
@@ -304,14 +302,8 @@ public:
     constexpr iterator begin() const noexcept { return span_.begin(); }
     constexpr iterator end() const noexcept { return span_.end(); }
 
-    constexpr const_iterator cbegin() const noexcept { return span_.cbegin(); }
-    constexpr const_iterator cend() const noexcept { return span_.cend(); }
-
     constexpr reverse_iterator rbegin() const noexcept { return span_.rbegin(); }
     constexpr reverse_iterator rend() const noexcept { return span_.rend(); }
-
-    constexpr const_reverse_iterator crbegin() const noexcept { return span_.crbegin(); }
-    constexpr const_reverse_iterator crend() const noexcept { return span_.crend(); }
 
 private:
     static impl_type remove_z(pointer const& sz, std::size_t max)

--- a/tests/span_compatibility_tests.cpp
+++ b/tests/span_compatibility_tests.cpp
@@ -387,12 +387,8 @@ TEST(span_compatibility_tests, assertion_tests)
         static_assert(noexcept(sp_dyn.data()), "noexcept(sp_dyn.data())");
         static_assert(noexcept(sp_dyn.begin()), "noexcept(sp_dyn.begin())");
         static_assert(noexcept(sp_dyn.end()), "noexcept(sp_dyn.end())");
-        static_assert(noexcept(sp_dyn.cbegin()), "noexcept(sp_dyn.cbegin())");
-        static_assert(noexcept(sp_dyn.cend()), "noexcept(sp_dyn.cend())");
         static_assert(noexcept(sp_dyn.rbegin()), "noexcept(sp_dyn.rbegin())");
         static_assert(noexcept(sp_dyn.rend()), "noexcept(sp_dyn.rend())");
-        static_assert(noexcept(sp_dyn.crbegin()), "noexcept(sp_dyn.crbegin())");
-        static_assert(noexcept(sp_dyn.crend()), "noexcept(sp_dyn.crend())");
 
         static_assert(noexcept(sp_nine.size()), "noexcept(sp_nine.size())");
         static_assert(noexcept(sp_nine.size_bytes()), "noexcept(sp_nine.size_bytes())");
@@ -403,12 +399,8 @@ TEST(span_compatibility_tests, assertion_tests)
         static_assert(noexcept(sp_nine.data()), "noexcept(sp_nine.data())");
         static_assert(noexcept(sp_nine.begin()), "noexcept(sp_nine.begin())");
         static_assert(noexcept(sp_nine.end()), "noexcept(sp_nine.end())");
-        static_assert(noexcept(sp_nine.cbegin()), "noexcept(sp_nine.cbegin())");
-        static_assert(noexcept(sp_nine.cend()), "noexcept(sp_nine.cend())");
         static_assert(noexcept(sp_nine.rbegin()), "noexcept(sp_nine.rbegin())");
         static_assert(noexcept(sp_nine.rend()), "noexcept(sp_nine.rend())");
-        static_assert(noexcept(sp_nine.crbegin()), "noexcept(sp_nine.crbegin())");
-        static_assert(noexcept(sp_nine.crend()), "noexcept(sp_nine.crend())");
 
         EXPECT_TRUE(sp_dyn.size() == 9);
         EXPECT_TRUE(sp_nine.size() == 9);
@@ -446,23 +438,11 @@ TEST(span_compatibility_tests, assertion_tests)
         EXPECT_TRUE(sp_dyn.end()[-2] == 80);
         EXPECT_TRUE(sp_nine.end()[-2] == 80);
 
-        EXPECT_TRUE(*sp_dyn.cbegin() == 10);
-        EXPECT_TRUE(*sp_nine.cbegin() == 10);
-
-        EXPECT_TRUE(sp_dyn.cend()[-2] == 80);
-        EXPECT_TRUE(sp_nine.cend()[-2] == 80);
-
         EXPECT_TRUE(*sp_dyn.rbegin() == 90);
         EXPECT_TRUE(*sp_nine.rbegin() == 90);
 
         EXPECT_TRUE(sp_dyn.rend()[-2] == 20);
         EXPECT_TRUE(sp_nine.rend()[-2] == 20);
-
-        EXPECT_TRUE(*sp_dyn.crbegin() == 90);
-        EXPECT_TRUE(*sp_nine.crbegin() == 90);
-
-        EXPECT_TRUE(sp_dyn.crend()[-2] == 20);
-        EXPECT_TRUE(sp_nine.crend()[-2] == 20);
 
         static_assert(is_same<decltype(sp_dyn.begin()), gsl::span<int>::iterator>::value,
                       "is_same<decltype(sp_dyn.begin()), gsl::span<int>::iterator>::value");
@@ -472,16 +452,6 @@ TEST(span_compatibility_tests, assertion_tests)
                       "is_same<decltype(sp_dyn.end()), gsl::span<int>::iterator>::value");
         static_assert(is_same<decltype(sp_nine.end()), gsl::span<int, 9>::iterator>::value,
                       "is_same<decltype(sp_nine.end()), gsl::span<int, 9>::iterator>::value");
-        static_assert(is_same<decltype(sp_dyn.cbegin()), gsl::span<int>::const_iterator>::value,
-                      "is_same<decltype(sp_dyn.cbegin()), gsl::span<int>::const_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_nine.cbegin()), gsl::span<int, 9>::const_iterator>::value,
-            "is_same<decltype(sp_nine.cbegin()), gsl::span<int, 9>::const_iterator>::value");
-        static_assert(is_same<decltype(sp_dyn.cend()), gsl::span<int>::const_iterator>::value,
-                      "is_same<decltype(sp_dyn.cend()), gsl::span<int>::const_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_nine.cend()), gsl::span<int, 9>::const_iterator>::value,
-            "is_same<decltype(sp_nine.cend()), gsl::span<int, 9>::const_iterator>::value");
         static_assert(
             is_same<decltype(sp_dyn.rbegin()), gsl::span<int>::reverse_iterator>::value,
             "is_same<decltype(sp_dyn.rbegin()), gsl::span<int>::reverse_iterator>::value");
@@ -493,19 +463,6 @@ TEST(span_compatibility_tests, assertion_tests)
         static_assert(
             is_same<decltype(sp_nine.rend()), gsl::span<int, 9>::reverse_iterator>::value,
             "is_same<decltype(sp_nine.rend()), gsl::span<int, 9>::reverse_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_dyn.crbegin()), gsl::span<int>::const_reverse_iterator>::value,
-            "is_same<decltype(sp_dyn.crbegin()), gsl::span<int>::const_reverse_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_nine.crbegin()), gsl::span<int, 9>::const_reverse_iterator>::value,
-            "is_same<decltype(sp_nine.crbegin()), gsl::span<int, "
-            "9>::const_reverse_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_dyn.crend()), gsl::span<int>::const_reverse_iterator>::value,
-            "is_same<decltype(sp_dyn.crend()), gsl::span<int>::const_reverse_iterator>::value");
-        static_assert(
-            is_same<decltype(sp_nine.crend()), gsl::span<int, 9>::const_reverse_iterator>::value,
-            "is_same<decltype(sp_nine.crend()), gsl::span<int, 9>::const_reverse_iterator>::value");
     }
     {
         int sequence[9]{10, 20, 30, 40, 50, 60, 70, 80, 90};
@@ -647,89 +604,53 @@ static_assert(std::is_same<gsl::span<const int, 3>::const_reference, const int&>
 static_assert(std::is_same<std::iterator_traits<gsl::span<int>::iterator>::pointer, int*>::value,
               "span<int>::iterator's pointer should be int*");
 static_assert(
-    std::is_same<std::iterator_traits<gsl::span<int>::const_iterator>::pointer, const int*>::value,
-    "span<int>::const_iterator's pointer should be const int*");
-static_assert(
     std::is_same<gsl::span<int>::reverse_iterator,
                  std::reverse_iterator<gsl::span<int>::iterator>>::value,
     "span<int>::reverse_iterator should equal std::reverse_iterator<span<int>::iterator>");
-static_assert(std::is_same<gsl::span<int>::const_reverse_iterator,
-                           std::reverse_iterator<gsl::span<int>::const_iterator>>::value,
-              "span<int>::const_reverse_iterator should equal "
-              "std::reverse_iterator<span<int>::const_iterator>");
 
 static_assert(std::is_same<std::iterator_traits<gsl::span<int, 3>::iterator>::pointer, int*>::value,
               "span<int, 3>::iterator's pointer should be int*");
-static_assert(std::is_same<std::iterator_traits<gsl::span<int, 3>::const_iterator>::pointer,
-                           const int*>::value,
-              "span<int, 3>::const_iterator's pointer should be const int*");
 static_assert(
     std::is_same<gsl::span<int, 3>::reverse_iterator,
                  std::reverse_iterator<gsl::span<int, 3>::iterator>>::value,
     "span<int, 3>::reverse_iterator should equal std::reverse_iterator<span<int, 3>::iterator>");
-static_assert(std::is_same<gsl::span<int, 3>::const_reverse_iterator,
-                           std::reverse_iterator<gsl::span<int, 3>::const_iterator>>::value,
-              "span<int, 3>::const_reverse_iterator should equal std::reverse_iterator<span<int, "
-              "3>::const_iterator>");
 
 static_assert(
     std::is_same<std::iterator_traits<gsl::span<const int>::iterator>::pointer, const int*>::value,
     "span<const int>::iterator's pointer should be int*");
-static_assert(std::is_same<std::iterator_traits<gsl::span<const int>::const_iterator>::pointer,
-                           const int*>::value,
-              "span<const int>::const_iterator's pointer should be const int*");
 static_assert(std::is_same<gsl::span<const int>::reverse_iterator,
                            std::reverse_iterator<gsl::span<const int>::iterator>>::value,
               "span<const int>::reverse_iterator should equal std::reverse_iterator<span<const "
               "int>::iterator>");
-static_assert(std::is_same<gsl::span<const int>::const_reverse_iterator,
-                           std::reverse_iterator<gsl::span<const int>::const_iterator>>::value,
-              "span<const int>::const_reverse_iterator should equal "
-              "std::reverse_iterator<span<const int>::const_iterator>");
 
 static_assert(std::is_same<std::iterator_traits<gsl::span<const int, 3>::iterator>::pointer,
                            const int*>::value,
               "span<const int, 3>::iterator's pointer should be int*");
-static_assert(std::is_same<std::iterator_traits<gsl::span<const int, 3>::const_iterator>::pointer,
-                           const int*>::value,
-              "span<const int, 3>::const_iterator's pointer should be const int*");
 static_assert(std::is_same<gsl::span<const int, 3>::reverse_iterator,
                            std::reverse_iterator<gsl::span<const int, 3>::iterator>>::value,
               "span<const int, 3>::reverse_iterator should equal std::reverse_iterator<span<const "
               "int, 3>::iterator>");
-static_assert(std::is_same<gsl::span<const int, 3>::const_reverse_iterator,
-                           std::reverse_iterator<gsl::span<const int, 3>::const_iterator>>::value,
-              "span<const int, 3>::const_reverse_iterator should equal "
-              "std::reverse_iterator<span<const int, 3>::const_iterator>");
 
 // copyability assertions
 static_assert(std::is_trivially_copyable<gsl::span<int>>::value,
               "span<int> should be trivially copyable");
 static_assert(std::is_trivially_copyable<gsl::span<int>::iterator>::value,
               "span<int>::iterator should be trivially copyable");
-static_assert(std::is_trivially_copyable<gsl::span<int>::const_iterator>::value,
-              "span<int>::const_iterator should be trivially copyable");
 
 static_assert(std::is_trivially_copyable<gsl::span<int, 3>>::value,
               "span<int, 3> should be trivially copyable");
 static_assert(std::is_trivially_copyable<gsl::span<int, 3>::iterator>::value,
               "span<int, 3>::iterator should be trivially copyable");
-static_assert(std::is_trivially_copyable<gsl::span<int, 3>::const_iterator>::value,
-              "span<int, 3>::const_iterator should be trivially copyable");
 
 static_assert(std::is_trivially_copyable<gsl::span<const int>>::value,
               "span<const int> should be trivially copyable");
 static_assert(std::is_trivially_copyable<gsl::span<const int>::iterator>::value,
               "span<const int>::iterator should be trivially copyable");
-static_assert(std::is_trivially_copyable<gsl::span<const int>::const_iterator>::value,
-              "span<const int>::const_iterator should be trivially copyable");
 
 static_assert(std::is_trivially_copyable<gsl::span<const int, 3>>::value,
               "span<const int, 3> should be trivially copyable");
 static_assert(std::is_trivially_copyable<gsl::span<const int, 3>::iterator>::value,
               "span<const int, 3>::iterator should be trivially copyable");
-static_assert(std::is_trivially_copyable<gsl::span<const int, 3>::const_iterator>::value,
-              "span<const int, 3>::const_iterator should be trivially copyable");
 
 // nothrow constructible assertions
 static_assert(std::is_nothrow_constructible<gsl::span<int>, int*, std::size_t>::value,

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -208,26 +208,14 @@ TEST(span_ext_test, make_span_from_array_constructor)
      EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
 
-     EXPECT_TRUE((std::is_same<decltype(s.cbegin()), decltype(cbegin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(s.cend()), decltype(cend(s))>::value));
-
      EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
-
-     EXPECT_TRUE((std::is_same<decltype(s.crbegin()), decltype(crbegin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(s.crend()), decltype(crend(s))>::value));
 
      EXPECT_TRUE(s.begin() == begin(s));
      EXPECT_TRUE(s.end() == end(s));
 
-     EXPECT_TRUE(s.cbegin() == cbegin(s));
-     EXPECT_TRUE(s.cend() == cend(s));
-
      EXPECT_TRUE(s.rbegin() == rbegin(s));
      EXPECT_TRUE(s.rend() == rend(s));
-
-     EXPECT_TRUE(s.crbegin() == crbegin(s));
-     EXPECT_TRUE(s.crend() == crend(s));
  }
 
  TEST(span_ext_test, ssize_free_function)

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -208,14 +208,26 @@ TEST(span_ext_test, make_span_from_array_constructor)
      EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
 
+     EXPECT_TRUE((std::is_same<decltype(std::cbegin(s)), decltype(cbegin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(std::cend(s)), decltype(cend(s))>::value));
+
      EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
      EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
+
+     EXPECT_TRUE((std::is_same<decltype(std::crbegin(s)), decltype(crbegin(s))>::value));
+     EXPECT_TRUE((std::is_same<decltype(std::crend(s)), decltype(crend(s))>::value));
 
      EXPECT_TRUE(s.begin() == begin(s));
      EXPECT_TRUE(s.end() == end(s));
 
      EXPECT_TRUE(s.rbegin() == rbegin(s));
      EXPECT_TRUE(s.rend() == rend(s));
+
+     EXPECT_TRUE(s.begin() == cbegin(s));
+     EXPECT_TRUE(s.end() == cend(s));
+
+     EXPECT_TRUE(s.rbegin() == crbegin(s));
+     EXPECT_TRUE(s.rend() == crend(s));
  }
 
  TEST(span_ext_test, ssize_free_function)

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -864,34 +864,6 @@ TEST(span_test, from_array_constructor)
      EXPECT_TRUE(it1 == it2);
  }
 
- TEST(span_test, const_iterator_default_init)
- {
-     span<int>::const_iterator it1;
-     span<int>::const_iterator it2;
-     EXPECT_TRUE(it1 == it2);
- }
-
- TEST(span_test, iterator_conversions)
- {
-     span<int>::iterator badIt;
-     span<int>::const_iterator badConstIt;
-     EXPECT_TRUE(badIt == badConstIt);
-
-     int a[] = {1, 2, 3, 4};
-     span<int> s = a;
-
-     auto it = s.begin();
-     auto cit = s.cbegin();
-
-     EXPECT_TRUE(it == cit);
-     EXPECT_TRUE(cit == it);
-
-     span<int>::const_iterator cit2 = it;
-     EXPECT_TRUE(cit2 == cit);
-
-     span<int>::const_iterator cit3 = it + 4;
-     EXPECT_TRUE(cit3 == s.cend());
- }
  TEST(span_test, iterator_comparisons)
  {
      int a[] = {1, 2, 3, 4};
@@ -899,15 +871,8 @@ TEST(span_test, from_array_constructor)
          span<int> s = a;
          span<int>::iterator it = s.begin();
          auto it2 = it + 1;
-         span<int>::const_iterator cit = s.cbegin();
 
-         EXPECT_TRUE(it == cit);
-         EXPECT_TRUE(cit == it);
          EXPECT_TRUE(it == it);
-         EXPECT_TRUE(cit == cit);
-         EXPECT_TRUE(cit == s.begin());
-         EXPECT_TRUE(s.begin() == cit);
-         EXPECT_TRUE(s.cbegin() == cit);
          EXPECT_TRUE(it == s.begin());
          EXPECT_TRUE(s.begin() == it);
 
@@ -916,26 +881,16 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(it != s.end());
          EXPECT_TRUE(it2 != s.end());
          EXPECT_TRUE(s.end() != it);
-         EXPECT_TRUE(it2 != cit);
-         EXPECT_TRUE(cit != it2);
 
          EXPECT_TRUE(it < it2);
          EXPECT_TRUE(it <= it2);
          EXPECT_TRUE(it2 <= s.end());
          EXPECT_TRUE(it < s.end());
-         EXPECT_TRUE(it <= cit);
-         EXPECT_TRUE(cit <= it);
-         EXPECT_TRUE(cit < it2);
-         EXPECT_TRUE(cit <= it2);
-         EXPECT_TRUE(cit < s.end());
-         EXPECT_TRUE(cit <= s.end());
 
          EXPECT_TRUE(it2 > it);
          EXPECT_TRUE(it2 >= it);
          EXPECT_TRUE(s.end() > it2);
          EXPECT_TRUE(s.end() >= it2);
-         EXPECT_TRUE(it2 > cit);
-         EXPECT_TRUE(it2 >= cit);
      }
  }
 
@@ -1019,63 +974,6 @@ TEST(span_test, from_array_constructor)
      }
  }
 
- TEST(span_test, cbegin_cend)
- {
-    std::set_terminate([] {
-        std::cerr << "Expected Death. cbegin_cend";
-        std::abort();
-    });
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
-
-         span<int>::const_iterator cit = s.cbegin();
-         span<int>::const_iterator cit2 = std::cbegin(s);
-         EXPECT_TRUE(cit == cit2);
-
-         cit = s.cend();
-         cit2 = std::cend(s);
-         EXPECT_TRUE(cit == cit2);
-     }
-
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
-
-         auto it = s.cbegin();
-         auto first = it;
-         EXPECT_TRUE(it == first);
-         EXPECT_TRUE(*it == 1);
-
-         auto beyond = s.cend();
-         EXPECT_TRUE(it != beyond);
-         EXPECT_DEATH(*beyond, deathstring);
-
-         EXPECT_TRUE(beyond - first == 4);
-         EXPECT_TRUE(first - first == 0);
-         EXPECT_TRUE(beyond - beyond == 0);
-
-         ++it;
-         EXPECT_TRUE(it - first == 1);
-         EXPECT_TRUE(*it == 2);
-         EXPECT_TRUE(beyond - it == 3);
-
-         int last = 0;
-         it = first;
-         EXPECT_TRUE(it == first);
-         while (it != s.cend())
-         {
-             EXPECT_TRUE(*it == last + 1);
-
-             last = *it;
-             ++it;
-         }
-
-         EXPECT_TRUE(it == beyond);
-         EXPECT_TRUE(it - beyond == 0);
-     }
- }
-
  TEST(span_test, rbegin_rend)
  {
     std::set_terminate([] {
@@ -1122,55 +1020,6 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(it - beyond == 0);
 
          for (const auto& n : s) { EXPECT_TRUE(n == 5); }
-     }
- }
-
- TEST(span_test, crbegin_crend)
- {
-    std::set_terminate([] {
-        std::cerr << "Expected Death. crbegin_crend";
-        std::abort();
-    });
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
-
-         auto it = s.crbegin();
-         auto first = it;
-         EXPECT_TRUE(it == first);
-         EXPECT_TRUE(*it == 4);
-
-         auto beyond = s.crend();
-         EXPECT_TRUE(it != beyond);
-#if (__cplusplus > 201402L)
-        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond, deathstring);
-#else
-        EXPECT_DEATH(auto _ = *beyond, deathstring);
-#endif
-
-         EXPECT_TRUE(beyond - first == 4);
-         EXPECT_TRUE(first - first == 0);
-         EXPECT_TRUE(beyond - beyond == 0);
-
-         std::cout << *first << std::endl;
-         ++it;
-         EXPECT_TRUE(it - s.crbegin() == 1);
-         EXPECT_TRUE(*it == 3);
-         EXPECT_TRUE(beyond - it == 3);
-
-         it = first;
-         EXPECT_TRUE(it == first);
-         int last = 5;
-         while (it != s.crend())
-         {
-             EXPECT_TRUE(*it == last - 1);
-             last = *it;
-
-             ++it;
-         }
-
-         EXPECT_TRUE(it == beyond);
-         EXPECT_TRUE(it - beyond == 0);
      }
  }
 


### PR DESCRIPTION
[LWG3320](https://cplusplus.github.io/LWG/issue3320 ) removes const_iterator and const_reverse_iterator from span. 

This change removes all references to the removed elements.