### PR TITLE
Improve build script for standalone tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,13 +5,14 @@ project(GSLTests CXX)
 include(FindPkgConfig)
 include(ExternalProject)
 
-find_package(Git REQUIRED QUIET)
-
 # will make visual studio generated project group files
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 pkg_search_module(GTestMain gtest_main)
 if (NOT GTestMain_FOUND)
+    # No pre-installed GTest is available, try to download it using Git.
+    find_package(Git REQUIRED QUIET)
+
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
     execute_process(
         COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 
 project(GSLTests CXX)
+enable_testing()  # again, for support standalone testing
 
 include(FindPkgConfig)
 include(ExternalProject)
@@ -40,6 +41,13 @@ if (NOT GTestMain_FOUND)
         ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
         EXCLUDE_FROM_ALL
     )
+endif()
+
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # CMake has been started independently in this directory with tests. Do
+    # import the globally installed Guidelines Support Library and test it
+    # instead of the current version from the include/ folder.
+    find_package(Microsoft.GSL REQUIRED)
 endif()
 
 if (MSVC AND (GSL_CXX_STANDARD EQUAL 17))
@@ -157,7 +165,7 @@ set_property(TARGET  PROPERTY FOLDER "GSL_tests")
 function(add_gsl_test name)
     add_executable(${name} ${name}.cpp)
     target_link_libraries(${name}
-        GSL
+        Microsoft.GSL::GSL
         gsl_tests_config
         ${GTestMain_LIBRARIES}
     )
@@ -259,7 +267,7 @@ endif(MSVC)
 function(add_gsl_test_noexcept name)
     add_executable(${name} ${name}.cpp)
     target_link_libraries(${name}
-        GSL
+        Microsoft.GSL::GSL
         gsl_tests_config_noexcept
         ${GTestMain_LIBRARIES}
     )


### PR DESCRIPTION
 * Do not require Git for build tests

   Cloning via Git is not the only path to obtain Google Test framework. In Linux, using a system package manager is the preferred way, and gtest can be installed through APK, APT, DNF, pacman, or many other.

   See also: https://github.com/microsoft/GSL/pull/961#discussion_r548959056

 * Support standalone tests

    The patch makes possible to run auto-tests against globally installed GSL, ignoring local headers. To do this, run CMake in the tests/ folder.

        cmake -B build -S tests -DGSL_CXX_STANDARD=14

    This feature should not break existing build recipes.
