### PR TITLE
Allow usage on platforms not providing iostreams

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -20,10 +20,14 @@
 #include <gsl/gsl_assert>  // for Ensures, Expects
 
 #include <algorithm>    // for forward
-#include <iosfwd>       // for ptrdiff_t, nullptr_t, ostream, size_t
+#include <cstddef>      // for ptrdiff_t, nullptr_t, size_t
 #include <memory>       // for shared_ptr, unique_ptr
 #include <system_error> // for hash
 #include <type_traits>  // for enable_if_t, is_convertible, is_assignable
+
+#if !defined(GSL_NO_IOSTREAMS)
+#include <iosfwd>       // for ostream
+#endif // !defined(GSL_NO_IOSTREAMS)
 
 namespace gsl
 {
@@ -116,12 +120,14 @@ auto make_not_null(T&& t) noexcept {
     return not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
+#if !defined(GSL_NO_IOSTREAMS)
 template <class T>
 std::ostream& operator<<(std::ostream& os, const not_null<T>& val)
 {
     os << val.get();
     return os;
 }
+#endif // !defined(GSL_NO_IOSTREAMS)
 
 template <class T, class U>
 auto operator==(const not_null<T>& lhs, const not_null<U>& rhs) noexcept(noexcept(lhs.get() == rhs.get())) -> decltype(lhs.get() == rhs.get())


### PR DESCRIPTION
Some embedded/low-profile STL implementations may not provide iostreams (e.g., EASTL). Allow to use <pointer> without iostreams if desired.

Closes #933.