### PR TITLE
suppress code analysis warning

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -582,12 +582,18 @@ public:
     constexpr iterator begin() const noexcept
     {
         const auto data = storage_.data();
+        // clang-format off
+        GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
+        // clang-format on
         return {data, data + size(), data};
     }
 
     constexpr iterator end() const noexcept
     {
         const auto data = storage_.data();
+        // clang-format off
+        GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
+        // clang-format on
         const auto endData = data + storage_.size();
         return {data, endData, endData};
     }


### PR DESCRIPTION
- suppress " warning C26481: Don't use pointer arithmetic. Use span instead (bounds.1)."
- Please note that the suppression in `end()` does not work with MSVC 16.5.4.