### PR TITLE
reflects verification of iOS and Android support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,94 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  iOS:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: build
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create build directory
+        run: mkdir -p build
+        working-directory: .
+
+      - name: Configure
+        run: |
+          cmake \
+            -GXcode \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=8 \
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+            "-DMACOSX_BUNDLE_GUI_IDENTIFIER=GSL.\$(EXECUTABLE_NAME)" \
+            -DMACOSX_BUNDLE_BUNDLE_VERSION=3.0.1 \
+            -DMACOSX_BUNDLE_SHORT_VERSION_STRING=3.0.1 \
+            ..
+
+      - name: Build
+        run: cmake --build . --parallel `sysctl -n hw.ncpu` --config Release -- -sdk iphonesimulator
+
+      - name: Start simulator
+        run: |
+          RUNTIME=`xcrun simctl list runtimes iOS -j|jq '.runtimes|last.identifier'`
+          UDID=`xcrun simctl list devices iPhone available -j|jq -r ".devices[$RUNTIME]|last.udid"`
+          xcrun simctl bootstatus $UDID -b
+
+      - name: Test
+        run: |
+          for TEST in `find tests/Release-iphonesimulator -depth 1 -name "*.app"`
+          do
+            xcrun simctl install booted $TEST
+            TEST_ID=`plutil -convert json -o - $TEST/Info.plist|jq -r ".CFBundleIdentifier"`
+            xcrun simctl launch --console booted $TEST_ID
+            xcrun simctl uninstall booted $TEST_ID
+          done
+
+  Android:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: build
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create build directory
+        run: mkdir -p build
+        working-directory: .
+
+      - name: Start emulator
+        run: |
+          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-24;default;x86_64'
+          echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k 'system-images;android-24;default;x86_64' --force
+          $ANDROID_HOME/emulator/emulator -list-avds
+          echo "Starting emulator"
+          # Start emulator in background
+          nohup $ANDROID_HOME/emulator/emulator -avd xamarin_android_emulator -no-snapshot > /dev/null 2>&1 &
+          echo "Emulator starting"
+
+      - name: Configure
+        run: cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
+
+      - name: Build
+        run: cmake --build . --parallel
+
+      - name: Wait for emulator ready
+        run: |
+          $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 10; done; input keyevent 82'
+          $ANDROID_HOME/platform-tools/adb devices
+          $ANDROID_HOME/platform-tools/adb shell getprop ro.product.cpu.abi
+          echo "Emulator started"
+
+      - name: Deploy tests
+        run: |
+          adb push tests /data/local/tmp
+          adb shell find /data/local/tmp/tests -maxdepth 1 -exec chmod +x {} \\\;
+
+      - name: Test
+        run: adb shell find /data/local/tmp/tests -name "*_tests" -maxdepth 1 -exec {} \\\;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(GSL INTERFACE)
 # determine whether this is a standalone project or included by other projects
 set(GSL_STANDALONE_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(GSL_STANDALONE_PROJECT ON)
+    set(GSL_STANDALONE_PROJECT ON)
 endif ()
 
 set(GSL_CXX_STANDARD "14" CACHE STRING "Use c++ standard")
@@ -98,6 +98,11 @@ add_library(Microsoft.GSL::GSL ALIAS GSL)
 
 option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})
 if (GSL_TEST)
-	enable_testing()
-	add_subdirectory(tests)
+    enable_testing()
+    if(IOS)
+        add_compile_definitions(
+            GTEST_HAS_DEATH_TEST=1
+        )
+    endif()
+    add_subdirectory(tests)
 endif ()

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The test suite that exercises GSL has been built and passes successfully on the 
 * OS X El Capitan (10.11) using Xcode with AppleClang 8.0.0.8000042
 * OS X High Sierra 10.13.2 (17C88) using Apple LLVM version 9.0.0 (clang-900.0.39.2)
 * FreeBSD 10.x with Clang/LLVM 3.6
+* iOS 8 and newer using AppleClang 11.0.3.11030032
+* Android 4.1 and newer (API Level 16 and above) using NDK r21b
 
 > If you successfully port GSL to another platform, we would love to hear from you. Please submit an issue to let us know. Also please consider
 contributing any changes that were necessary back to this project to benefit the wider community.


### PR DESCRIPTION
GSL and its tests have been verified to build, run, and pass on iOS and Android, see https://github.com/dipidoo/GSL/runs/644183162. However, this requires forcing GTEST_HAS_DEATH_TEST definition on the test. No modifications were necessary within GSL.

googletest does not support EXPECT_DEATH in iOS platform, see how it tests for !GTEST_OS_IOS: https://github.com/google/googletest/blob/0eea2e9fc63461761dea5f2f517bd6af2ca024fa/googletest/include/gtest/internal/gtest-port.h#L592

By forcing GTEST_HAS_DEATH_TEST definition, I found that the test runs normally and successfully. I am unsure what the reasoning behind googletest's Death Test suppression for iOS platform is, but seeing that this is impacts test code only I feel that this definition is within reason. I have reported this issue as https://github.com/google/googletest/issues/2834.

#883 #878 