### PR TITLE
feat: narrow for non totally ordered types

### DIFF
--- a/include/gsl/gsl_narrow
+++ b/include/gsl/gsl_narrow
@@ -25,7 +25,7 @@ struct narrowing_error : public std::exception
 };
 
 // narrow() : a checked version of narrow_cast() that throws if the cast changed the value
-template <class T, class U>
+template <class T, class U, typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
 GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recognise noexcept(false)
 constexpr
@@ -38,6 +38,22 @@ T narrow(U u) noexcept(false)
     if (static_cast<U>(t) != u
         || (is_different_signedness
             && ((t < T{}) != (u < U{}))))
+    {
+        throw narrowing_error{};
+    }
+
+    return t;
+}
+
+template <class T, class U, typename std::enable_if<!std::is_arithmetic<T>::value>::type* = nullptr>
+GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recognise noexcept(false)
+constexpr
+T narrow(U u) noexcept(false)
+{
+    const T t = narrow_cast<T>(u);
+
+    if (static_cast<U>(t) != u)
     {
         throw narrowing_error{};
     }

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -24,6 +24,7 @@
 #include <stdint.h>    // for uint32_t, int32_t
 #include <type_traits> // for is_same
 #include <cstddef>     // for std::ptrdiff_t
+#include <complex>
 
 using namespace gsl;
 
@@ -122,4 +123,8 @@ TEST(utils_tests, narrow)
 
     n = -42;
     EXPECT_THROW(narrow<unsigned>(n), narrowing_error);
+
+    EXPECT_TRUE(
+        narrow<std::complex<float>>(std::complex<double>(4, 2)) == std::complex<float>(4, 2));
+    EXPECT_THROW(narrow<std::complex<float>>(std::complex<double>(4.2)), narrowing_error);
 }


### PR DESCRIPTION
Resolves #900.

In the original overload, `((t < T{}) != (u < U{}))` is only ever reached when `is_different_signedness` is `true`, which is only ever `true` for arithmetic types because the same applies to `std::is_signed<T>::value` which `is_different_signedness` is initialized from. So we use `std::is_arithmetic<T>::value` to add an overload.