### PR TITLE
Refactor `narrow`.

### DIFF
--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -100,15 +100,6 @@ struct narrowing_error : public std::exception
 {
 };
 
-namespace details
-{
-    template <class T, class U>
-    struct is_same_signedness
-        : public std::integral_constant<bool, std::is_signed<T>::value == std::is_signed<U>::value>
-    {
-    };
-} // namespace details
-
 // narrow() : a checked version of narrow_cast() that throws if the cast changed the value
 template <class T, class U>
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
@@ -118,10 +109,17 @@ constexpr
 #endif
 T narrow(U u) noexcept(false)
 {
-    T t = narrow_cast<T>(u);
-    if (static_cast<U>(t) != u) throw narrowing_error{};
-    if (!details::is_same_signedness<T, U>::value && ((t < T{}) != (u < U{})))
+    constexpr const bool is_same_signedness = std::is_signed<T>::value == std::is_signed<U>::value;
+    
+    const T t = narrow_cast<T>(u);
+    
+    if (static_cast<U>(t) != u
+        || (!is_same_signedness
+            && ((t < T{}) != (u < U{}))))
+    {
         throw narrowing_error{};
+    }
+    
     return t;
 }
 

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -109,12 +109,12 @@ constexpr
 #endif
 T narrow(U u) noexcept(false)
 {
-    constexpr const bool is_same_signedness = std::is_signed<T>::value == std::is_signed<U>::value;
+    constexpr const bool is_different_signedness = (std::is_signed<T>::value != std::is_signed<U>::value);
     
     const T t = narrow_cast<T>(u);
     
     if (static_cast<U>(t) != u
-        || (!is_same_signedness
+        || (is_different_signedness
             && ((t < T{}) != (u < U{}))))
     {
         throw narrowing_error{};


### PR DESCRIPTION
Simplify & move `is_same_signedness` into the function.
Remove uneeded `detail` namespace.
Merge 2 `if`'s with a `||`.