### PR TITLE
Change install destination CMake Config-file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 # Make library importable by other projects
-install(EXPORT Microsoft.GSLConfig NAMESPACE Microsoft.GSL:: DESTINATION share/Microsoft.GSL/cmake)
+install(EXPORT Microsoft.GSLConfig NAMESPACE Microsoft.GSL:: DESTINATION share/Microsoft.GSL)
 export(TARGETS GSL NAMESPACE Microsoft.GSL:: FILE Microsoft.GSLConfig.cmake)
 
 # Add Microsoft.GSL::GSL alias for GSL so that dependents can be agnostic about


### PR DESCRIPTION
Removing the final `cmake` from the install destination path for the `Microsoft.GSLConfig.cmake` file.

While updating the vcpkg port https://github.com/microsoft/vcpkg/pull/10831 to use the new functionality added with PR #784 
Vcpkg does not expect the additional `cmake` folder in the export destination path.
`vcpkg install ms-gsl` returns the following hint:
````CMake
The package ms-gsl:x86-windows provides CMake targets:

    find_package(cmake CONFIG REQUIRED)
    target_link_libraries(main PRIVATE Microsoft.GSL::GSL)
````
Note the `cmake`  in `find_package`.

----
This PR solves the issue with vcpkg, but `find_package` works for both situations.
@hanst99, @Adnn Is there a reason or advantage for the additional `cmake` folder?
@ras0219-msft If so, should vcpkg support this?