### PR TITLE
compiler support revision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ stages:
   - name: Legacy     # build with all other supported compilers
 
 jobs:
+  fast_finish: true
+  allow_failures:
+  -  stage: Legacy
+
   include:
 
     ##########################################################################
@@ -111,6 +115,7 @@ jobs:
 
     # Xcode 10.1
     - name: AppleClang Xcode-10.1 C++14 Debug
+      stage: Latest
       env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       os: osx
       osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
@@ -147,7 +152,6 @@ jobs:
 
     # Xcode 11.3
     - name: AppleClang Xcode-11.3 C++17 Debug
-      stage: Latest
       env: BUILD_TYPE=Debug GSL_CXX_STANDARD=17
       os: osx
       osx_image: xcode11.3 # AppleClang 11.0.0 linker update / same as Xcode 11.2
@@ -296,6 +300,7 @@ jobs:
 
     # Clang 9
     - name: Clang-9 C++14 Debug
+      stage: Latest
       env: CXX=clang++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang9
         apt:
@@ -316,7 +321,6 @@ jobs:
 
     # Clang 10
     - name: Clang-10 C++14 Debug
-      stage: Latest
       env: CXX=clang++-10 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang10
         apt:
@@ -370,6 +374,7 @@ jobs:
 
     # GCC 8
     - name: GCC-8 C++14 Debug
+      stage: Latest
       env: CXX=g++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &gcc8
         apt:
@@ -386,7 +391,6 @@ jobs:
 
     # GCC 9
     - name: GCC-9 C++14 Debug
-      stage: Latest
       env: CXX=g++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &gcc9
         apt:
@@ -538,7 +542,7 @@ before_script:
   - |
     cd "${TRAVIS_BUILD_DIR:?}"
     mkdir build && cd build
-    if [[ ${GSL_CXX_STANDARD:-} ]]; then 
+    if [[ ${GSL_CXX_STANDARD:-} ]]; then
       CMAKE_GEN_FLAGS=("-DGSL_CXX_STANDARD=$GSL_CXX_STANDARD")
     fi
     CMAKE_GEN_FLAGS+=("-Wdev -Werror=dev --warn-uninitialized")

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,11 @@ cache:
     - ${TRAVIS_BUILD_DIR}/deps
 
 stages:
-  - name: Latest     # build jobs to run first and always
+  - name: Latest     # Compiler with the latest major version
+  - name: Previous   # Compilers with the major version Latest - 1
   - name: Validation # run other jobs
-  - name: Legacy     # build with all other supported compilers
 
 jobs:
-  fast_finish: true
-  allow_failures:
-  -  stage: Legacy
-
   include:
 
     ##########################################################################
@@ -66,74 +62,11 @@ jobs:
     # AppleClang on OSX
     ##########################################################################
 
-    # Xcode 8.3
-    - name: AppleClang Xcode-8.3 C++14 Debug
-      stage: Legacy
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode8.3
-    - name: AppleClang Xcode-8.3 C++14 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode8.3
 
-    # Xcode 9.0 earliest C++17 support
-    - name: AppleClang Xcode-9.0 C++17 Debug
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode9 # AppleClang 9.1.0 same compiler in Xcode 9.0, 9.1 and 9.2
-    - name: AppleClang Xcode-9.0 C++17 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode9
-    - name: AppleClang Xcode-9.0 C++14 Debug
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode9
-    - name: AppleClang Xcode-9.0 C++14 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode9
-
-    # Xcode 9.4
-    - name: AppleClang Xcode-9.4 C++14 Debug
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
-    - name: AppleClang Xcode-9.4 C++14 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode9.4
-    - name: AppleClang Xcode-9.4 C++17 Debug
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode9.4
-    - name: AppleClang Xcode-9.4 C++17 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode9.4
-
-    # Xcode 10.1
-    - name: AppleClang Xcode-10.1 C++14 Debug
-      stage: Latest
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
-    - name: AppleClang Xcode-10.1 C++14 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      os: osx
-      osx_image: xcode10.1
-    - name: AppleClang Xcode-10.1 C++17 Debug
-      env: BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode10.1
-    - name: AppleClang Xcode-10.1 C++17 Release
-      env: BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      os: osx
-      osx_image: xcode10.1
 
     # Xcode 10.3
     - name: AppleClang Xcode-10.3 C++14 Debug
+      stage: Previous
       env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       os: osx
       osx_image: xcode10.3 # AppleClang 10.0.1 same compiler as Xcode 10.2
@@ -150,157 +83,33 @@ jobs:
       os: osx
       osx_image: xcode10.3
 
-    # Xcode 11.3
-    - name: AppleClang Xcode-11.3 C++17 Debug
+
+    # Xcode 11.4
+    - name: AppleClang Xcode-11.4 C++17 Debug
+      stage: Latest
       env: BUILD_TYPE=Debug GSL_CXX_STANDARD=17
       os: osx
-      osx_image: xcode11.3 # AppleClang 11.0.0 linker update / same as Xcode 11.2
-    - name: AppleClang Xcode-11.3 C++17 Release
+      osx_image: xcode11.4
+    - name: AppleClang Xcode-11.4 C++17 Release
       env: BUILD_TYPE=Release GSL_CXX_STANDARD=17
       os: osx
-      osx_image: xcode11.3
-    - name: AppleClang Xcode-11.3 C++14 Debug
+      osx_image: xcode11.4
+    - name: AppleClang Xcode-11.4 C++14 Debug
       env: BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       os: osx
-      osx_image: xcode11.3
-    - name: AppleClang Xcode-11.3 C++14 Release
+      osx_image: xcode11.4
+    - name: AppleClang Xcode-11.4 C++14 Release
       env: BUILD_TYPE=Release GSL_CXX_STANDARD=14
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.4
 
     ##########################################################################
     # Clang on Linux
     ##########################################################################
 
-    # Clang 3.6
-    - name: Clang-3.6 C++14 Debug
-      stage: Legacy
-      dist: xenial
-      env: CXX=clang++-3.6 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang36
-        apt:
-          packages:
-            - clang-3.6
-    - name: Clang-3.6 C++14 Release
-      dist: xenial
-      env: CXX=clang++-3.6 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang36
-
-    # Clang 3.7
-    - name: Clang-3.7 C++14 Debug
-      dist: xenial
-      env: CXX=clang++-3.7 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang37
-        apt:
-          packages:
-            - clang-3.7
-    - name: Clang-3.7 C++14 Release
-      dist: xenial
-      env: CXX=clang++-3.7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang37
-
-    # Clang 3.8
-    - name: Clang-3.8 C++14 Debug
-      dist: xenial
-      env: CXX=clang++-3.8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang38
-        apt:
-          packages:
-            - clang-3.8
-    - name: Clang-3.8 C++14 Release
-      dist: xenial
-      env: CXX=clang++-3.8 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang38
-
-    # Clang 3.9
-    - name: Clang-3.9 C++14 Debug
-      env: CXX=clang++-3.9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang39
-        apt:
-          packages:
-            - clang-3.9
-    - name: Clang-3.9 C++14 Release
-      env: CXX=clang++-3.9 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang39
-
-    # Clang 4.0
-    - name: Clang-4.0 C++14 Debug
-      env: CXX=clang++-4.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang40
-        apt:
-          packages:
-            - clang-4.0
-    - name: Clang-4.0 C++14 Release
-      env: CXX=clang++-4.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang40
-
-    # Clang 5.0
-    - name: Clang-5.0 C++14 Debug
-      env: CXX=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang50
-        apt:
-          packages:
-            - clang-5.0
-    - name: Clang-5.0 C++14 Release
-      env: CXX=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang50
-    - name: Clang-5.0 C++17 Debug
-      env: CXX=clang++-5.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      addons: *clang50
-    - name: Clang 5.0 C++17 Release
-      env: CXX=clang++-5.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      addons: *clang50
-
-    # Clang 6.0
-    - name: Clang-6.0 C++14 Debug
-      env: CXX=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang60
-        apt:
-          packages:
-            - clang-6.0
-    - name: Clang 6.0 C++14 Release
-      env: CXX=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang60
-    - name: Clang-6.0 C++17 Debug
-      env: CXX=clang++-6.0 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      addons: *clang60
-    - name: Clang 6.0 C++17 Release
-      env: CXX=clang++-6.0 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      addons: *clang60
-
-    # Clang 7 (default on Xenial and Bionic images)
-    - name: Clang-7 C++14 Debug
-      env: CXX=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-    - name: Clang-7 C++14 Release
-      env: CXX=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=14
-    - name: Clang-7 C++17 Debug
-      env: CXX=clang++ BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-    - name: Clang-7 C++17 Release
-      env: CXX=clang++ BUILD_TYPE=Release GSL_CXX_STANDARD=17
-
-    # Clang 8
-    - name: Clang-8 C++14 Debug
-      env: CXX=clang++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &clang8
-        apt:
-          sources:
-          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
-            key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
-          packages:
-          - clang-8
-    - name: Clang-8 C++14 Release
-      env: CXX=clang++-8 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *clang8
-    - name: Clang-8 C++17 Debug
-      env: CXX=clang++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-      addons: *clang8
-    - name: Clang-8 C++17 Release
-      env: CXX=clang++-8 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-      addons: *clang8
-
     # Clang 9
     - name: Clang-9 C++14 Debug
-      stage: Latest
+      stage: Previous
       env: CXX=clang++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang9
         apt:
@@ -321,6 +130,7 @@ jobs:
 
     # Clang 10
     - name: Clang-10 C++14 Debug
+      stage: Latest
       env: CXX=clang++-10 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &clang10
         apt:
@@ -343,38 +153,9 @@ jobs:
     # GCC on Linux
     ##########################################################################
 
-    # GCC 5 (default on the Xenial image)
-    - name: GCC-5 C++14 Debug
-      stage: Legacy
-      dist: xenial
-      env: CXX=g++-5 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-    - name: GCC-5 C++14 Release
-      dist: xenial
-      env: CXX=g++-5 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-
-    # GCC 6
-    - name: GCC-6 C++14 Debug
-      env: CXX=g++-6 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-      addons: &gcc6
-        apt:
-          packages: g++-6
-    - name: GCC-6 C++14 Release
-      env: CXX=g++-6 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-      addons: *gcc6
-
-    # GCC 7 (default on the Bionic image)
-    - name: GCC-7 C++14 Debug
-      env: CXX=g++-7 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
-    - name: GCC-7 C++14 Release
-      env: CXX=g++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=14
-    - name: GCC-7 C++17 Debug
-      env: CXX=g++-7 BUILD_TYPE=Debug GSL_CXX_STANDARD=17
-    - name: GCC-7 C++17 Release
-      env: CXX=g++-7 BUILD_TYPE=Release GSL_CXX_STANDARD=17
-
     # GCC 8
     - name: GCC-8 C++14 Debug
-      stage: Latest
+      stage: Previous
       env: CXX=g++-8 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &gcc8
         apt:
@@ -391,6 +172,7 @@ jobs:
 
     # GCC 9
     - name: GCC-9 C++14 Debug
+      stage: Latest
       env: CXX=g++-9 BUILD_TYPE=Debug GSL_CXX_STANDARD=14
       addons: &gcc9
         apt:

--- a/README.md
+++ b/README.md
@@ -22,10 +22,18 @@ This project makes use of the [Google Test](https://github.com/google/googletest
 
 # Quick Start
 ## Supported Platforms
-The test suite that exercises GSL has been built and passes successfully on the following platforms:<sup>1)</sup>
+The GSL officially supports the current and previous major releases of MSVC, GCC, Clang, and XCode's AppleClang.
+See our latest test results for the most up-to-date list of supported configurations. <sup>1)</sup>
 
-* Windows using Visual Studio 2015
+- For XCode, Clang, and GCC: [![Build Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+- For Visual Studio with MSVC and LLVM toolsets: [![Build status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
+- Android and iOS support: ![CI](https://github.com/microsoft/GSL/workflows/CI/badge.svg) <sup>2)</sup>
+
+
+The test suite that exercises GSL has been built and passes successfully on the following platforms: <sup>3)</sup>
+
 * Windows using Visual Studio 2017
+* Windows using Visual Studio 2019
 * Windows using Clang/LLVM 3.6
 * Windows using Clang/LLVM 7.0.0
 * Windows using GCC 5.1
@@ -50,7 +58,9 @@ The test suite that exercises GSL has been built and passes successfully on the 
 > If you successfully port GSL to another platform, we would love to hear from you. Please submit an issue to let us know. Also please consider
 contributing any changes that were necessary back to this project to benefit the wider community.
 
-<sup>1)</sup> For `gsl::byte` to work correctly with Clang and GCC you might have to use the ` -fno-strict-aliasing` compiler option.
+<sup>1)</sup> The test matrix contains legacy versions of these compilers. The legacy releases are no longer officially supported. If a change causes a legacy compiler to fail, please file an issue or submit a pull request to have the legacy version to be removed from the test matrix.
+<sup>2)</sup> Android and iOS build failures are non-blocking and do not prevent pull request merging.
+<sup>3)</sup> For `gsl::byte` to work correctly with Clang and GCC you might have to use the ` -fno-strict-aliasing` compiler option.
 
 ## Building the tests
 To build the tests, you will require the following:

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ This project makes use of the [Google Test](https://github.com/google/googletest
 The GSL officially supports the current and previous major release of MSVC, GCC, Clang, and XCode's Apple-Clang.
 See our latest test results for the most up-to-date list of supported configurations.
 
-Compiler | Build Status
-:------- | ------------:
- XCode | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
- GCC | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
- Clang | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
- Visual Studio with MSVC | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
- Visual Studio with LLVM | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
+Compiler |Toolset Versions Currently Tested| Build Status
+:------- |:--|------------:
+ XCode |11.4 & 10.3 | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ GCC |9 & 8| [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ Clang |11 &  10| [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ Visual Studio with MSVC | VS2017 (15.9) & VS2019 (16.4) | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
+ Visual Studio with LLVM | VS2017 (Clang 9) & VS2019 (Clang 10) | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
 
 
 Note: For `gsl::byte` to work correctly with Clang and GCC you might have to use the ` -fno-strict-aliasing` compiler option.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# GSL: Guidelines Support Library [![Build Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL) [![Build status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
+# GSL: Guidelines Support Library
+[![Build Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL) [![Build status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
 
 The Guidelines Support Library (GSL) contains functions and types that are suggested for use by the
 [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines) maintained by the [Standard C++ Foundation](https://isocpp.org).
@@ -21,46 +22,33 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 This project makes use of the [Google Test](https://github.com/google/googletest) testing library. Please see the [ThirdPartyNotices.txt](./ThirdPartyNotices.txt) file for details regarding the licensing of Google Test.
 
 # Quick Start
-## Supported Platforms
-The GSL officially supports the current and previous major releases of MSVC, GCC, Clang, and XCode's AppleClang.
-See our latest test results for the most up-to-date list of supported configurations. <sup>1)</sup>
+## Supported Compilers
+The GSL officially supports the current and previous major release of MSVC, GCC, Clang, and XCode's Apple-Clang.
+See our latest test results for the most up-to-date list of supported configurations.
 
-- For XCode, Clang, and GCC: [![Build Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
-- For Visual Studio with MSVC and LLVM toolsets: [![Build status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
-- Android and iOS support: ![CI](https://github.com/microsoft/GSL/workflows/CI/badge.svg) <sup>2)</sup>
+Compiler | Build Status
+:------- | ------------:
+ XCode | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ GCC | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ Clang | [![Status](https://travis-ci.org/Microsoft/GSL.svg?branch=master)](https://travis-ci.org/Microsoft/GSL)
+ Visual Studio with MSVC | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
+ Visual Studio with LLVM | [![Status](https://ci.appveyor.com/api/projects/status/github/Microsoft/GSL?svg=true)](https://ci.appveyor.com/project/neilmacintosh/GSL)
 
 
-The test suite that exercises GSL has been built and passes successfully on the following platforms: <sup>3)</sup>
+Note: For `gsl::byte` to work correctly with Clang and GCC you might have to use the ` -fno-strict-aliasing` compiler option.
 
-* Windows using Visual Studio 2017
-* Windows using Visual Studio 2019
-* Windows using Clang/LLVM 3.6
-* Windows using Clang/LLVM 7.0.0
-* Windows using GCC 5.1
-* Windows using Intel C++ Compiler 18.0
-* GNU/Linux using Clang/LLVM 3.6-3.9
-* GNU/Linux using Clang/LLVM 4.0
-* GNU/Linux using Clang/LLVM 5.0
-* GNU/Linux using Clang/LLVM 6.0
-* GNU/Linux using Clang/LLVM 7.0
-* GNU/Linux using GCC 5.1
-* OS X Mojave 10.14.4 using Apple LLVM version 10.0.0 (10.0.1.10010046)
-* OS X Mojave 10.14.3 using Apple LLVM version 10.0.0 (clang-1000.11.45.5)
-* OS X Yosemite using Xcode with Apple Clang 7.0.0.7000072
-* OS X Yosemite using GCC-5.2.0
-* OS X Sierra 10.12.4 using Apple LLVM version 8.1.0 (Clang-802.0.42)
-* OS X El Capitan (10.11) using Xcode with AppleClang 8.0.0.8000042
-* OS X High Sierra 10.13.2 (17C88) using Apple LLVM version 9.0.0 (clang-900.0.39.2)
-* FreeBSD 10.x with Clang/LLVM 3.6
-* iOS 8 and newer using AppleClang 11.0.3.11030032
-* Android 4.1 and newer (API Level 16 and above) using NDK r21b
+---
+If you successfully port GSL to another platform, we would love to hear from you!
+- Submit an issue specifying the platform and target.
+- Consider contributing your changes by filing a pull request with any necessary changes.
+- If at all possible, add a CI/CD step and add the button to the table below!
 
-> If you successfully port GSL to another platform, we would love to hear from you. Please submit an issue to let us know. Also please consider
-contributing any changes that were necessary back to this project to benefit the wider community.
+Target | CI/CD Status
+:------- | -----------:
+iOS | ![CI](https://github.com/microsoft/GSL/workflows/CI/badge.svg)
+Android | ![CI](https://github.com/microsoft/GSL/workflows/CI/badge.svg)
 
-<sup>1)</sup> The test matrix contains legacy versions of these compilers. The legacy releases are no longer officially supported. If a change causes a legacy compiler to fail, please file an issue or submit a pull request to have the legacy version to be removed from the test matrix.
-<sup>2)</sup> Android and iOS build failures are non-blocking and do not prevent pull request merging.
-<sup>3)</sup> For `gsl::byte` to work correctly with Clang and GCC you might have to use the ` -fno-strict-aliasing` compiler option.
+Note: These CI/CD steps are run with each pull request, however failures in them are non-blocking.
 
 ## Building the tests
 To build the tests, you will require the following:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ configuration:
   - Release
 
 image:
-  - Visual Studio 2015
   - Visual Studio 2017
   - Visual Studio 2019
 
@@ -17,7 +16,6 @@ environment:
   NINJA_TAG: v1.8.2
   NINJA_SHA512: 9B9CE248240665FCD6404B989F3B3C27ED9682838225E6DC9B67B551774F251E4FF8A207504F941E7C811E7A8BE1945E7BCB94472A335EF15E23A0200A32E6D5
   NINJA_PATH: C:\Tools\ninja\ninja-%NINJA_TAG%
-  VCVAR2015: 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat'
   VCVAR2017: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat'
   VCVAR2019: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat'
   matrix:
@@ -33,14 +31,6 @@ environment:
     - GSL_CXX_STANDARD: 17
       USE_TOOLSET: LLVM
       USE_GENERATOR: Ninja
-
-matrix:
-    exclude:
-    - image: Visual Studio 2015
-      GSL_CXX_STANDARD: 17
-    - image: Visual Studio 2015
-      USE_TOOLSET: LLVM
-      USE_GENERATOR: MSBuild
 
 cache:
   - C:\cmake-3.14.4-win32-x86
@@ -72,9 +62,7 @@ before_build:
       if ("$env:USE_GENERATOR" -eq "Ninja") {
         $GeneratorFlags = '-k 10'
         $Architecture = $env:PLATFORM
-        if ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2015") {
-          $env:VCVARSALL = "`"$env:VCVAR2015`" $Architecture"
-        } elseif ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2017") {
+        if ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2017") {
           $env:VCVARSALL = "`"$env:VCVAR2017`" $Architecture"
         } else {
           $env:VCVARSALL = "`"$env:VCVAR2019`" $Architecture"
@@ -82,17 +70,15 @@ before_build:
         $env:CMakeGenFlags = "-G Ninja -DGSL_CXX_STANDARD=$env:GSL_CXX_STANDARD"
       } else {
         $GeneratorFlags = '/m /v:minimal'
-        if ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2015") {
-          $Generator = 'Visual Studio 14 2015'
-        } elseif ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2017") {
+        if ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -eq "Visual Studio 2017") {
           $Generator = 'Visual Studio 15 2017'
         } else {
           $Generator = 'Visual Studio 16 2019'
         }
-        if ("$env:PLATFORM" -eq "x86") { 
+        if ("$env:PLATFORM" -eq "x86") {
             $Architecture = "Win32"
-        } else { 
-            $Architecture = "x64" 
+        } else {
+            $Architecture = "x64"
         }
         if ("$env:USE_TOOLSET" -eq "LLVM") {
           $env:CMakeGenFlags = "-G `"$Generator`" -A $Architecture -T llvm -DGSL_CXX_STANDARD=$env:GSL_CXX_STANDARD"

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -30,17 +30,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
 
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-#endif            // _MSC_VER < 1910
 #endif            // _MSC_VER
-
-#if (defined(_MSC_VER) && _MSC_VER < 1910) || (!defined(__clang__) && defined(__GNUC__) && __GNUC__ < 6)
-#define GSL_CONSTEXPR_NARROW 0
-#else
-#define GSL_CONSTEXPR_NARROW 1
-#endif
 
 namespace gsl
 {
@@ -113,9 +103,7 @@ namespace details
 template <class T, class U>
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
 GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recognise noexcept(false)
-#if GSL_CONSTEXPR_NARROW
 constexpr
-#endif
 T narrow(U u) noexcept(false)
 {
     T t = narrow_cast<T>(u);
@@ -158,11 +146,6 @@ constexpr T at(const std::initializer_list<T> cont, const index i)
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
 
 #pragma warning(pop)
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -38,12 +38,6 @@
 #pragma warning(disable : 26495) // uninitalized member when constructor calls constructor
 #pragma warning(disable : 26446) // parser bug does not allow attributes on some templates
 
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-#define GSL_USE_STATIC_CONSTEXPR_WORKAROUND
-
-#endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
 // See if we have enough C++17 power to use a static constexpr data member
@@ -748,11 +742,6 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
 
 #pragma warning(pop)
 #endif // _MSC_VER

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -741,12 +741,6 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
 
 } // namespace gsl
 
-//TEST
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 6
-asdfadfasdfasdfasdfasdfasdfasdfasdf
-#endif
-//
-
 #if defined(_MSC_VER) && !defined(__clang__)
 
 #pragma warning(pop)

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -742,7 +742,7 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
 } // namespace gsl
 
 //TEST
-#if defined(__GNUC__) && __GNUC__ < 6
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 6
 asdfadfasdfasdfasdfasdfasdfasdfasdf
 #endif
 //

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -741,6 +741,12 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
 
 } // namespace gsl
 
+//TEST
+#if defined(__GNUC__) && __GNUC__ < 6
+asdfadfasdfasdfasdfasdfasdfasdfasdf
+#endif
+//
+
 #if defined(_MSC_VER) && !defined(__clang__)
 
 #pragma warning(pop)

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -36,11 +36,6 @@
 #pragma warning(disable : 26446) // TODO: bug in parser - attributes and templates
 #pragma warning(disable : 26481) // TODO: suppress does not work inside templates sometimes
 
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
 namespace gsl
@@ -706,11 +701,6 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other)
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
 
-#if _MSC_VER < 1910
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
 #endif // GSL_STRING_SPAN_H

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -122,8 +122,4 @@ TEST(utils_tests, narrow)
 
     n = -42;
     EXPECT_THROW(narrow<unsigned>(n), narrowing_error);
-
-#if GSL_CONSTEXPR_NARROW
-    static_assert(narrow<char>(120) == 120, "Fix GSL_CONSTEXPR_NARROW");
-#endif
 }


### PR DESCRIPTION
We have always unofficially said that we support the current and previous version of each compiler. This change will make that officially stated in the readme, updates the CI/CD, and removes some work arounds for various compiler versions N-2 and beyond.  

Changes: 
- remove VS2015 from appveyor matrix and all associated work arounds from the code ie `_MSC_VER < 1910`
- change travis and appveyor to reflect the N and N-1 compiler version support
- update readme
  - indicate that Android and iOS support are secondary and failure of that flow will not prevent the acceptance of the code in PR.

