### PR TITLE
eliminate warning, use narrow_cast instead of static_cast

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -434,7 +434,7 @@ public:
 
     template <std::size_t MyExtent = Extent, std::enable_if_t<MyExtent != dynamic_extent, int> = 0>
     constexpr explicit span(pointer firstElem, pointer lastElem) noexcept
-        : storage_(firstElem, gsl::narrow_cast<std::size_t>(lastElem - firstElem))
+        : storage_(firstElem, narrow_cast<std::size_t>(lastElem - firstElem))
     {
         Expects(lastElem - firstElem == static_cast<difference_type>(Extent));
     }

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -19,6 +19,7 @@
 
 #include <gsl/gsl_assert> // for Expects
 #include <gsl/gsl_byte>   // for byte
+#include <gsl/gsl_util>   // for narrow_cast
 
 #include <array>       // for array
 #include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
@@ -433,14 +434,14 @@ public:
 
     template <std::size_t MyExtent = Extent, std::enable_if_t<MyExtent != dynamic_extent, int> = 0>
     constexpr explicit span(pointer firstElem, pointer lastElem) noexcept
-        : storage_(firstElem, static_cast<std::size_t>(lastElem - firstElem))
+        : storage_(firstElem, gsl::narrow_cast<std::size_t>(lastElem - firstElem))
     {
         Expects(lastElem - firstElem == static_cast<difference_type>(Extent));
     }
 
     template <std::size_t MyExtent = Extent, std::enable_if_t<MyExtent == dynamic_extent, int> = 0>
     constexpr span(pointer firstElem, pointer lastElem) noexcept
-        : storage_(firstElem, static_cast<std::size_t>(lastElem - firstElem))
+        : storage_(firstElem, gsl::narrow_cast<std::size_t>(lastElem - firstElem))
     {}
 
     template <std::size_t N,

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -441,7 +441,7 @@ public:
 
     template <std::size_t MyExtent = Extent, std::enable_if_t<MyExtent == dynamic_extent, int> = 0>
     constexpr span(pointer firstElem, pointer lastElem) noexcept
-        : storage_(firstElem, gsl::narrow_cast<std::size_t>(lastElem - firstElem))
+        : storage_(firstElem, narrow_cast<std::size_t>(lastElem - firstElem))
     {}
 
     template <std::size_t N,


### PR DESCRIPTION
The original code triggers

> warning C26472: Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow (type.1).

The change eliminates the warning.