### PR TITLE
add what to narrowing_error

### DIFF
--- a/include/gsl/gsl_narrow
+++ b/include/gsl/gsl_narrow
@@ -22,6 +22,10 @@ namespace gsl
 {
 struct narrowing_error : public std::exception
 {
+    const char* what() const noexcept override
+    {
+        return "narrowing_error";
+    }
 };
 
 // narrow() : a checked version of narrow_cast() that throws if the cast changed the value


### PR DESCRIPTION
fixes #927 by adding an implementation for `narrowing_error::what()` which provides the string "narrowing_error"