### PR TITLE
Minor cmake nitpicks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ project(GSL
     LANGUAGES CXX
 )
 
-# Use GNUInstallDirs to provide the right locations on all platforms
-include(GNUInstallDirs)
-
 # Creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
 
@@ -41,8 +38,8 @@ else()
     gsl_client_set_cxx_standard(${gsl_min_cxx_standard})
 endif()
 
-# Setup the include directory
-gsl_target_include_directories(${GSL_STANDALONE_PROJECT})
+# Setup include directory
+add_subdirectory(include)
 
 # Add natvis file
 gsl_add_native_visualizer_support()

--- a/cmake/guidelineSupportLibrary.cmake
+++ b/cmake/guidelineSupportLibrary.cmake
@@ -4,13 +4,20 @@
 # for multiple versions of cmake.
 #
 # Any functions/macros should have a gsl_* prefix to avoid problems
-if (DEFINED guideline_support_library_include_guard)
-    return()
+if (CMAKE_VERSION VERSION_GREATER 3.10 OR CMAKE_VERSION VERSION_EQUAL 3.10)
+    include_guard()
+else()
+    if (DEFINED guideline_support_library_include_guard)
+        return()
+    endif()
+    set(guideline_support_library_include_guard ON)
 endif()
-set(guideline_support_library_include_guard ON)
 
 # Necessary for 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
+
+# Use GNUInstallDirs to provide the right locations on all platforms
+include(GNUInstallDirs)
 
 function(gsl_set_default_cxx_standard min_cxx_standard)
     set(GSL_CXX_STANDARD "${min_cxx_standard}" CACHE STRING "Use c++ standard")
@@ -76,22 +83,6 @@ function(gsl_add_native_visualizer_support)
         if(GSL_VS_ADD_NATIVE_VISUALIZERS)
             target_sources(GSL INTERFACE $<BUILD_INTERFACE:${GSL_SOURCE_DIR}/GSL.natvis>)
         endif()
-    endif()
-endfunction()
-
-function(gsl_target_include_directories is_standalone)
-    # Add include folders to the library and targets that consume it
-    # the SYSTEM keyword suppresses warnings for users of the library
-    if(${is_standalone})
-        target_include_directories(GSL INTERFACE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        )
-    else()
-        target_include_directories(GSL SYSTEM INTERFACE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        )
     endif()
 endfunction()
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+# Add include folders to the library and targets that consume it
+# the SYSTEM keyword suppresses warnings for users of the library
+#
+# By adding this directory as an include directory the user gets a
+# namespace effect.
+#
+# IE:
+#   #include <gsl/gsl>
+if(GSL_STANDALONE_PROJECT)
+    target_include_directories(GSL INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+else()
+    target_include_directories(GSL SYSTEM INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+endif()


### PR DESCRIPTION
It's much nicer and less error prone to just use add_subdirectory to establish the include directory.

Hide the GNUInstallDirs module by placing it in the helper module. The intent being that the main CMakeLists.txt should have a little code as possible. So that readers can quickly understand the project.

Use include_guard() when available in cmake 3.10+