### PR TITLE
Remove msvc < 1910 checks.

### DIFF
--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -50,11 +50,6 @@
 #pragma warning(disable : 26465) // TODO: bug - suppression does not work on template functions
 #pragma warning(disable : 4996)  // use of function or classes marked [[deprecated]]
 
-#if _MSC_VER < 1910
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif // _MSC_VER < 1910
 #endif // _MSC_VER
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/gsl/multi_span
+++ b/include/gsl/multi_span
@@ -2247,11 +2247,6 @@ general_span_iterator<Span> operator+(typename general_span_iterator<Span>::diff
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if _MSC_VER < 1910
-
-#undef constexpr
-#pragma pop_macro("constexpr")
-#endif // _MSC_VER < 1910
 
 #pragma warning(pop)
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -285,11 +285,4 @@ struct hash<gsl::strict_not_null<T>>
 
 } // namespace std
 
-#if defined(_MSC_VER) && _MSC_VER < 1910 && !defined(__clang__)
-
-#undef constexpr
-#pragma pop_macro("constexpr")
-
-#endif // defined(_MSC_VER) && _MSC_VER < 1910 && !defined(__clang__)
-
 #endif // GSL_POINTERS_H

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -25,12 +25,6 @@
 #include <system_error> // for hash
 #include <type_traits>  // for enable_if_t, is_convertible, is_assignable
 
-#if defined(_MSC_VER) && _MSC_VER < 1910 && !defined(__clang__)
-#pragma push_macro("constexpr")
-#define constexpr /*constexpr*/
-
-#endif                          // defined(_MSC_VER) && _MSC_VER < 1910
-
 namespace gsl
 {
 


### PR DESCRIPTION
remove msvc < 1910 checks as those versions are no longer supported.

These are the last of the pragma push_macro / pop_macro combos and will close #18 