### PR TITLE
is_comparable_to_nullptr for better static_assert

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -38,7 +38,7 @@ template<typename T, typename = void>
 struct is_comparable_to_nullptr : std::false_type {};
 
 template <typename T>
-struct is_comparable_to_nullptr<T, std::is_convertible<decltype(std::declval<T>() != nullptr), bool>> : std::true_type {};
+struct is_comparable_to_nullptr<T, std::enable_if_t<std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value>> : std::true_type {};
 }   // namespace details
 
 //

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -32,6 +32,15 @@
 namespace gsl
 {
 
+namespace details
+{
+template<typename T, typename = void>
+struct is_comparable_to_nullptr : std::false_type {};
+
+template <typename T>
+struct is_comparable_to_nullptr<T, std::is_convertible<decltype(std::declval<T>() != nullptr), bool>> : std::true_type {};
+}   // namespace details
+
 //
 // GSL.owner: ownership pointers
 //
@@ -68,8 +77,7 @@ template <class T>
 class not_null
 {
 public:
-    static_assert(std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value,
-                  "T cannot be compared to nullptr.");
+    static_assert(details::is_comparable_to_nullptr<T>::value, "T cannot be compared to nullptr.");
 
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
     constexpr not_null(U&& u) : ptr_(std::forward<U>(u))


### PR DESCRIPTION
Trying `gsl::not_null<char> p2{ 0 };` on VS2019 the current implementation would trigger

>error C2446 : '!=' : no conversion from 'nullptr' to 'int'
>message: A native nullptr can only be converted to bool or , using reinterpret_cast, to an integral type
>message: see reference to class template instantiation 'gsl::not_null<char>' being compiled
>error C2955 : 'std::is_convertible' : use of class template requires template argument list
>message: see declaration of 'std::is_convertible'
>error C2039 : 'value' : is not a member of 'std::is_convertible<_From,_To>'
>error C2065 : 'value' : undeclared identifier


The new implementation gives much shorter and clearer message and does exactly as the `static_assert` intends to do:

> error C2338: T cannot be compared to nullptr.
> message : see reference to class template instantiation 'gsl::not_null<char *>' being compiled