### PR TITLE
Deprecate string_span

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,8 @@ Feature                            | Supported? | Description
 [**1. Views**][cg-views]           |            |
 owner                              | &#x2611;   | an alias for a raw pointer
 not_null                           | &#x2611;   | restricts a pointer / smart pointer to hold non-null values
-strict_not_null                    | &#x2611;   | a stricter version of `not_null` with explicit constructors
 span                               | &#x2611;   | a view over a contiguous sequence of memory. Based on the standardized verison of `std::span`, however `gsl::span` enforces bounds checking. See the [wiki](https://github.com/microsoft/GSL/wiki/gsl::span-and-std::span) for additional information.
 span_p                             | &#x2610;   | spans a range starting from a pointer to the first place for which the predicate is true
-basic_zstring                      | &#x2611;   | a pointer to a C-string (zero-terminated array) with a templated char type
-zstring                            | &#x2611;   | an alias to `basic_zstring` with a char type of char
-czstring                           | &#x2611;   | an alias to `basic_zstring` with a char type of const char
-wzstring                           | &#x2611;   | an alias to `basic_zstring` with a char type of wchar_t
-cwzstring                          | &#x2611;   | an alias to `basic_zstring` with a char type of const wchar_t
-u16zstring                         | &#x2611;   | an alias to `basic_zstring` with a char type of char16_t
-cu16zstring                        | &#x2611;   | an alias to `basic_zstring` with a char type of const char16_t
-u32zstring                         | &#x2611;   | an alias to `basic_zstring` with a char type of char32_t
-cu32zstring                        | &#x2611;   | an alias to `basic_zstring` with a char type of const char32_t
-basic_string_span                  | &#x2611;   | like `span` but for strings with a templated char type
-string_span                        | &#x2611;   | an alias to `basic_string_span` with a char type of char
-cstring_span                       | &#x2611;   | an alias to `basic_string_span` with a char type of const char
-wstring_span                       | &#x2611;   | an alias to `basic_string_span` with a char type of wchar_t
-cwstring_span                      | &#x2611;   | an alias to `basic_string_span` with a char type of const wchar_t
-u16string_span                     | &#x2611;   | an alias to `basic_string_span` with a char type of char16_t
-cu16string_span                    | &#x2611;   | an alias to `basic_string_span` with a char type of const char16_t
-u32string_span                     | &#x2611;   | an alias to `basic_string_span` with a char type of char32_t
-cu32string_span                    | &#x2611;   | an alias to `basic_string_span` with a char type of const char32_t
 [**2. Owners**][cg-owners]         |            |
 unique_ptr                         | &#x2611;   | an alias to `std::unique_ptr`
 shared_ptr                         | &#x2611;   | an alias to `std::shared_ptr`
@@ -70,11 +51,30 @@ narrow_cast                        | &#x2611;   | a narrowing cast for values an
 narrowing_error                    | &#x2611;   | a custom exception type thrown by `narrow()`
 [**5. Concepts**][cg-concepts]     | &#x2610;   |
 
-## The following features do not exist in C++ Core Guidelines:
+## The following features do not exist in or have been removed from the C++ Core Guidelines:
 Feature                            | Supported? | Description
 -----------------------------------|:----------:|-------------
-multi_span                         | &#x2610;   | Deprecated. Support for this type has been discontinued.
+strict_not_null                    | &#x2611;   | A stricter version of `not_null` with explicit constructors
+multi_span                         | &#x2610;   | Deprecated. Multi-dimensional span.
 strided_span                       | &#x2610;   | Deprecated. Support for this type has been discontinued.
+basic_zstring                      | &#x2610;   | Deprecated. A pointer to a C-string (zero-terminated array) with a templated char type
+zstring                            | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of char
+czstring                           | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of const char
+wzstring                           | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of wchar_t
+cwzstring                          | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of const wchar_t
+u16zstring                         | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of char16_t
+cu16zstring                        | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of const char16_t
+u32zstring                         | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of char32_t
+cu32zstring                        | &#x2610;   | Deprecated. An alias to `basic_zstring` with a char type of const char32_t
+basic_string_span                  | &#x2610;   | Deprecated. Like `span` but for strings with a templated char type
+string_span                        | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of char
+cstring_span                       | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of const char
+wstring_span                       | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of wchar_t
+cwstring_span                      | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of const wchar_t
+u16string_span                     | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of char16_t
+cu16string_span                    | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of const char16_t
+u32string_span                     | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of char32_t
+cu32string_span                    | &#x2610;   | Deprecated. An alias to `basic_string_span` with a char type of const char32_t
 
 This is based on [CppCoreGuidelines semi-specification](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gsl-guidelines-support-library).
 

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -133,12 +133,15 @@ ensure_sentinel(T* seq, std::size_t max = static_cast<std::size_t>(-1))
 {
     Ensures(seq != nullptr);
 
-    GSL_SUPPRESS(
-        f .23) // NO-FORMAT: attribute // TODO: false positive // TODO: suppress does not work
+    // clang-format off
+    GSL_SUPPRESS(f.23) // TODO: false positive // TODO: suppress does not work
+    // clang-format on
     auto cur = seq;
     Ensures(cur != nullptr); // workaround for removing the warning
 
-    GSL_SUPPRESS(bounds .1) // NO-FORMAT: attribute // TODO: suppress does not work
+    // clang-format off
+    GSL_SUPPRESS(bounds.1) // TODO: suppress does not work
+    // clang-format on
     while (static_cast<std::size_t>(cur - seq) < max && *cur != Sentinel) ++cur;
     Ensures(*cur == Sentinel);
     return {seq, static_cast<std::size_t>(cur - seq)};
@@ -163,9 +166,12 @@ constexpr span<CharT, dynamic_extent> ensure_z(CharT (&sz)[N])
 }
 
 template <class Cont>
-[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see "
-             "isocpp/CppCoreGuidelines PR#1680")]] constexpr span<
-    typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent>
+[[deprecated(
+    "string_span was removed from the C++ Core Guidelines. For more information, see "
+    "isocpp/CppCoreGuidelines PR#1680")]] constexpr span<typename std::
+                                                             remove_pointer<
+                                                                 typename Cont::pointer>::type,
+                                                         dynamic_extent>
 ensure_z(Cont& cont)
 {
     return ensure_z(cont.data(), cont.size());
@@ -243,7 +249,7 @@ public:
 
     // Container signature should work for basic_string after C++17 version exists
     template <class Traits, class Allocator>
-    // GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute // TODO: parser bug
+    // GSL_SUPPRESS(bounds.4) // TODO: parser bug
     constexpr basic_string_span(std::basic_string<element_type, Traits, Allocator> & str)
         : span_(&str[0], str.length())
     {}
@@ -410,7 +416,9 @@ template <class ElementType, std::size_t Extent>
 constexpr basic_string_span<const byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_bytes(basic_string_span<ElementType, Extent> s) noexcept
 {
-    GSL_SUPPRESS(type .1) // NO-FORMAT: attribute
+    // clang-format off
+    GSL_SUPPRESS(type.1)
+    // clang-format on
     return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
 }
 
@@ -419,7 +427,9 @@ template <class ElementType, std::size_t Extent,
 constexpr basic_string_span<byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_writable_bytes(basic_string_span<ElementType, Extent> s) noexcept
 {
-    GSL_SUPPRESS(type .1) // NO-FORMAT: attribute
+    // clang-format off
+    GSL_SUPPRESS(type.1)
+    // clang-format on
     return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
 }
 

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -35,8 +35,13 @@
 // Turn MSVC /analyze rules that generate too much noise. TODO: fix in the tool.
 #pragma warning(disable : 26446) // TODO: bug in parser - attributes and templates
 #pragma warning(disable : 26481) // TODO: suppress does not work inside templates sometimes
-
+#pragma warning(disable : 4996)  // use of functions & classes marked [[deprecated]]
 #endif // _MSC_VER
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 namespace gsl
 {
@@ -52,36 +57,36 @@ namespace gsl
 //
 
 template <typename CharT, std::size_t Extent = dynamic_extent>
-using basic_zstring = CharT*;
+using basic_zstring [[deprecated]] = CharT*;
 
 template <std::size_t Extent = dynamic_extent>
-using czstring = basic_zstring<const char, Extent>;
+using czstring [[deprecated]] = basic_zstring<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwzstring = basic_zstring<const wchar_t, Extent>;
+using cwzstring [[deprecated]] = basic_zstring<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16zstring = basic_zstring<const char16_t, Extent>;
+using cu16zstring [[deprecated]] = basic_zstring<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32zstring = basic_zstring<const char32_t, Extent>;
+using cu32zstring [[deprecated]] = basic_zstring<const char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using zstring = basic_zstring<char, Extent>;
+using zstring [[deprecated]] = basic_zstring<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wzstring = basic_zstring<wchar_t, Extent>;
+using wzstring [[deprecated]] = basic_zstring<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16zstring = basic_zstring<char16_t, Extent>;
+using u16zstring [[deprecated]] = basic_zstring<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32zstring = basic_zstring<char32_t, Extent>;
+using u32zstring [[deprecated]] = basic_zstring<char32_t, Extent>;
 
 namespace details
 {
     template <class CharT>
-    constexpr std::size_t string_length(const CharT* str, std::size_t n)
+    [[deprecated]] constexpr std::size_t string_length(const CharT* str, std::size_t n)
     {
         if (str == nullptr || n == dynamic_extent) return 0;
 
@@ -103,7 +108,7 @@ namespace details
 // Will fail-fast if sentinel cannot be found before max elements are examined.
 //
 template <typename T, const T Sentinel>
-constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
+[[deprecated]]constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
                                         std::size_t max = static_cast<std::size_t>(-1))
 {
     Ensures(seq != nullptr);
@@ -124,7 +129,7 @@ constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
 // Will fail fast if a null-terminator cannot be found before the limit of size_type.
 //
 template <typename CharT>
-constexpr span<CharT, dynamic_extent> ensure_z(CharT* const& sz,
+[[deprecated]] constexpr span<CharT, dynamic_extent> ensure_z(CharT* const& sz,
                                      std::size_t max = static_cast<std::size_t>(-1))
 {
     return ensure_sentinel<CharT, CharT(0)>(sz, max);
@@ -137,29 +142,28 @@ constexpr span<CharT, dynamic_extent> ensure_z(CharT (&sz)[N])
 }
 
 template <class Cont>
-constexpr span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent>
-ensure_z(Cont& cont)
+[[deprecated]] constexpr span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent> ensure_z(Cont& cont)
 {
     return ensure_z(cont.data(), cont.size());
 }
 
 template <typename CharT, std::size_t>
-class basic_string_span;
+class [[deprecated]] basic_string_span;
 
 namespace details
 {
     template <typename T>
-    struct is_basic_string_span_oracle : std::false_type
+    struct [[deprecated]] is_basic_string_span_oracle : std::false_type
     {
     };
 
     template <typename CharT, std::size_t Extent>
-    struct is_basic_string_span_oracle<basic_string_span<CharT, Extent>> : std::true_type
+    struct [[deprecated]] is_basic_string_span_oracle<basic_string_span<CharT, Extent>> : std::true_type
     {
     };
 
     template <typename T>
-    struct is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
+    struct [[deprecated]] is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
     {
     };
 } // namespace details
@@ -168,7 +172,7 @@ namespace details
 // string_span and relatives
 //
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class basic_string_span
+class [[deprecated]] basic_string_span
 {
 public:
     using element_type = CharT;
@@ -315,28 +319,28 @@ private:
 };
 
 template <std::size_t Extent = dynamic_extent>
-using string_span = basic_string_span<char, Extent>;
+using string_span [[deprecated]] = basic_string_span<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cstring_span = basic_string_span<const char, Extent>;
+using cstring_span [[deprecated]] = basic_string_span<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wstring_span = basic_string_span<wchar_t, Extent>;
+using wstring_span [[deprecated]] = basic_string_span<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwstring_span = basic_string_span<const wchar_t, Extent>;
+using cwstring_span [[deprecated]] = basic_string_span<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16string_span = basic_string_span<char16_t, Extent>;
+using u16string_span [[deprecated]] = basic_string_span<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16string_span = basic_string_span<const char16_t, Extent>;
+using cu16string_span [[deprecated]] = basic_string_span<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32string_span = basic_string_span<char32_t, Extent>;
+using u32string_span [[deprecated]] = basic_string_span<char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32string_span = basic_string_span<const char32_t, Extent>;
+using cu32string_span [[deprecated]] = basic_string_span<const char32_t, Extent>;
 
 //
 // to_string() allow (explicit) conversions from string_span to string
@@ -377,7 +381,7 @@ as_writable_bytes(basic_string_span<ElementType, Extent> s) noexcept
 // zero-terminated string span, used to convert
 // zero-terminated spans to legacy strings
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class basic_zstring_span
+class [[deprecated]] basic_zstring_span
 {
 public:
     using value_type = CharT;
@@ -426,28 +430,28 @@ private:
 };
 
 template <std::size_t Max = dynamic_extent>
-using zstring_span = basic_zstring_span<char, Max>;
+using zstring_span [[deprecated]] = basic_zstring_span<char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using wzstring_span = basic_zstring_span<wchar_t, Max>;
+using wzstring_span [[deprecated]] = basic_zstring_span<wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u16zstring_span = basic_zstring_span<char16_t, Max>;
+using u16zstring_span [[deprecated]] = basic_zstring_span<char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u32zstring_span = basic_zstring_span<char32_t, Max>;
+using u32zstring_span [[deprecated]] = basic_zstring_span<char32_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using czstring_span = basic_zstring_span<const char, Max>;
+using czstring_span [[deprecated]] = basic_zstring_span<const char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cwzstring_span = basic_zstring_span<const wchar_t, Max>;
+using cwzstring_span [[deprecated]] = basic_zstring_span<const wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu16zstring_span = basic_zstring_span<const char16_t, Max>;
+using cu16zstring_span [[deprecated]] = basic_zstring_span<const char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu32zstring_span = basic_zstring_span<const char32_t, Max>;
+using cu32zstring_span [[deprecated]] = basic_zstring_span<const char32_t, Max>;
 
 // operator ==
 template <class CharT, std::size_t Extent, class T,
@@ -703,4 +707,7 @@ bool operator>=(const T& one, gsl::basic_string_span<CharT, Extent> other)
 
 #endif // _MSC_VER
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #endif // GSL_STRING_SPAN_H

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -19,14 +19,14 @@
 
 #include <gsl/gsl_assert> // for Ensures, Expects
 #include <gsl/gsl_util>   // for narrow_cast
-#include <gsl/span_ext>       // for operator!=, operator==, dynamic_extent
+#include <gsl/span_ext>   // for operator!=, operator==, dynamic_extent
 
 #include <algorithm> // for equal, lexicographical_compare
 #include <array>     // for array
 #include <cstddef>   // for size_t, nullptr_t
 #include <cstdint>   // for PTRDIFF_MAX
 #include <cstring>
-#include <string>    // for basic_string, allocator, char_traits
+#include <string>      // for basic_string, allocator, char_traits
 #include <type_traits> // for declval, is_convertible, enable_if_t, add_...
 
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -36,7 +36,7 @@
 #pragma warning(disable : 26446) // TODO: bug in parser - attributes and templates
 #pragma warning(disable : 26481) // TODO: suppress does not work inside templates sometimes
 #pragma warning(disable : 4996)  // use of functions & classes marked [[deprecated]]
-#endif // _MSC_VER
+#endif                           // _MSC_VER
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -57,36 +57,55 @@ namespace gsl
 //
 
 template <typename CharT, std::size_t Extent = dynamic_extent>
-using basic_zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = CharT*;
+using basic_zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                 "information, see isocpp/CppCoreGuidelines PR#1680")]] = CharT*;
 
 template <std::size_t Extent = dynamic_extent>
-using czstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char, Extent>;
+using czstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                            "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const wchar_t, Extent>;
+using cwzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                             "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char16_t, Extent>;
+using cu16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                               "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char32_t, Extent>;
+using cu32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                               "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<const char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char, Extent>;
+using zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                           "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<wchar_t, Extent>;
+using wzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                            "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char16_t, Extent>;
+using u16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                              "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char32_t, Extent>;
+using u32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                              "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring<char32_t, Extent>;
 
 namespace details
 {
     template <class CharT>
-    [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr std::size_t string_length(const CharT* str, std::size_t n)
+    [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see "
+                 "isocpp/CppCoreGuidelines PR#1680")]] constexpr std::size_t
+    string_length(const CharT* str, std::size_t n)
     {
         if (str == nullptr || n == dynamic_extent) return 0;
 
@@ -108,29 +127,31 @@ namespace details
 // Will fail-fast if sentinel cannot be found before max elements are examined.
 //
 template <typename T, const T Sentinel>
-[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]]constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
-                                        std::size_t max = static_cast<std::size_t>(-1))
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see "
+             "isocpp/CppCoreGuidelines PR#1680")]] constexpr span<T, dynamic_extent>
+ensure_sentinel(T* seq, std::size_t max = static_cast<std::size_t>(-1))
 {
     Ensures(seq != nullptr);
 
     GSL_SUPPRESS(
-        f.23) // NO-FORMAT: attribute // TODO: false positive // TODO: suppress does not work
+        f .23) // NO-FORMAT: attribute // TODO: false positive // TODO: suppress does not work
     auto cur = seq;
     Ensures(cur != nullptr); // workaround for removing the warning
 
-    GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute // TODO: suppress does not work
+    GSL_SUPPRESS(bounds .1) // NO-FORMAT: attribute // TODO: suppress does not work
     while (static_cast<std::size_t>(cur - seq) < max && *cur != Sentinel) ++cur;
     Ensures(*cur == Sentinel);
     return {seq, static_cast<std::size_t>(cur - seq)};
 }
 
 //
-// ensure_z - creates a span for a zero terminated strings. The span will not contain the zero termination.
-// Will fail fast if a null-terminator cannot be found before the limit of size_type.
+// ensure_z - creates a span for a zero terminated strings. The span will not contain the zero
+// termination. Will fail fast if a null-terminator cannot be found before the limit of size_type.
 //
 template <typename CharT>
-[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr span<CharT, dynamic_extent> ensure_z(CharT* const& sz,
-                                     std::size_t max = static_cast<std::size_t>(-1))
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see "
+             "isocpp/CppCoreGuidelines PR#1680")]] constexpr span<CharT, dynamic_extent>
+ensure_z(CharT* const& sz, std::size_t max = static_cast<std::size_t>(-1))
 {
     return ensure_sentinel<CharT, CharT(0)>(sz, max);
 }
@@ -142,37 +163,45 @@ constexpr span<CharT, dynamic_extent> ensure_z(CharT (&sz)[N])
 }
 
 template <class Cont>
-[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent> ensure_z(Cont& cont)
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see "
+             "isocpp/CppCoreGuidelines PR#1680")]] constexpr span<
+    typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent>
+ensure_z(Cont& cont)
 {
     return ensure_z(cont.data(), cont.size());
 }
 
 template <typename CharT, std::size_t>
-class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span;
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, "
+                   "see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span;
 
 namespace details
 {
     template <typename T>
-    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle : std::false_type
-    {
-    };
+    struct [
+        [deprecated("string_span was removed from the C++ Core Guidelines. For more information, "
+                    "see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle
+        : std::false_type{};
 
     template <typename CharT, std::size_t Extent>
-    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle<basic_string_span<CharT, Extent>> : std::true_type
-    {
-    };
+    struct [[deprecated(
+        "string_span was removed from the C++ Core Guidelines. For more information, see "
+        "isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle<basic_string_span<CharT,
+                                                                                            Extent>>
+        : std::true_type{};
 
     template <typename T>
-    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
-    {
-    };
+    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                        "information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span
+        : is_basic_string_span_oracle<std::remove_cv_t<T>>{};
 } // namespace details
 
 //
 // string_span and relatives
 //
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, "
+                   "see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span
 {
 public:
     using element_type = CharT;
@@ -201,11 +230,11 @@ public:
     // From static arrays - if 0-terminated, remove 0 from the view
     // All other containers allow 0s within the length, so we do not remove them
     template <std::size_t N>
-    constexpr basic_string_span(element_type (&arr)[N]) : span_(remove_z(arr))
+    constexpr basic_string_span(element_type(&arr)[N]) : span_(remove_z(arr))
     {}
 
     template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
-    constexpr basic_string_span(std::array<ArrayElementType, N>& arr) noexcept : span_(arr)
+    constexpr basic_string_span(std::array<ArrayElementType, N> & arr) noexcept : span_(arr)
     {}
 
     template <std::size_t N, class ArrayElementType = std::remove_const_t<element_type>>
@@ -215,7 +244,7 @@ public:
     // Container signature should work for basic_string after C++17 version exists
     template <class Traits, class Allocator>
     // GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute // TODO: parser bug
-    constexpr basic_string_span(std::basic_string<element_type, Traits, Allocator>& str)
+    constexpr basic_string_span(std::basic_string<element_type, Traits, Allocator> & str)
         : span_(&str[0], str.length())
     {}
 
@@ -231,7 +260,7 @@ public:
                   std::is_convertible<typename Container::pointer, pointer>::value &&
                   std::is_convertible<typename Container::pointer,
                                       decltype(std::declval<Container>().data())>::value>>
-    constexpr basic_string_span(Container& cont) : span_(cont)
+    constexpr basic_string_span(Container & cont) : span_(cont)
     {}
 
     template <class Container,
@@ -280,8 +309,8 @@ public:
         return {span_.template subspan<Offset, Count>()};
     }
 
-    constexpr basic_string_span<element_type, dynamic_extent>
-    subspan(size_type offset, size_type count = dynamic_extent) const
+    constexpr basic_string_span<element_type, dynamic_extent> subspan(
+        size_type offset, size_type count = dynamic_extent) const
     {
         return {span_.subspan(offset, count)};
     }
@@ -310,7 +339,7 @@ private:
     }
 
     template <std::size_t N>
-    static constexpr impl_type remove_z(element_type (&sz)[N])
+    static constexpr impl_type remove_z(element_type(&sz)[N])
     {
         return remove_z(&sz[0], N);
     }
@@ -319,28 +348,44 @@ private:
 };
 
 template <std::size_t Extent = dynamic_extent>
-using string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char, Extent>;
+using string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                               "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char, Extent>;
+using cstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<wchar_t, Extent>;
+using wstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const wchar_t, Extent>;
+using cwstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                 "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char16_t, Extent>;
+using u16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                  "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char16_t, Extent>;
+using cu16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                   "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char32_t, Extent>;
+using u32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                  "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char32_t, Extent>;
+using cu32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                   "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_string_span<const char32_t, Extent>;
 
 //
 // to_string() allow (explicit) conversions from string_span to string
@@ -365,7 +410,7 @@ template <class ElementType, std::size_t Extent>
 constexpr basic_string_span<const byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_bytes(basic_string_span<ElementType, Extent> s) noexcept
 {
-    GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    GSL_SUPPRESS(type .1) // NO-FORMAT: attribute
     return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
 }
 
@@ -374,14 +419,15 @@ template <class ElementType, std::size_t Extent,
 constexpr basic_string_span<byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_writable_bytes(basic_string_span<ElementType, Extent> s) noexcept
 {
-    GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    GSL_SUPPRESS(type .1) // NO-FORMAT: attribute
     return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
 }
 
 // zero-terminated string span, used to convert
 // zero-terminated spans to legacy strings
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_zstring_span
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, "
+                   "see isocpp/CppCoreGuidelines PR#1680")]] basic_zstring_span
 {
 public:
     using value_type = CharT;
@@ -407,7 +453,7 @@ public:
     constexpr basic_zstring_span(const basic_zstring_span& other) = default;
 
     // move
-    constexpr basic_zstring_span(basic_zstring_span&& other) = default;
+    constexpr basic_zstring_span(basic_zstring_span && other) = default;
 
     // assign
     constexpr basic_zstring_span& operator=(const basic_zstring_span& other) = default;
@@ -430,28 +476,44 @@ private:
 };
 
 template <std::size_t Max = dynamic_extent>
-using zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char, Max>;
+using zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using wzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<wchar_t, Max>;
+using wzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                 "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char16_t, Max>;
+using u16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                   "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char32_t, Max>;
+using u32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                   "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<char32_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using czstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char, Max>;
+using czstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                 "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<const char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cwzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const wchar_t, Max>;
+using cwzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more "
+                                  "information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<const wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char16_t, Max>;
+using cu16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For "
+                                    "more information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<const char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char32_t, Max>;
+using cu32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For "
+                                    "more information, see isocpp/CppCoreGuidelines PR#1680")]] =
+    basic_zstring_span<const char32_t, Max>;
 
 // operator ==
 template <class CharT, std::size_t Extent, class T,

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -57,36 +57,36 @@ namespace gsl
 //
 
 template <typename CharT, std::size_t Extent = dynamic_extent>
-using basic_zstring [[deprecated]] = CharT*;
+using basic_zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = CharT*;
 
 template <std::size_t Extent = dynamic_extent>
-using czstring [[deprecated]] = basic_zstring<const char, Extent>;
+using czstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwzstring [[deprecated]] = basic_zstring<const wchar_t, Extent>;
+using cwzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16zstring [[deprecated]] = basic_zstring<const char16_t, Extent>;
+using cu16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32zstring [[deprecated]] = basic_zstring<const char32_t, Extent>;
+using cu32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<const char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using zstring [[deprecated]] = basic_zstring<char, Extent>;
+using zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wzstring [[deprecated]] = basic_zstring<wchar_t, Extent>;
+using wzstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16zstring [[deprecated]] = basic_zstring<char16_t, Extent>;
+using u16zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32zstring [[deprecated]] = basic_zstring<char32_t, Extent>;
+using u32zstring [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring<char32_t, Extent>;
 
 namespace details
 {
     template <class CharT>
-    [[deprecated]] constexpr std::size_t string_length(const CharT* str, std::size_t n)
+    [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr std::size_t string_length(const CharT* str, std::size_t n)
     {
         if (str == nullptr || n == dynamic_extent) return 0;
 
@@ -108,7 +108,7 @@ namespace details
 // Will fail-fast if sentinel cannot be found before max elements are examined.
 //
 template <typename T, const T Sentinel>
-[[deprecated]]constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]]constexpr span<T, dynamic_extent> ensure_sentinel(T* seq,
                                         std::size_t max = static_cast<std::size_t>(-1))
 {
     Ensures(seq != nullptr);
@@ -129,7 +129,7 @@ template <typename T, const T Sentinel>
 // Will fail fast if a null-terminator cannot be found before the limit of size_type.
 //
 template <typename CharT>
-[[deprecated]] constexpr span<CharT, dynamic_extent> ensure_z(CharT* const& sz,
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr span<CharT, dynamic_extent> ensure_z(CharT* const& sz,
                                      std::size_t max = static_cast<std::size_t>(-1))
 {
     return ensure_sentinel<CharT, CharT(0)>(sz, max);
@@ -142,28 +142,28 @@ constexpr span<CharT, dynamic_extent> ensure_z(CharT (&sz)[N])
 }
 
 template <class Cont>
-[[deprecated]] constexpr span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent> ensure_z(Cont& cont)
+[[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] constexpr span<typename std::remove_pointer<typename Cont::pointer>::type, dynamic_extent> ensure_z(Cont& cont)
 {
     return ensure_z(cont.data(), cont.size());
 }
 
 template <typename CharT, std::size_t>
-class [[deprecated]] basic_string_span;
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span;
 
 namespace details
 {
     template <typename T>
-    struct [[deprecated]] is_basic_string_span_oracle : std::false_type
+    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle : std::false_type
     {
     };
 
     template <typename CharT, std::size_t Extent>
-    struct [[deprecated]] is_basic_string_span_oracle<basic_string_span<CharT, Extent>> : std::true_type
+    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span_oracle<basic_string_span<CharT, Extent>> : std::true_type
     {
     };
 
     template <typename T>
-    struct [[deprecated]] is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
+    struct [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] is_basic_string_span : is_basic_string_span_oracle<std::remove_cv_t<T>>
     {
     };
 } // namespace details
@@ -172,7 +172,7 @@ namespace details
 // string_span and relatives
 //
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class [[deprecated]] basic_string_span
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_string_span
 {
 public:
     using element_type = CharT;
@@ -319,28 +319,28 @@ private:
 };
 
 template <std::size_t Extent = dynamic_extent>
-using string_span [[deprecated]] = basic_string_span<char, Extent>;
+using string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cstring_span [[deprecated]] = basic_string_span<const char, Extent>;
+using cstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using wstring_span [[deprecated]] = basic_string_span<wchar_t, Extent>;
+using wstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cwstring_span [[deprecated]] = basic_string_span<const wchar_t, Extent>;
+using cwstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const wchar_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u16string_span [[deprecated]] = basic_string_span<char16_t, Extent>;
+using u16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu16string_span [[deprecated]] = basic_string_span<const char16_t, Extent>;
+using cu16string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char16_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using u32string_span [[deprecated]] = basic_string_span<char32_t, Extent>;
+using u32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<char32_t, Extent>;
 
 template <std::size_t Extent = dynamic_extent>
-using cu32string_span [[deprecated]] = basic_string_span<const char32_t, Extent>;
+using cu32string_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_string_span<const char32_t, Extent>;
 
 //
 // to_string() allow (explicit) conversions from string_span to string
@@ -381,7 +381,7 @@ as_writable_bytes(basic_string_span<ElementType, Extent> s) noexcept
 // zero-terminated string span, used to convert
 // zero-terminated spans to legacy strings
 template <typename CharT, std::size_t Extent = dynamic_extent>
-class [[deprecated]] basic_zstring_span
+class [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] basic_zstring_span
 {
 public:
     using value_type = CharT;
@@ -430,28 +430,28 @@ private:
 };
 
 template <std::size_t Max = dynamic_extent>
-using zstring_span [[deprecated]] = basic_zstring_span<char, Max>;
+using zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using wzstring_span [[deprecated]] = basic_zstring_span<wchar_t, Max>;
+using wzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u16zstring_span [[deprecated]] = basic_zstring_span<char16_t, Max>;
+using u16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using u32zstring_span [[deprecated]] = basic_zstring_span<char32_t, Max>;
+using u32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<char32_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using czstring_span [[deprecated]] = basic_zstring_span<const char, Max>;
+using czstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cwzstring_span [[deprecated]] = basic_zstring_span<const wchar_t, Max>;
+using cwzstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const wchar_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu16zstring_span [[deprecated]] = basic_zstring_span<const char16_t, Max>;
+using cu16zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char16_t, Max>;
 
 template <std::size_t Max = dynamic_extent>
-using cu32zstring_span [[deprecated]] = basic_zstring_span<const char32_t, Max>;
+using cu32zstring_span [[deprecated("string_span was removed from the C++ Core Guidelines. For more information, see isocpp/CppCoreGuidelines PR#1680")]] = basic_zstring_span<const char32_t, Max>;
 
 // operator ==
 template <class CharT, std::size_t Extent, class T,


### PR DESCRIPTION
isocpp/cppcoreguidelines#1680 removed string_span from the C++ Core Guidelines. 
This change deprecates `basic_string_span`, `basic_zstring_span`, and all of their derived types.

Edit: as with multi_span and strided_span, string_span will remain deprecated in the GSL for a year before it is removed. 