### PR TITLE
Reintroduce CMake changes that were reverted in #966

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.1.3...3.16)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 include(guidelineSupportLibrary)
 
-project(GSL VERSION 3.1.0 LANGUAGES CXX)
-
-# Use GNUInstallDirs to provide the right locations on all platforms
-include(GNUInstallDirs)
+project(GSL
+    VERSION 3.1.0
+    LANGUAGES CXX
+)
 
 # Creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
@@ -25,6 +25,10 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(GSL_STANDALONE_PROJECT ON)
 endif()
 
+### Project options
+option(GSL_INSTALL "Generate and install GSL target" ${GSL_STANDALONE_PROJECT})
+option(GSL_TEST "Build and perform GSL tests" ${GSL_STANDALONE_PROJECT})
+
 # This GSL implementation generally assumes a platform that implements C++14 support.
 set(gsl_min_cxx_standard "14")
 
@@ -34,58 +38,21 @@ else()
     gsl_client_set_cxx_standard(${gsl_min_cxx_standard})
 endif()
 
-# add include folders to the library and targets that consume it
-# the SYSTEM keyword suppresses warnings for users of the library
-if(GSL_STANDALONE_PROJECT)
-    target_include_directories(GSL INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
-else()
-    target_include_directories(GSL SYSTEM INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
-endif()
+# Setup the include directory
+gsl_target_include_directories(${GSL_STANDALONE_PROJECT})
 
 # Add natvis file
 gsl_add_native_visualizer_support()
 
-install(TARGETS GSL EXPORT Microsoft.GSLConfig)
-install(
-    DIRECTORY include/gsl
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-# Make library importable by other projects
-install(EXPORT Microsoft.GSLConfig NAMESPACE Microsoft.GSL:: DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Microsoft.GSL)
-export(TARGETS GSL NAMESPACE Microsoft.GSL:: FILE Microsoft.GSLConfig.cmake)
+# Add packaging support
+gsl_create_packaging_file()
 
-# Add find_package() versioning support. The version for
-# generated Microsoft.GSLConfigVersion.cmake will be used from
-# last project() command. The version's compatibility is set between all
-# minor versions (as it was in prev. GSL releases).
-include(CMakePackageConfigHelpers)
-if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/Microsoft.GSLConfigVersion.cmake
-        COMPATIBILITY SameMajorVersion
-    )
-else()
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/Microsoft.GSLConfigVersion.cmake
-        COMPATIBILITY SameMajorVersion
-        ARCH_INDEPENDENT
-    )
+if (GSL_INSTALL)
+    # Setup install/export logic
+    gsl_install_logic()
 endif()
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Microsoft.GSLConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Microsoft.GSL)
 
-option(GSL_TEST "Generate tests." ${GSL_STANDALONE_PROJECT})
 if (GSL_TEST)
     enable_testing()
-    if(IOS)
-        add_compile_definitions(
-            GTEST_HAS_DEATH_TEST=1
-        )
-    endif()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(GSL
     LANGUAGES CXX
 )
 
+# Use GNUInstallDirs to provide the right locations on all platforms
+include(GNUInstallDirs)
+
 # Creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
 

--- a/cmake/guidelineSupportLibrary.cmake
+++ b/cmake/guidelineSupportLibrary.cmake
@@ -9,7 +9,7 @@ if (DEFINED guideline_support_library_include_guard)
 endif()
 set(guideline_support_library_include_guard ON)
 
-# Neccessary for 'write_basic_package_version_file'
+# Necessary for 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
 
 function(gsl_set_default_cxx_standard min_cxx_standard)
@@ -96,10 +96,6 @@ function(gsl_target_include_directories is_standalone)
 endfunction()
 
 function(gsl_install_logic)
-    # Use GNUInstallDirs to provide the right locations on all platforms
-    # NOTE: Including GNUInstallDirs automatically executes logic
-    include(GNUInstallDirs)
-
     install(TARGETS GSL EXPORT Microsoft.GSLConfig)
     install(
         DIRECTORY include/gsl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ find_package(Git REQUIRED QUIET)
 # will make visual studio generated project group files
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if(IOS)
+  add_compile_definitions(GTEST_HAS_DEATH_TEST=1)
+endif()
+
 pkg_search_module(GTestMain gtest_main)
 if (NOT GTestMain_FOUND)
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)


### PR DESCRIPTION
Reintroducing the changes from #964 by @hdf89shfdfs that were reverted in #966. @pr0g found that the change unintentionally removed a line from the Microsoft.GSLConfig.cmake file, which broke `FindPackage`.

I was able to restore the missing line in the config file by moving `include(GNUInstallDirs)` back to the main CMakeLists.txt file.