### PR TITLE
Include gsl_narrow from gsl and fix comment.

### DIFF
--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -20,10 +20,14 @@
 #include <gsl/gsl_algorithm> // copy
 #include <gsl/gsl_assert>    // Ensures/Expects
 #include <gsl/gsl_byte>      // byte
-#include <gsl/gsl_util>      // finally()/narrow()/narrow_cast()...
+#include <gsl/gsl_util>      // finally()/narrow_cast()...
 #include <gsl/multi_span>    // multi_span, strided_span...
 #include <gsl/pointers>      // owner, not_null
 #include <gsl/span>          // span
 #include <gsl/string_span>   // zstring, string_span, zstring_builder...
+
+#ifdef __cpp_exceptions
+#include <gsl/gsl_narrow>      // narrow()
+#endif
 
 #endif // GSL_GSL_H


### PR DESCRIPTION
narrow() is now in gsl_narrow rather than gsl_util. Include gsl_narrow when exceptions are enabled. Ensures that #include <gsl/gsl> includes entire library as advertised in the documentation.