### PR TITLE
narrow_cast specialization for floating point -> unsigned types

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -88,12 +88,13 @@ finally(F&& f) noexcept
         std::forward<F>(f));
 }
 
-namespace details{
+namespace details
+{
 
-template <class T, class U> constexpr bool FloatingPointToUnsignedConversion =
-        std::is_floating_point<typename std::decay<U>::type>::value
-        && std::is_integral<T>::value
-        && std::is_unsigned<T>::value;
+    template <class T, class U>
+    constexpr bool FloatingPointToUnsignedConversion =
+        std::is_floating_point<typename std::decay<U>::type>::value&& std::is_integral<T>::value&&
+            std::is_unsigned<T>::value;
 
 } // namespace details
 
@@ -103,26 +104,22 @@ template <class T, class U> constexpr bool FloatingPointToUnsignedConversion =
 // architectures and build configurations when the floating value is negative.
 // To force a consistent behavior the float should first cast to signed and then to unsigned.
 template <class T, class U,
-            std::enable_if_t<
-                details::FloatingPointToUnsignedConversion<T,U>
-                , int> = 0>
+          std::enable_if_t<details::FloatingPointToUnsignedConversion<T, U>, int> = 0>
 // clang-format off
 GSL_SUPPRESS(type.1)
-// clang-format on
-constexpr T narrow_cast(U&& u) noexcept
+    // clang-format on
+    constexpr T narrow_cast(U&& u) noexcept
 {
     using signed_type = typename std::make_signed<T>::type;
     return static_cast<T>(static_cast<signed_type>(std::forward<U>(u)));
 }
 
 template <class T, class U,
-            std::enable_if_t<
-                !details::FloatingPointToUnsignedConversion<T,U>
-                , int> = 0>
+          std::enable_if_t<!details::FloatingPointToUnsignedConversion<T, U>, int> = 0>
 // clang-format off
 GSL_SUPPRESS(type.1)
-// clang-format on
-constexpr T narrow_cast(U&& u) noexcept
+    // clang-format on
+    constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
@@ -134,7 +131,7 @@ template <class T, std::size_t N>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-// clang-format on
+    // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(N));
@@ -145,7 +142,7 @@ template <class Cont>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-// clang-format on
+    // clang-format on
     constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
@@ -156,8 +153,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
 template <class T>
 // clang-format off
 GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
-// clang-format on
-constexpr T at(const std::initializer_list<T> cont, const index i)
+    // clang-format on
+    constexpr T at(const std::initializer_list<T> cont, const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     return *(cont.begin() + i);

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -88,10 +88,39 @@ finally(F&& f) noexcept
         std::forward<F>(f));
 }
 
+namespace details{
+
+template <class T, class U> constexpr bool FloatingPointToUnsignedConversion =
+        std::is_floating_point<typename std::decay<U>::type>::value
+        && std::is_integral<T>::value
+        && std::is_unsigned<T>::value;
+
+} // namespace details
+
 // narrow_cast(): a searchable way to do narrowing casts of values
-template <class T, class U>
+
+// floating point to unsigned values have unpredictable conversions across various
+// architectures and build configurations when the floating value is negative.
+// To force a consistent behavior the float should first cast to signed and then to unsigned.
+template <class T, class U,
+            std::enable_if_t<
+                details::FloatingPointToUnsignedConversion<T,U>
+                , int> = 0>
 // clang-format off
-GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+GSL_SUPPRESS(type.1)
+// clang-format on
+constexpr T narrow_cast(U&& u) noexcept
+{
+    using signed_type = typename std::make_signed<T>::type;
+    return static_cast<T>(static_cast<signed_type>(std::forward<U>(u)));
+}
+
+template <class T, class U,
+            std::enable_if_t<
+                !details::FloatingPointToUnsignedConversion<T,U>
+                , int> = 0>
+// clang-format off
+GSL_SUPPRESS(type.1)
 // clang-format on
 constexpr T narrow_cast(U&& u) noexcept
 {

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -100,15 +100,15 @@ namespace details
 
 // narrow_cast(): a searchable way to do narrowing casts of values
 
-// floating point to unsigned values have unpredictable conversions across various
+// floating point to unsigned values can have unpredictable conversions across various
 // architectures and build configurations when the floating value is negative.
 // To force a consistent behavior the float should first cast to signed and then to unsigned.
 template <class T, class U,
           std::enable_if_t<details::FloatingPointToUnsignedConversion<T, U>, int> = 0>
 // clang-format off
 GSL_SUPPRESS(type.1)
-    // clang-format on
-    constexpr T narrow_cast(U&& u) noexcept
+// clang-format on
+constexpr T narrow_cast(U&& u) noexcept
 {
     using signed_type = typename std::make_signed<T>::type;
     return static_cast<T>(static_cast<signed_type>(std::forward<U>(u)));
@@ -118,8 +118,8 @@ template <class T, class U,
           std::enable_if_t<!details::FloatingPointToUnsignedConversion<T, U>, int> = 0>
 // clang-format off
 GSL_SUPPRESS(type.1)
-    // clang-format on
-    constexpr T narrow_cast(U&& u) noexcept
+// clang-format on
+constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
@@ -131,8 +131,8 @@ template <class T, std::size_t N>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-    // clang-format on
-    constexpr T& at(T (&arr)[N], const index i)
+// clang-format on
+constexpr T& at(T (&arr)[N], const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
@@ -142,8 +142,8 @@ template <class Cont>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-    // clang-format on
-    constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
+// clang-format on
+constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     using size_type = decltype(cont.size());
@@ -153,8 +153,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
 template <class T>
 // clang-format off
 GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
-    // clang-format on
-    constexpr T at(const std::initializer_list<T> cont, const index i)
+// clang-format on
+constexpr T at(const std::initializer_list<T> cont, const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     return *(cont.begin() + i);


### PR DESCRIPTION
Floating point to unsigned values can have unpredictable conversions across various architectures and build configurations when the floating value is negative. To force a consistent behavior the float should first cast to signed and then to unsigned.

Also ran clang-format and adjusted some weird formatting. 