### PR TITLE
Adding missing span deduction guides

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -740,6 +740,12 @@ span(std::array<Type, Size>&)->span<Type, Size>;
 template <class Type, std::size_t Size>
 span(const std::array<Type, Size>&)->span<const Type, Size>;
 
+template <class Container>
+span(Container&)->span<typename Container::value_type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
 #endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1242,7 +1242,7 @@ TEST(span_test, from_array_constructor)
 #if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
     // this test is just to verify that these compile
     {
-        std::vector v{1,2,3,4};
+        std::vector<int> v{1,2,3,4};
         gsl::span sp{v};
         static_assert(std::is_same<decltype(sp), gsl::span<int>>::value);
     }

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -31,7 +31,7 @@
 #include <vector>      // for vector
 #include <utility>
 
-// the string_view include and macro are used in the deduciton guide verification
+// the string_view include and macro are used in the deduction guide verification
 #if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 #ifdef __has_include
 #if __has_include(<string_view>)

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -31,12 +31,15 @@
 #include <vector>      // for vector
 #include <utility>
 
+// the string_view include and macro are used in the deduciton guide verification
+#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 #ifdef __has_include
 #if __has_include(<string_view>)
 #include <string_view>
 #define HAS_STRING_VIEW
-#endif
-#endif
+#endif // __has_include(<string_view>)
+#endif // __has_include
+#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 
 using namespace std;
 using namespace gsl;

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1227,6 +1227,21 @@ TEST(span_test, from_array_constructor)
      EXPECT_FALSE((std::is_default_constructible<span<int, 42>>::value));
  }
 
+ TEST(span_test, std_container_ctad)
+ {
+#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+    // this test is just to verify that these compile
+    {
+        std::vector v{1,2,3,4};
+        gsl::span sp{v};
+    }
+    {
+        std::string str{"foo"};
+        gsl::span sp{str};
+    }
+#endif
+ }
+
  TEST(span_test, front_back)
  {
     int arr[5] = {1,2,3,4,5};


### PR DESCRIPTION
I noticed while experimenting with std::span that some of the functionality wasn't 1:1 regarding CTAD.
The deduction of container types was missing. The following std::span example compiles without any problems, while the the gsl equivalent does not.

Ex: Current behavior
```c++ 
std::vector v{1,2,3,4}; 
std::span sp{v}; // no problem, compiles
```
```c++ 
std::vector v{1,2,3,4}; 
gsl::span sp{v}; // fails to compile. gsl::span<int>, however does compile
```
By examining the container's value_type in the deduction guide, we're able to deduce the internal type and construct the span. This more closely aligns gsl::span's behavior to std::span. 