### PR TITLE
gsl::at behavior change regarding gsl::span

### DIFF
--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -22,6 +22,7 @@
 // Currently terminate is a no-op in this mode, so we add termination behavior back
 //
 #if defined(_MSC_VER) && (defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS))
+#define GSL_KERNEL_MODE
 
 #define GSL_MSVC_USE_STL_NOEXCEPTION_WORKAROUND
 #include <intrin.h>

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -1,3 +1,4 @@
 #pragma once
-#pragma message("This header will soon be removed. Use <gsl/algorithm> instead of <gsl/gsl_algorithm>")
+#pragma message(                                                                                   \
+    "This header will soon be removed. Use <gsl/algorithm> instead of <gsl/gsl_algorithm>")
 #include <gsl/algorithm>

--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -30,7 +30,7 @@ template <class T, class U>
 // clang-format off
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
 GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recognise noexcept(false)
-// clang-format on
+    // clang-format on
     constexpr T narrow(U u) noexcept(false)
 {
     constexpr const bool is_different_signedness =

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -34,12 +34,19 @@ namespace gsl
 
 namespace details
 {
-template<typename T, typename = void>
-struct is_comparable_to_nullptr : std::false_type {};
+    template <typename T, typename = void>
+    struct is_comparable_to_nullptr : std::false_type
+    {
+    };
 
-template <typename T>
-struct is_comparable_to_nullptr<T, std::enable_if_t<std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value>> : std::true_type {};
-}   // namespace details
+    template <typename T>
+    struct is_comparable_to_nullptr<
+        T,
+        std::enable_if_t<std::is_convertible<decltype(std::declval<T>() != nullptr), bool>::value>>
+        : std::true_type
+    {
+    };
+} // namespace details
 
 //
 // GSL.owner: ownership pointers

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -25,6 +25,7 @@
 #include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
 #include <iterator>    // for reverse_iterator, distance, random_access_...
 #include <type_traits> // for enable_if_t, declval, is_convertible, inte...
+#include <gsl/span_ext>    // for span specialization of gsl::at and other span-related extensions
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
@@ -59,12 +60,6 @@
 
 namespace gsl
 {
-
-// [views.constants], constants
-constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
-
-template <class ElementType, std::size_t Extent = dynamic_extent>
-class span;
 
 // implementation details
 namespace details
@@ -810,15 +805,6 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
     // clang-format on
     return type{reinterpret_cast<byte*>(s.data()), s.size_bytes()};
-}
-
-// Specialization of gsl::at for span
-template <class ElementType, std::size_t Extent>
-constexpr ElementType& at(span<ElementType, Extent>& s, index i)
-{
-    // No bounds checking here because it is done in span::operator[] called below
-    Ensures(i >= 0);
-    return s[narrow_cast<std::size_t>(i)];
 }
 
 } // namespace gsl

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -21,11 +21,11 @@
 #include <gsl/byte>   // for byte
 #include <gsl/util>   // for narrow_cast
 
-#include <array>       // for array
-#include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
-#include <iterator>    // for reverse_iterator, distance, random_access_...
-#include <type_traits> // for enable_if_t, declval, is_convertible, inte...
-#include <gsl/span_ext>    // for span specialization of gsl::at and other span-related extensions
+#include <array>        // for array
+#include <cstddef>      // for ptrdiff_t, size_t, nullptr_t
+#include <gsl/span_ext> // for span specialization of gsl::at and other span-related extensions
+#include <iterator>     // for reverse_iterator, distance, random_access_...
+#include <type_traits>  // for enable_if_t, declval, is_convertible, inte...
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -812,6 +812,15 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
     return type{reinterpret_cast<byte*>(s.data()), s.size_bytes()};
 }
 
+// Specialization of gsl::at for span
+template <class ElementType, std::size_t Extent>
+constexpr ElementType& at(span<ElementType, Extent>& s, index i)
+{
+    // No bounds checking here because it is done in span::operator[] called below
+    Ensures(i >= 0);
+    return s[narrow_cast<std::size_t>(i)];
+}
+
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -119,15 +119,6 @@ constexpr span<typename Ptr::element_type> make_span(Ptr& cont)
     return span<typename Ptr::element_type>(cont);
 }
 
-// Specialization of gsl::at for span
-template <class ElementType, std::size_t Extent>
-constexpr ElementType& at(span<ElementType, Extent> s, index i)
-{
-    // No bounds checking here because it is done in span::operator[] called below
-    Ensures(i >= 0);
-    return s[narrow_cast<std::size_t>(i)];
-}
-
 // [span.obs] Free observer functions
 template <class ElementType, std::size_t Extent>
 constexpr std::ptrdiff_t ssize(const span<ElementType, Extent>& s) noexcept

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -27,15 +27,28 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <gsl/span> // for span
 #include <gsl/util> // for narrow_cast, narrow
+#include <gsl/assert> // GSL_KERNEL_MODE
 
-#include <algorithm> // for lexicographical_compare
 #include <cstddef>   // for ptrdiff_t, size_t
 #include <utility>
 
+#ifndef GSL_KERNEL_MODE
+#include <algorithm> // for lexicographical_compare
+#endif // GSL_KERNEL_MODE
+
 namespace gsl
 {
+
+// [span.views.constants], constants
+constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
+
+template <class ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+// std::equal and std::lexicographical_compare are not /kernel compatible 
+// so all comparison operators must be removed for kernel mode.
+#ifndef GSL_KERNEL_MODE
 
 // [span.comparison], span comparison operators
 template <class ElementType, std::size_t FirstExtent, std::size_t SecondExtent>
@@ -73,6 +86,8 @@ constexpr bool operator>=(span<ElementType, Extent> l, span<ElementType, Extent>
 {
     return !(l < r);
 }
+
+#endif // GSL_KERNEL_MODE
 
 //
 // make_span() - Utility functions for creating spans
@@ -117,6 +132,15 @@ template <class Ptr>
 constexpr span<typename Ptr::element_type> make_span(Ptr& cont)
 {
     return span<typename Ptr::element_type>(cont);
+}
+
+// Specialization of gsl::at for span
+template <class ElementType, std::size_t Extent>
+constexpr ElementType& at(span<ElementType, Extent> s, index i)
+{
+    // No bounds checking here because it is done in span::operator[] called below
+    Ensures(i >= 0);
+    return s[narrow_cast<std::size_t>(i)];
 }
 
 // [span.obs] Free observer functions

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -27,15 +27,15 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <gsl/util> // for narrow_cast, narrow
 #include <gsl/assert> // GSL_KERNEL_MODE
+#include <gsl/util>   // for narrow_cast, narrow
 
-#include <cstddef>   // for ptrdiff_t, size_t
+#include <cstddef> // for ptrdiff_t, size_t
 #include <utility>
 
 #ifndef GSL_KERNEL_MODE
 #include <algorithm> // for lexicographical_compare
-#endif // GSL_KERNEL_MODE
+#endif               // GSL_KERNEL_MODE
 
 namespace gsl
 {
@@ -46,7 +46,7 @@ constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
 template <class ElementType, std::size_t Extent = dynamic_extent>
 class span;
 
-// std::equal and std::lexicographical_compare are not /kernel compatible 
+// std::equal and std::lexicographical_compare are not /kernel compatible
 // so all comparison operators must be removed for kernel mode.
 #ifndef GSL_KERNEL_MODE
 

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -25,6 +25,10 @@
 #include <type_traits>      // for is_signed, integral_constant
 #include <utility>          // for exchange, forward
 
+#if defined(__cplusplus) && __cplusplus >= 202002L
+#include <span>
+#endif // __cplusplus >= 202002L
+
 #if defined(_MSC_VER) && !defined(__clang__)
 
 #pragma warning(push)
@@ -111,13 +115,13 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }
-
+    
 template <class Cont>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
 // clang-format on
-    constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
+constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     using size_type = decltype(cont.size());
@@ -134,6 +138,14 @@ constexpr T at(const std::initializer_list<T> cont, const index i)
     return *(cont.begin() + i);
 }
 
+#if defined(__cplusplus) && __cplusplus >= 202002L
+template <class T, size_t extent = std::dynamic_extent>
+constexpr auto at(std::span<T, extent> sp, const index i)
+{
+    Expects(i >= 0 && i < narrow_cast<i>(sp.size()));
+    return sp[i];
+}
+#endif // __cplusplus >= 202002L
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -96,8 +96,8 @@ finally(F&& f) noexcept
 template <class T, class U>
 // clang-format off
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
-// clang-format on
-constexpr T narrow_cast(U&& u) noexcept
+    // clang-format on
+    constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
@@ -109,19 +109,19 @@ template <class T, std::size_t N>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-// clang-format on
+    // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }
-    
+
 template <class Cont>
 // clang-format off
 GSL_SUPPRESS(bounds.4) // NO-FORMAT: attribute
 GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
-// clang-format on
-constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
+    // clang-format on
+    constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     using size_type = decltype(cont.size());
@@ -131,8 +131,8 @@ constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 template <class T>
 // clang-format off
 GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
-// clang-format on
-constexpr T at(const std::initializer_list<T> cont, const index i)
+    // clang-format on
+    constexpr T at(const std::initializer_list<T> cont, const index i)
 {
     Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     return *(cont.begin() + i);

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -14,11 +14,11 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <gtest/gtest.h>
+#include <array>         // for array
+#include <cstddef>       // for size_t
 #include <gsl/algorithm> // for copy
-#include <gsl/span>          // for span
-#include <array>   // for array
-#include <cstddef> // for size_t
+#include <gsl/span>      // for span
+#include <gtest/gtest.h>
 
 #include "deathTestCommon.h"
 

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -20,10 +20,7 @@
 #include <array>   // for array
 #include <cstddef> // for size_t
 
-namespace
-{
-    static constexpr char deathstring[] = "Expected Death";
-}
+#include "deathTestCommon.h"
 
 namespace gsl
 {
@@ -204,10 +201,11 @@ TEST(algorithm_tests, incompatible_type)
 
 TEST(algorithm_tests, small_destination_span)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. small_destination_span";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     std::array<int, 12> src{1, 2, 3, 4};
     std::array<int, 4> dst{};
@@ -217,9 +215,9 @@ TEST(algorithm_tests, small_destination_span)
     const span<int> dst_span_dyn(dst);
     const span<int, 4> dst_span_static(dst);
 
-    EXPECT_DEATH(copy(src_span_dyn, dst_span_dyn), deathstring);
-    EXPECT_DEATH(copy(src_span_dyn, dst_span_static), deathstring);
-    EXPECT_DEATH(copy(src_span_static, dst_span_dyn), deathstring);
+    EXPECT_DEATH(copy(src_span_dyn, dst_span_dyn), expected);
+    EXPECT_DEATH(copy(src_span_dyn, dst_span_static), expected);
+    EXPECT_DEATH(copy(src_span_static, dst_span_dyn), expected);
 
 #ifdef CONFIRM_COMPILATION_ERRORS
     copy(src_span_static, dst_span_static);

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 #include <gsl/assert> // for fail_fast (ptr only), Ensures, Expects
+#include "deathTestCommon.h"
 
 using namespace gsl;
 
 namespace
 {
-static constexpr char deathstring[] = "Expected Death";
 
 int f(int i)
 {
@@ -39,23 +39,23 @@ int g(int i)
 
 TEST(assertion_tests, expects)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. expects";
         std::abort();
     });
 
     EXPECT_TRUE(f(2) == 2);
-    EXPECT_DEATH(f(10), deathstring);
+    EXPECT_DEATH(f(10), GetExpectedDeathString(terminateHandler));
 }
 
 
 TEST(assertion_tests, ensures)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. ensures";
         std::abort();
     });
 
     EXPECT_TRUE(g(2) == 3);
-    EXPECT_DEATH(g(9), deathstring);
+    EXPECT_DEATH(g(9), GetExpectedDeathString(terminateHandler));
 }

--- a/tests/assertion_tests.cpp
+++ b/tests/assertion_tests.cpp
@@ -14,9 +14,9 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <gtest/gtest.h>
-#include <gsl/assert> // for fail_fast (ptr only), Ensures, Expects
 #include "deathTestCommon.h"
+#include <gsl/assert> // for fail_fast (ptr only), Ensures, Expects
+#include <gtest/gtest.h>
 
 using namespace gsl;
 
@@ -47,7 +47,6 @@ TEST(assertion_tests, expects)
     EXPECT_TRUE(f(2) == 2);
     EXPECT_DEATH(f(10), GetExpectedDeathString(terminateHandler));
 }
-
 
 TEST(assertion_tests, ensures)
 {

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -33,7 +33,8 @@ TEST(at_tests, static_array)
     int a[4] = {1, 2, 3, 4};
     const int(&c_a)[4] = a;
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         EXPECT_TRUE(&gsl::at(a, i) == &a[i]);
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[i]);
     }
@@ -55,7 +56,8 @@ TEST(at_tests, std_array)
     std::array<int, 4> a = {1, 2, 3, 4};
     const std::array<int, 4>& c_a = a;
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         EXPECT_TRUE(&gsl::at(a, i) == &a[static_cast<std::size_t>(i)]);
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[static_cast<std::size_t>(i)]);
     }
@@ -77,7 +79,8 @@ TEST(at_tests, std_vector)
     std::vector<int> a = {1, 2, 3, 4};
     const std::vector<int>& c_a = a;
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         EXPECT_TRUE(&gsl::at(a, i) == &a[static_cast<std::size_t>(i)]);
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[static_cast<std::size_t>(i)]);
     }
@@ -98,7 +101,8 @@ TEST(at_tests, InitializerList)
 {
     const std::initializer_list<int> a = {1, 2, 3, 4};
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         EXPECT_TRUE(gsl::at(a, i) == i + 1);
         EXPECT_TRUE(gsl::at({1, 2, 3, 4}, i) == i + 1);
     }
@@ -118,13 +122,13 @@ TEST(at_tests, InitializerList)
 #if defined(__cplusplus) && __cplusplus >= 202002L
 TEST(at_tests, std_span)
 {
-    std::vector<int> vec {1,2,3,4,5};
+    std::vector<int> vec{1, 2, 3, 4, 5};
     std::span sp{vec};
 
-    std::vector<int> cvec {1,2,3,4,5};
+    std::vector<int> cvec{1, 2, 3, 4, 5};
     std::span csp{cvec};
 
-    for(size_t i = 0, i < vec.size(); ++i)
+    for (size_t i = 0, i < vec.size(); ++i)
     {
         EXPECT_TRUE(&gsl::at(sp, i) == &vec[i]);
         EXPECT_TRUE(&gsl::at(csp, i) == &cvec[i]);
@@ -145,7 +149,8 @@ static constexpr bool test_constexpr()
     std::array<int, 4> a2 = {1, 2, 3, 4};
     const std::array<int, 4>& c_a2 = a2;
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i)
+    {
         if (&gsl::at(a1, i) != &a1[i]) return false;
         if (&gsl::at(c_a1, i) != &a1[i]) return false;
         // requires C++17:

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -22,11 +22,11 @@
 #include <cstddef>          // for size_t
 #include <initializer_list> // for initializer_list
 #include <vector>           // for vector
+#if defined(__cplusplus) && __cplusplus >= 202002L
+#include <span>
+#endif // __cplusplus >= 202002L
 
-namespace
-{
-    static constexpr char deathstring[] = "Expected Death";
-}
+#include "deathTestCommon.h"
 
 TEST(at_tests, static_array)
 {
@@ -38,15 +38,16 @@ TEST(at_tests, static_array)
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[i]);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. static_array";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
-    EXPECT_DEATH(gsl::at(a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(a, 4), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, 4), deathstring);
+    EXPECT_DEATH(gsl::at(a, -1), expected);
+    EXPECT_DEATH(gsl::at(a, 4), expected);
+    EXPECT_DEATH(gsl::at(c_a, -1), expected);
+    EXPECT_DEATH(gsl::at(c_a, 4), expected);
 }
 
 TEST(at_tests, std_array)
@@ -59,15 +60,16 @@ TEST(at_tests, std_array)
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[static_cast<std::size_t>(i)]);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. std_array";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
-    EXPECT_DEATH(gsl::at(a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(a, 4), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, 4), deathstring);
+    EXPECT_DEATH(gsl::at(a, -1), expected);
+    EXPECT_DEATH(gsl::at(a, 4), expected);
+    EXPECT_DEATH(gsl::at(c_a, -1), expected);
+    EXPECT_DEATH(gsl::at(c_a, 4), expected);
 }
 
 TEST(at_tests, std_vector)
@@ -80,15 +82,16 @@ TEST(at_tests, std_vector)
         EXPECT_TRUE(&gsl::at(c_a, i) == &a[static_cast<std::size_t>(i)]);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. std_vector";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
-    EXPECT_DEATH(gsl::at(a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(a, 4), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(c_a, 4), deathstring);
+    EXPECT_DEATH(gsl::at(a, -1), expected);
+    EXPECT_DEATH(gsl::at(a, 4), expected);
+    EXPECT_DEATH(gsl::at(c_a, -1), expected);
+    EXPECT_DEATH(gsl::at(c_a, 4), expected);
 }
 
 TEST(at_tests, InitializerList)
@@ -100,16 +103,39 @@ TEST(at_tests, InitializerList)
         EXPECT_TRUE(gsl::at({1, 2, 3, 4}, i) == i + 1);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. InitializerList";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
-    EXPECT_DEATH(gsl::at(a, -1), deathstring);
-    EXPECT_DEATH(gsl::at(a, 4), deathstring);
-    EXPECT_DEATH(gsl::at({1, 2, 3, 4}, -1), deathstring);
-    EXPECT_DEATH(gsl::at({1, 2, 3, 4}, 4), deathstring);
+    EXPECT_DEATH(gsl::at(a, -1), expected);
+    EXPECT_DEATH(gsl::at(a, 4), expected);
+    EXPECT_DEATH(gsl::at({1, 2, 3, 4}, -1), expected);
+    EXPECT_DEATH(gsl::at({1, 2, 3, 4}, 4), expected);
 }
+
+#if defined(__cplusplus) && __cplusplus >= 202002L
+TEST(at_tests, std_span)
+{
+    std::vector<int> vec {1,2,3,4,5};
+    std::span sp{vec};
+
+    std::vector<int> cvec {1,2,3,4,5};
+    std::span csp{cvec};
+
+    for(size_t i = 0, i < vec.size(); ++i)
+    {
+        EXPECT_TRUE(&gsl::at(sp, i) == &vec[i]);
+        EXPECT_TRUE(&gsl::at(csp, i) == &cvec[i]);
+    }
+
+    EXPECT_DEATH(gsl::at(sp, -1), expected);
+    EXPECT_DEATH(gsl::at(sp, sp.size()), expected);
+    EXPECT_DEATH(gsl::at(csp, -1), expected);
+    EXPECT_DEATH(gsl::at(csp, sp.size()), expected);
+}
+#endif // __cplusplus >= 202002L
 
 #if !defined(_MSC_VER) || defined(__clang__) || _MSC_VER >= 1910
 static constexpr bool test_constexpr()

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -37,7 +37,9 @@ TEST(byte_tests, construction)
         EXPECT_TRUE(static_cast<unsigned char>(b) == 4);
     }
 
+    // clang-format off
     GSL_SUPPRESS(es.49)
+    // clang-format on
     {
         const byte b = byte(12);
         EXPECT_TRUE(static_cast<unsigned char>(b) == 12);
@@ -55,7 +57,7 @@ TEST(byte_tests, construction)
 
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
     {
-        const byte b { 14 };
+        const byte b{14};
         EXPECT_TRUE(static_cast<unsigned char>(b) == 14);
     }
 #endif
@@ -122,7 +124,7 @@ TEST(byte_tests, aliasing)
     EXPECT_TRUE(res == i);
 }
 
-}
+} // namespace
 
 #ifdef CONFIRM_COMPILATION_ERRORS
 copy(src_span_static, dst_span_static);

--- a/tests/deathTestCommon.h
+++ b/tests/deathTestCommon.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <gsl/assert>
+
+constexpr char deathstring[] = "Expected Death";
+constexpr char failed_set_terminate_deathstring[] = ".*";
+
+// This prevents a failed call to set_terminate from failing the test suite.
+constexpr const char* GetExpectedDeathString(std::terminate_handler handle)
+{
+    return handle ? deathstring : failed_set_terminate_deathstring;
+}

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -25,12 +25,8 @@
 #include <string>    // for basic_string, operator==, string, operator<<
 #include <typeinfo>  // for type_info
 
+#include "deathTestCommon.h"
 using namespace gsl;
-
-namespace
-{
-constexpr char deathstring[] = "Expected Death";
-} // namespace
 
 struct MyBase
 {
@@ -145,10 +141,12 @@ TEST(notnull_tests, TestNotNullConstructors)
 #endif
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. TestNotNullConstructors";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     {
         // from shared pointer
         int i = 12;
@@ -160,7 +158,7 @@ TEST(notnull_tests, TestNotNullConstructors)
             std::make_shared<int>(10)); // shared_ptr<int> is nullptr assignable
 
         int* pi = nullptr;
-        EXPECT_DEATH((not_null<decltype(pi)>(pi)), deathstring);
+        EXPECT_DEATH((not_null<decltype(pi)>(pi)), expected);
     }
 
     {
@@ -217,8 +215,8 @@ TEST(notnull_tests, TestNotNullConstructors)
     {
         // from returned pointer
 
-        EXPECT_DEATH(helper(return_pointer()), deathstring);
-        EXPECT_DEATH(helper_const(return_pointer()), deathstring);
+        EXPECT_DEATH(helper(return_pointer()), expected);
+        EXPECT_DEATH(helper_const(return_pointer()), expected);
     }
 }
 
@@ -278,17 +276,18 @@ TEST(notnull_tests, TestNotNullCasting)
 
 TEST(notnull_tests, TestNotNullAssignment)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. TestNotNullAssignmentd";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     int i = 12;
     not_null<int*> p(&i);
     EXPECT_TRUE(helper(p));
 
     int* q = nullptr;
-    EXPECT_DEATH(p = not_null<int*>(q), deathstring);
+    EXPECT_DEATH(p = not_null<int*>(q), expected);
 }
 
 TEST(notnull_tests, TestNotNullRawPointerComparison)
@@ -437,17 +436,18 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         EXPECT_TRUE(*x == 42);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. TestNotNullConstructorTypeDeduction";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     {
         auto workaround_macro = []() {
             int* p1 = nullptr;
             const not_null x{p1};
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
@@ -455,14 +455,14 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
             const int* p1 = nullptr;
             const not_null x{p1};
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
         int* p = nullptr;
 
-        EXPECT_DEATH(helper(not_null{p}), deathstring);
-        EXPECT_DEATH(helper_const(not_null{p}), deathstring);
+        EXPECT_DEATH(helper(not_null{p}), expected);
+        EXPECT_DEATH(helper_const(not_null{p}), expected);
     }
 
 #ifdef CONFIRM_COMPILATION_ERRORS
@@ -498,10 +498,11 @@ TEST(notnull_tests, TestMakeNotNull)
         EXPECT_TRUE(*x == 42);
     }
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. TestMakeNotNull";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     {
         const auto workaround_macro = []() {
@@ -509,7 +510,7 @@ TEST(notnull_tests, TestMakeNotNull)
             const auto x = make_not_null(p1);
             EXPECT_TRUE(*x == 42);
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
@@ -518,21 +519,21 @@ TEST(notnull_tests, TestMakeNotNull)
             const auto x = make_not_null(p1);
             EXPECT_TRUE(*x == 42);
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
         int* p = nullptr;
 
-        EXPECT_DEATH(helper(make_not_null(p)), deathstring);
-        EXPECT_DEATH(helper_const(make_not_null(p)), deathstring);
+        EXPECT_DEATH(helper(make_not_null(p)), expected);
+        EXPECT_DEATH(helper_const(make_not_null(p)), expected);
     }
 
 #ifdef CONFIRM_COMPILATION_ERRORS
     {
-        EXPECT_DEATH(make_not_null(nullptr), deathstring);
-        EXPECT_DEATH(helper(make_not_null(nullptr)), deathstring);
-        EXPECT_DEATH(helper_const(make_not_null(nullptr)), deathstring);
+        EXPECT_DEATH(make_not_null(nullptr), expected);
+        EXPECT_DEATH(helper(make_not_null(nullptr)), expected);
+        EXPECT_DEATH(helper_const(make_not_null(nullptr)), expected);
     }
 #endif
 }

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -60,7 +60,9 @@ struct CustomPtr
 template <typename T, typename U>
 std::string operator==(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) == reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                           : "false";
 }
@@ -68,7 +70,9 @@ std::string operator==(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 template <typename T, typename U>
 std::string operator!=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) != reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                           : "false";
 }
@@ -76,7 +80,9 @@ std::string operator!=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 template <typename T, typename U>
 std::string operator<(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) < reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                          : "false";
 }
@@ -84,7 +90,9 @@ std::string operator<(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 template <typename T, typename U>
 std::string operator>(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) > reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                          : "false";
 }
@@ -92,7 +100,9 @@ std::string operator>(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 template <typename T, typename U>
 std::string operator<=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) <= reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                           : "false";
 }
@@ -100,7 +110,9 @@ std::string operator<=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 template <typename T, typename U>
 std::string operator>=(CustomPtr<T> const& lhs, CustomPtr<U> const& rhs)
 {
+    // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
+    // clang-format on
     return reinterpret_cast<const void*>(lhs.p_) >= reinterpret_cast<const void*>(rhs.p_) ? "true"
                                                                                           : "false";
 }
@@ -116,9 +128,13 @@ struct NonCopyableNonMovable
 
 namespace
 {
-GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format off
+GSL_SUPPRESS(f .4) // NO-FORMAT: attribute
+// clang-format on
 bool helper(not_null<int*> p) { return *p == 12; }
-GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format off
+GSL_SUPPRESS(f .4) // NO-FORMAT: attribute
+// clang-format on
 bool helper_const(not_null<const int*> p) { return *p == 12; }
 
 int* return_pointer() { return nullptr; }

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -20,7 +20,7 @@
 
 using namespace gsl;
 
-GSL_SUPPRESS(f.23) // NO-FORMAT: attribute
+GSL_SUPPRESS(f .23) // NO-FORMAT: attribute
 void f(int* i) { *i += 1; }
 
 TEST(owner_tests, basic_test)
@@ -34,10 +34,10 @@ TEST(owner_tests, basic_test)
 
 TEST(owner_tests, check_pointer_constraint)
 {
-    #ifdef CONFIRM_COMPILATION_ERRORS
+#ifdef CONFIRM_COMPILATION_ERRORS
     {
         owner<int> integerTest = 10;
         owner<std::shared_ptr<int>> sharedPtrTest(new int(10));
     }
-    #endif
+#endif
 }

--- a/tests/span_compatibility_tests.cpp
+++ b/tests/span_compatibility_tests.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <gsl/byte> // for byte
-#include <gsl/span>     // for span, span_iterator, operator==, operator!=
+#include <gsl/span> // for span, span_iterator, operator==, operator!=
 
 #include <array>       // for array
 #include <cstddef>     // for ptrdiff_t

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <gsl/util> // for narrow_cast, at
-#include <gsl/span_ext> // for operator==, operator!=, make_span
+#include <gsl/span> // for span and span_ext
 
 #include <array>       // for array
 #include <iostream>    // for cerr
@@ -26,17 +26,16 @@
 using namespace std;
 using namespace gsl;
 
-namespace
-{
-static constexpr char deathstring[] = "Expected Death";
-} // namespace
+#include "deathTestCommon.h"
 
 TEST(span_ext_test, make_span_from_pointer_length_constructor)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. from_pointer_length_constructor";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     int arr[4] = {1, 2, 3, 4};
 
     {
@@ -57,7 +56,7 @@ TEST(span_ext_test, make_span_from_pointer_length_constructor)
     {
         int* p = nullptr;
         auto workaround_macro = [=]() { make_span(p, 2); };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 }
 
@@ -112,249 +111,252 @@ TEST(span_ext_test, make_span_from_array_constructor)
      }
  }
 
- TEST(span_ext_test, make_span_from_dynamic_array_constructor)
- {
-     double(*arr)[3][4] = new double[100][3][4];
+TEST(span_ext_test, make_span_from_dynamic_array_constructor)
+{
+    double(*arr)[3][4] = new double[100][3][4];
 
-     {
-         auto s = make_span(&arr[0][0][0], 10);
-         EXPECT_TRUE(s.size() == 10);
-         EXPECT_TRUE(s.data() == &arr[0][0][0]);
-     }
+    {
+        auto s = make_span(&arr[0][0][0], 10);
+        EXPECT_TRUE(s.size() == 10);
+        EXPECT_TRUE(s.data() == &arr[0][0][0]);
+    }
 
-     delete[] arr;
- }
+    delete[] arr;
+}
 
- TEST(span_ext_test, make_span_from_std_array_constructor)
- {
-     std::array<int, 4> arr = {1, 2, 3, 4};
+TEST(span_ext_test, make_span_from_std_array_constructor)
+{
+    std::array<int, 4> arr = {1, 2, 3, 4};
 
-     {
-         auto s = make_span(arr);
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        auto s = make_span(arr);
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     // This test checks for the bug found in gcc 6.1, 6.2, 6.3, 6.4, 6.5 7.1, 7.2, 7.3 - issue #590
-     {
-         span<int> s1 = make_span(arr);
+    // This test checks for the bug found in gcc 6.1, 6.2, 6.3, 6.4, 6.5 7.1, 7.2, 7.3 - issue #590
+    {
+        span<int> s1 = make_span(arr);
 
-         static span<int> s2;
-         s2 = s1;
+        static span<int> s2;
+        s2 = s1;
 
- #if defined(__GNUC__) && __GNUC__ == 6 && (__GNUC_MINOR__ == 4 || __GNUC_MINOR__ == 5) &&          \
-     __GNUC_PATCHLEVEL__ == 0 && defined(__OPTIMIZE__)
-         // Known to be broken in gcc 6.4 and 6.5 with optimizations
-         // Issue in gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83116
-         EXPECT_TRUE(s1.size() == 4);
-         EXPECT_TRUE(s2.size() == 0);
- #else
-         EXPECT_TRUE(s1.size() == s2.size());
- #endif
-     }
- }
+#if defined(__GNUC__) && __GNUC__ == 6 && (__GNUC_MINOR__ == 4 || __GNUC_MINOR__ == 5) &&          \
+    __GNUC_PATCHLEVEL__ == 0 && defined(__OPTIMIZE__)
+        // Known to be broken in gcc 6.4 and 6.5 with optimizations
+        // Issue in gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83116
+        EXPECT_TRUE(s1.size() == 4);
+        EXPECT_TRUE(s2.size() == 0);
+#else
+        EXPECT_TRUE(s1.size() == s2.size());
+#endif
+    }
+}
 
- TEST(span_ext_test, make_span_from_const_std_array_constructor)
- {
-     const std::array<int, 4> arr = {1, 2, 3, 4};
+TEST(span_ext_test, make_span_from_const_std_array_constructor)
+{
+    const std::array<int, 4> arr = {1, 2, 3, 4};
 
-     {
-         auto s = make_span(arr);
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
- }
+    {
+        auto s = make_span(arr);
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
+}
 
- TEST(span_ext_test, make_span_from_std_array_const_constructor)
- {
-     std::array<const int, 4> arr = {1, 2, 3, 4};
+TEST(span_ext_test, make_span_from_std_array_const_constructor)
+{
+    std::array<const int, 4> arr = {1, 2, 3, 4};
 
-     {
-         auto s = make_span(arr);
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
- }
+    {
+        auto s = make_span(arr);
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
+}
 
- TEST(span_ext_test, make_span_from_container_constructor)
- {
-     std::vector<int> v = {1, 2, 3};
-     const std::vector<int> cv = v;
+TEST(span_ext_test, make_span_from_container_constructor)
+{
+    std::vector<int> v = {1, 2, 3};
+    const std::vector<int> cv = v;
 
-     {
-         auto s = make_span(v);
-         EXPECT_TRUE(s.size() == v.size());
-         EXPECT_TRUE(s.data() == v.data());
+    {
+        auto s = make_span(v);
+        EXPECT_TRUE(s.size() == v.size());
+        EXPECT_TRUE(s.data() == v.data());
 
-         auto cs = make_span(cv);
-         EXPECT_TRUE(cs.size() == cv.size());
-         EXPECT_TRUE(cs.data() == cv.data());
-     }
- }
+        auto cs = make_span(cv);
+        EXPECT_TRUE(cs.size() == cv.size());
+        EXPECT_TRUE(cs.data() == cv.data());
+    }
+}
 
- TEST(span_test, interop_with_gsl_at)
- {
-     int arr[5] = {1, 2, 3, 4, 5};
-     span<int> s{arr};
-     EXPECT_TRUE(at(s, 0) ==  1);
-     EXPECT_TRUE(at(s, 1) == 2);
- }
+TEST(span_test, interop_with_gsl_at)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
+    span<int> s{arr};
+    EXPECT_TRUE(at(s, 0) ==  1);
+    EXPECT_TRUE(at(s, 1) == 2);
+}
 
- TEST(span_ext_test, iterator_free_functions)
- {
-     int a[] = {1, 2, 3, 4};
-     span<int> s{a};
+TEST(span_ext_test, iterator_free_functions)
+{
+    int a[] = {1, 2, 3, 4};
+    span<int> s{a};
 
-     EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
 
-     EXPECT_TRUE((std::is_same<decltype(std::cbegin(s)), decltype(cbegin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(std::cend(s)), decltype(cend(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(std::cbegin(s)), decltype(cbegin(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(std::cend(s)), decltype(cend(s))>::value));
 
-     EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(s.rbegin()), decltype(rbegin(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(s.rend()), decltype(rend(s))>::value));
 
-     EXPECT_TRUE((std::is_same<decltype(std::crbegin(s)), decltype(crbegin(s))>::value));
-     EXPECT_TRUE((std::is_same<decltype(std::crend(s)), decltype(crend(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(std::crbegin(s)), decltype(crbegin(s))>::value));
+    EXPECT_TRUE((std::is_same<decltype(std::crend(s)), decltype(crend(s))>::value));
 
-     EXPECT_TRUE(s.begin() == begin(s));
-     EXPECT_TRUE(s.end() == end(s));
+    EXPECT_TRUE(s.begin() == begin(s));
+    EXPECT_TRUE(s.end() == end(s));
 
-     EXPECT_TRUE(s.rbegin() == rbegin(s));
-     EXPECT_TRUE(s.rend() == rend(s));
+    EXPECT_TRUE(s.rbegin() == rbegin(s));
+    EXPECT_TRUE(s.rend() == rend(s));
 
-     EXPECT_TRUE(s.begin() == cbegin(s));
-     EXPECT_TRUE(s.end() == cend(s));
+    EXPECT_TRUE(s.begin() == cbegin(s));
+    EXPECT_TRUE(s.end() == cend(s));
 
-     EXPECT_TRUE(s.rbegin() == crbegin(s));
-     EXPECT_TRUE(s.rend() == crend(s));
- }
+    EXPECT_TRUE(s.rbegin() == crbegin(s));
+    EXPECT_TRUE(s.rend() == crend(s));
+}
 
- TEST(span_ext_test, ssize_free_function)
- {
-     int a[] = {1, 2, 3, 4};
-     span<int> s{a};
+TEST(span_ext_test, ssize_free_function)
+{
+    int a[] = {1, 2, 3, 4};
+    span<int> s{a};
 
-     EXPECT_FALSE((std::is_same<decltype(s.size()), decltype(ssize(s))>::value));
-     EXPECT_TRUE(s.size() == static_cast<std::size_t>(ssize(s)));
- }
+    EXPECT_FALSE((std::is_same<decltype(s.size()), decltype(ssize(s))>::value));
+    EXPECT_TRUE(s.size() == static_cast<std::size_t>(ssize(s)));
+}
 
-  TEST(span_ext_test, comparison_operators)
- {
-     {
-         span<int> s1;
-         span<int> s2;
-         EXPECT_TRUE(s1 == s2);
-         EXPECT_FALSE(s1 != s2);
-         EXPECT_FALSE(s1 < s2);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s1 >= s2);
-         EXPECT_TRUE(s2 == s1);
-         EXPECT_FALSE(s2 != s1);
-         EXPECT_FALSE(s2 != s1);
-         EXPECT_TRUE(s2 <= s1);
-         EXPECT_FALSE(s2 > s1);
-         EXPECT_TRUE(s2 >= s1);
-     }
+#ifndef GSL_KERNEL_MODE
+TEST(span_ext_test, comparison_operators)
+{
+    {
+        span<int> s1;
+        span<int> s2;
+        EXPECT_TRUE(s1 == s2);
+        EXPECT_FALSE(s1 != s2);
+        EXPECT_FALSE(s1 < s2);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s1 >= s2);
+        EXPECT_TRUE(s2 == s1);
+        EXPECT_FALSE(s2 != s1);
+        EXPECT_FALSE(s2 != s1);
+        EXPECT_TRUE(s2 <= s1);
+        EXPECT_FALSE(s2 > s1);
+        EXPECT_TRUE(s2 >= s1);
+    }
 
-     {
-         int arr[] = {2, 1};
-         span<int> s1 = arr;
-         span<int> s2 = arr;
+    {
+        int arr[] = {2, 1};
+        span<int> s1 = arr;
+        span<int> s2 = arr;
 
-         EXPECT_TRUE(s1 == s2);
-         EXPECT_FALSE(s1 != s2);
-         EXPECT_FALSE(s1 < s2);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s1 >= s2);
-         EXPECT_TRUE(s2 == s1);
-         EXPECT_FALSE(s2 != s1);
-         EXPECT_FALSE(s2 < s1);
-         EXPECT_TRUE(s2 <= s1);
-         EXPECT_FALSE(s2 > s1);
-         EXPECT_TRUE(s2 >= s1);
-     }
+        EXPECT_TRUE(s1 == s2);
+        EXPECT_FALSE(s1 != s2);
+        EXPECT_FALSE(s1 < s2);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s1 >= s2);
+        EXPECT_TRUE(s2 == s1);
+        EXPECT_FALSE(s2 != s1);
+        EXPECT_FALSE(s2 < s1);
+        EXPECT_TRUE(s2 <= s1);
+        EXPECT_FALSE(s2 > s1);
+        EXPECT_TRUE(s2 >= s1);
+    }
 
-     {
-         int arr[] = {2, 1}; // bigger
+    {
+        int arr[] = {2, 1}; // bigger
 
-         span<int> s1;
-         span<int> s2 = arr;
+        span<int> s1;
+        span<int> s2 = arr;
 
-         EXPECT_TRUE(s1 != s2);
-         EXPECT_TRUE(s2 != s1);
-         EXPECT_FALSE(s1 == s2);
-         EXPECT_FALSE(s2 == s1);
-         EXPECT_TRUE(s1 < s2);
-         EXPECT_FALSE(s2 < s1);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s2 <= s1);
-         EXPECT_TRUE(s2 > s1);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s2 >= s1);
-         EXPECT_FALSE(s1 >= s2);
-     }
+        EXPECT_TRUE(s1 != s2);
+        EXPECT_TRUE(s2 != s1);
+        EXPECT_FALSE(s1 == s2);
+        EXPECT_FALSE(s2 == s1);
+        EXPECT_TRUE(s1 < s2);
+        EXPECT_FALSE(s2 < s1);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s2 <= s1);
+        EXPECT_TRUE(s2 > s1);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s2 >= s1);
+        EXPECT_FALSE(s1 >= s2);
+    }
 
-     {
-         int arr1[] = {1, 2};
-         int arr2[] = {1, 2};
-         span<int> s1 = arr1;
-         span<int> s2 = arr2;
+    {
+        int arr1[] = {1, 2};
+        int arr2[] = {1, 2};
+        span<int> s1 = arr1;
+        span<int> s2 = arr2;
 
-         EXPECT_TRUE(s1 == s2);
-         EXPECT_FALSE(s1 != s2);
-         EXPECT_FALSE(s1 < s2);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s1 >= s2);
-         EXPECT_TRUE(s2 == s1);
-         EXPECT_FALSE(s2 != s1);
-         EXPECT_FALSE(s2 < s1);
-         EXPECT_TRUE(s2 <= s1);
-         EXPECT_FALSE(s2 > s1);
-         EXPECT_TRUE(s2 >= s1);
-     }
+        EXPECT_TRUE(s1 == s2);
+        EXPECT_FALSE(s1 != s2);
+        EXPECT_FALSE(s1 < s2);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s1 >= s2);
+        EXPECT_TRUE(s2 == s1);
+        EXPECT_FALSE(s2 != s1);
+        EXPECT_FALSE(s2 < s1);
+        EXPECT_TRUE(s2 <= s1);
+        EXPECT_FALSE(s2 > s1);
+        EXPECT_TRUE(s2 >= s1);
+    }
 
-     {
-         int arr[] = {1, 2, 3};
+    {
+        int arr[] = {1, 2, 3};
 
-         span<int> s1 = {&arr[0], 2}; // shorter
-         span<int> s2 = arr;          // longer
+        span<int> s1 = {&arr[0], 2}; // shorter
+        span<int> s2 = arr;          // longer
 
-         EXPECT_TRUE(s1 != s2);
-         EXPECT_TRUE(s2 != s1);
-         EXPECT_FALSE(s1 == s2);
-         EXPECT_FALSE(s2 == s1);
-         EXPECT_TRUE(s1 < s2);
-         EXPECT_FALSE(s2 < s1);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s2 <= s1);
-         EXPECT_TRUE(s2 > s1);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s2 >= s1);
-         EXPECT_FALSE(s1 >= s2);
-     }
+        EXPECT_TRUE(s1 != s2);
+        EXPECT_TRUE(s2 != s1);
+        EXPECT_FALSE(s1 == s2);
+        EXPECT_FALSE(s2 == s1);
+        EXPECT_TRUE(s1 < s2);
+        EXPECT_FALSE(s2 < s1);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s2 <= s1);
+        EXPECT_TRUE(s2 > s1);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s2 >= s1);
+        EXPECT_FALSE(s1 >= s2);
+    }
 
-     {
-         int arr1[] = {1, 2}; // smaller
-         int arr2[] = {2, 1}; // bigger
+    {
+        int arr1[] = {1, 2}; // smaller
+        int arr2[] = {2, 1}; // bigger
 
-         span<int> s1 = arr1;
-         span<int> s2 = arr2;
+        span<int> s1 = arr1;
+        span<int> s2 = arr2;
 
-         EXPECT_TRUE(s1 != s2);
-         EXPECT_TRUE(s2 != s1);
-         EXPECT_FALSE(s1 == s2);
-         EXPECT_FALSE(s2 == s1);
-         EXPECT_TRUE(s1 < s2);
-         EXPECT_FALSE(s2 < s1);
-         EXPECT_TRUE(s1 <= s2);
-         EXPECT_FALSE(s2 <= s1);
-         EXPECT_TRUE(s2 > s1);
-         EXPECT_FALSE(s1 > s2);
-         EXPECT_TRUE(s2 >= s1);
-         EXPECT_FALSE(s1 >= s2);
-     }
- }
+        EXPECT_TRUE(s1 != s2);
+        EXPECT_TRUE(s2 != s1);
+        EXPECT_FALSE(s1 == s2);
+        EXPECT_FALSE(s2 == s1);
+        EXPECT_TRUE(s1 < s2);
+        EXPECT_FALSE(s2 < s1);
+        EXPECT_TRUE(s1 <= s2);
+        EXPECT_FALSE(s2 <= s1);
+        EXPECT_TRUE(s2 > s1);
+        EXPECT_FALSE(s1 > s2);
+        EXPECT_TRUE(s2 >= s1);
+        EXPECT_FALSE(s1 >= s2);
+    }
+}
+#endif // GSL_KERNEL_MODE
+

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 
-#include <gsl/util> // for narrow_cast, at
 #include <gsl/span> // for span and span_ext
+#include <gsl/util> // for narrow_cast, at
 
-#include <array>       // for array
-#include <iostream>    // for cerr
-#include <vector>      // for vector
+#include <array>    // for array
+#include <iostream> // for cerr
+#include <vector>   // for vector
 
 using namespace std;
 using namespace gsl;
@@ -87,29 +87,29 @@ TEST(span_ext_test, make_span_from_pointer_pointer_construction)
 }
 
 TEST(span_ext_test, make_span_from_array_constructor)
- {
-     int arr[5] = {1, 2, 3, 4, 5};
-     int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
-     int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+{
+    int arr[5] = {1, 2, 3, 4, 5};
+    int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
+    int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-     {
-         const auto s = make_span(arr);
-         EXPECT_TRUE(s.size() == 5);
-         EXPECT_TRUE(s.data() == std::addressof(arr[0]));
-     }
+    {
+        const auto s = make_span(arr);
+        EXPECT_TRUE(s.size() == 5);
+        EXPECT_TRUE(s.data() == std::addressof(arr[0]));
+    }
 
-     {
-         const auto s = make_span(std::addressof(arr2d[0]), 1);
-         EXPECT_TRUE(s.size() == 1);
-         EXPECT_TRUE(s.data() == std::addressof(arr2d[0]));
-     }
+    {
+        const auto s = make_span(std::addressof(arr2d[0]), 1);
+        EXPECT_TRUE(s.size() == 1);
+        EXPECT_TRUE(s.data() == std::addressof(arr2d[0]));
+    }
 
-     {
-         const auto s = make_span(std::addressof(arr3d[0]), 1);
-         EXPECT_TRUE(s.size() == 1);
-         EXPECT_TRUE(s.data() == std::addressof(arr3d[0]));
-     }
- }
+    {
+        const auto s = make_span(std::addressof(arr3d[0]), 1);
+        EXPECT_TRUE(s.size() == 1);
+        EXPECT_TRUE(s.data() == std::addressof(arr3d[0]));
+    }
+}
 
 TEST(span_ext_test, make_span_from_dynamic_array_constructor)
 {
@@ -195,7 +195,7 @@ TEST(span_test, interop_with_gsl_at)
 {
     int arr[5] = {1, 2, 3, 4, 5};
     span<int> s{arr};
-    EXPECT_TRUE(at(s, 0) ==  1);
+    EXPECT_TRUE(at(s, 0) == 1);
     EXPECT_TRUE(at(s, 1) == 2);
 }
 
@@ -359,4 +359,3 @@ TEST(span_ext_test, comparison_operators)
     }
 }
 #endif // GSL_KERNEL_MODE
-

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -17,19 +17,19 @@
 #include <gtest/gtest.h>
 
 #include <gsl/byte> // for byte
+#include <gsl/span> // for span, span_iterator, operator==, operator!=
 #include <gsl/util> // for narrow_cast, at
-#include <gsl/span>     // for span, span_iterator, operator==, operator!=
 
 #include <array>       // for array
+#include <cstddef>     // for ptrdiff_t
 #include <iostream>    // for ptrdiff_t
 #include <iterator>    // for reverse_iterator, operator-, operator==
 #include <memory>      // for unique_ptr, shared_ptr, make_unique, allo...
 #include <regex>       // for match_results, sub_match, match_results<>...
-#include <cstddef>     // for ptrdiff_t
 #include <string>      // for string
 #include <type_traits> // for integral_constant<>::value, is_default_co...
-#include <vector>      // for vector
 #include <utility>
+#include <vector> // for vector
 
 // the string_view include and macro are used in the deduction guide verification
 #if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
@@ -176,8 +176,7 @@ TEST(span_test, from_pointer_length_constructor)
                 EXPECT_TRUE(s.size() == narrow_cast<std::size_t>(i));
                 EXPECT_TRUE(s.data() == &arr[0]);
                 EXPECT_TRUE(s.empty() == (i == 0));
-                for (int j = 0; j < i; ++j)
-                    EXPECT_TRUE(arr[j] == s[narrow_cast<std::size_t>(j)]);
+                for (int j = 0; j < i; ++j) EXPECT_TRUE(arr[j] == s[narrow_cast<std::size_t>(j)]);
             }
             {
                 span<int> s = {&arr[i], 4 - narrow_cast<std::size_t>(i)};
@@ -280,907 +279,907 @@ TEST(span_test, from_pointer_pointer_construction)
 }
 
 TEST(span_test, from_array_constructor)
- {
-     int arr[5] = {1, 2, 3, 4, 5};
+{
+    int arr[5] = {1, 2, 3, 4, 5};
 
-     {
-         const span<int> s{arr};
-         EXPECT_TRUE(s.size() == 5);
-         EXPECT_TRUE(s.data() == &arr[0]);
-     }
+    {
+        const span<int> s{arr};
+        EXPECT_TRUE(s.size() == 5);
+        EXPECT_TRUE(s.data() == &arr[0]);
+    }
 
-     {
-         const span<int, 5> s{arr};
-         EXPECT_TRUE(s.size() == 5);
-         EXPECT_TRUE(s.data() == &arr[0]);
-     }
+    {
+        const span<int, 5> s{arr};
+        EXPECT_TRUE(s.size() == 5);
+        EXPECT_TRUE(s.data() == &arr[0]);
+    }
 
-     int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
+    int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<int, 6> s{arr};
-     }
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<int, 6> s{arr};
+    }
 
-     {
-         span<int, 0> s{arr};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == &arr[0]);
-     }
+    {
+        span<int, 0> s{arr};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == &arr[0]);
+    }
 
-     {
-         span<int> s{arr2d};
-         EXPECT_TRUE(s.size() == 6);
-         EXPECT_TRUE(s.data() == &arr2d[0][0]);
-         EXPECT_TRUE(s[0] == 1);
-         EXPECT_TRUE(s[5] == 6);
-     }
+    {
+        span<int> s{arr2d};
+        EXPECT_TRUE(s.size() == 6);
+        EXPECT_TRUE(s.data() == &arr2d[0][0]);
+        EXPECT_TRUE(s[0] == 1);
+        EXPECT_TRUE(s[5] == 6);
+    }
 
-     {
-         span<int, 0> s{arr2d};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == &arr2d[0][0]);
-     }
+    {
+        span<int, 0> s{arr2d};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == &arr2d[0][0]);
+    }
 
-     {
-         span<int, 6> s{arr2d};
-     }
- #endif
-     {
-         const span<int[3]> s{std::addressof(arr2d[0]), 1};
-         EXPECT_TRUE(s.size() == 1);
-         EXPECT_TRUE(s.data() == std::addressof(arr2d[0]));
-     }
+    {
+        span<int, 6> s{arr2d};
+    }
+#endif
+    {
+        const span<int[3]> s{std::addressof(arr2d[0]), 1};
+        EXPECT_TRUE(s.size() == 1);
+        EXPECT_TRUE(s.data() == std::addressof(arr2d[0]));
+    }
 
-     int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<int> s{arr3d};
-         EXPECT_TRUE(s.size() == 12);
-         EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-         EXPECT_TRUE(s[0] == 1);
-         EXPECT_TRUE(s[11] == 12);
-     }
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<int> s{arr3d};
+        EXPECT_TRUE(s.size() == 12);
+        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
+        EXPECT_TRUE(s[0] == 1);
+        EXPECT_TRUE(s[11] == 12);
+    }
 
-     {
-         span<int, 0> s{arr3d};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-     }
+    {
+        span<int, 0> s{arr3d};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
+    }
 
-     {
-         span<int, 11> s{arr3d};
-     }
+    {
+        span<int, 11> s{arr3d};
+    }
 
-     {
-         span<int, 12> s{arr3d};
-         EXPECT_TRUE(s.size() == 12);
-         EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-         EXPECT_TRUE(s[0] == 1);
-         EXPECT_TRUE(s[5] == 6);
-     }
- #endif
-     {
-         const span<int[3][2]> s{std::addressof(arr3d[0]), 1};
-         EXPECT_TRUE(s.size() ==  1);
-     }
+    {
+        span<int, 12> s{arr3d};
+        EXPECT_TRUE(s.size() == 12);
+        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
+        EXPECT_TRUE(s[0] == 1);
+        EXPECT_TRUE(s[5] == 6);
+    }
+#endif
+    {
+        const span<int[3][2]> s{std::addressof(arr3d[0]), 1};
+        EXPECT_TRUE(s.size() == 1);
+    }
 
-     AddressOverloaded ao_arr[5] = {};
+    AddressOverloaded ao_arr[5] = {};
 
-     {
-         const span<AddressOverloaded, 5> s{ao_arr};
-         EXPECT_TRUE(s.size() == 5);
-         EXPECT_TRUE(s.data() == std::addressof(ao_arr[0]));
-     }
- }
+    {
+        const span<AddressOverloaded, 5> s{ao_arr};
+        EXPECT_TRUE(s.size() == 5);
+        EXPECT_TRUE(s.data() == std::addressof(ao_arr[0]));
+    }
+}
 
- TEST(span_test, from_dynamic_array_constructor)
- {
-     double(*arr)[3][4] = new double[100][3][4];
+TEST(span_test, from_dynamic_array_constructor)
+{
+    double(*arr)[3][4] = new double[100][3][4];
 
-     {
-         span<double> s(&arr[0][0][0], 10);
-         EXPECT_TRUE(s.size() == 10);
-         EXPECT_TRUE(s.data() == &arr[0][0][0]);
-     }
+    {
+        span<double> s(&arr[0][0][0], 10);
+        EXPECT_TRUE(s.size() == 10);
+        EXPECT_TRUE(s.data() == &arr[0][0][0]);
+    }
 
-     delete[] arr;
- }
+    delete[] arr;
+}
 
- TEST(span_test, from_std_array_constructor)
- {
-     std::array<int, 4> arr = {1, 2, 3, 4};
+TEST(span_test, from_std_array_constructor)
+{
+    std::array<int, 4> arr = {1, 2, 3, 4};
 
-     {
-         span<int> s{arr};
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
+    {
+        span<int> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
 
-         span<const int> cs{arr};
-         EXPECT_TRUE(cs.size() == arr.size());
-         EXPECT_TRUE(cs.data() == arr.data());
-     }
+        span<const int> cs{arr};
+        EXPECT_TRUE(cs.size() == arr.size());
+        EXPECT_TRUE(cs.data() == arr.data());
+    }
 
-     {
-         span<int, 4> s{arr};
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
+    {
+        span<int, 4> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
 
-         span<const int, 4> cs{arr};
-         EXPECT_TRUE(cs.size() == arr.size());
-         EXPECT_TRUE(cs.data() == arr.data());
-     }
+        span<const int, 4> cs{arr};
+        EXPECT_TRUE(cs.size() == arr.size());
+        EXPECT_TRUE(cs.data() == arr.data());
+    }
 
-     {
-         std::array<int, 0> empty_arr{};
-         span<int> s{empty_arr};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.empty());
-     }
+    {
+        std::array<int, 0> empty_arr{};
+        span<int> s{empty_arr};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.empty());
+    }
 
-     std::array<AddressOverloaded, 4> ao_arr{};
+    std::array<AddressOverloaded, 4> ao_arr{};
 
-     {
-         span<AddressOverloaded, 4> fs{ao_arr};
-         EXPECT_TRUE(fs.size() == ao_arr.size());
-         EXPECT_TRUE(ao_arr.data() == fs.data());
-     }
+    {
+        span<AddressOverloaded, 4> fs{ao_arr};
+        EXPECT_TRUE(fs.size() == ao_arr.size());
+        EXPECT_TRUE(ao_arr.data() == fs.data());
+    }
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<int, 2> s{arr};
-         EXPECT_TRUE(s.size() == 2);
-         EXPECT_TRUE(s.data() == arr.data());
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<int, 2> s{arr};
+        EXPECT_TRUE(s.size() == 2);
+        EXPECT_TRUE(s.data() == arr.data());
 
-         span<const int, 2> cs{arr};
-         EXPECT_TRUE(cs.size() == 2);
-         EXPECT_TRUE(cs.data() == arr.data());
-     }
+        span<const int, 2> cs{arr};
+        EXPECT_TRUE(cs.size() == 2);
+        EXPECT_TRUE(cs.data() == arr.data());
+    }
 
-     {
-         span<int, 0> s{arr};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == arr.data());
+    {
+        span<int, 0> s{arr};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == arr.data());
 
-         span<const int, 0> cs{arr};
-         EXPECT_TRUE(cs.size() == 0);
-         EXPECT_TRUE(cs.data() == arr.data());
-     }
+        span<const int, 0> cs{arr};
+        EXPECT_TRUE(cs.size() == 0);
+        EXPECT_TRUE(cs.data() == arr.data());
+    }
 
-     {
-         span<int, 5> s{arr};
-     }
+    {
+        span<int, 5> s{arr};
+    }
 
-     {
-         auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-         auto take_a_span = [](span<int> s) { static_cast<void>(s); };
-         // try to take a temporary std::array
-         take_a_span(get_an_array());
-     }
- #endif
+    {
+        auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
+        auto take_a_span = [](span<int> s) { static_cast<void>(s); };
+        // try to take a temporary std::array
+        take_a_span(get_an_array());
+    }
+#endif
 
-     {
-         auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-         auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
-         // try to take a temporary std::array
-         take_a_span(get_an_array());
-     }
- }
+    {
+        auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
+        auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
+        // try to take a temporary std::array
+        take_a_span(get_an_array());
+    }
+}
 
- TEST(span_test, from_const_std_array_constructor)
- {
-     const std::array<int, 4> arr = {1, 2, 3, 4};
+TEST(span_test, from_const_std_array_constructor)
+{
+    const std::array<int, 4> arr = {1, 2, 3, 4};
 
-     {
-         span<const int> s{arr};
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 4> s{arr};
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int, 4> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     const std::array<AddressOverloaded, 4> ao_arr{};
+    const std::array<AddressOverloaded, 4> ao_arr{};
 
-     {
-         span<const AddressOverloaded, 4> s{ao_arr};
-         EXPECT_TRUE(s.size() == ao_arr.size());
-         EXPECT_TRUE(s.data() == ao_arr.data());
-     }
+    {
+        span<const AddressOverloaded, 4> s{ao_arr};
+        EXPECT_TRUE(s.size() == ao_arr.size());
+        EXPECT_TRUE(s.data() == ao_arr.data());
+    }
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<const int, 2> s{arr};
-         EXPECT_TRUE(s.size() == 2);
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<const int, 2> s{arr};
+        EXPECT_TRUE(s.size() == 2);
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 0> s{arr};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int, 0> s{arr};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 5> s{arr};
-     }
- #endif
+    {
+        span<const int, 5> s{arr};
+    }
+#endif
 
-     {
-         auto get_an_array = []() -> const std::array<int, 4> { return {1, 2, 3, 4}; };
-         auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
-         // try to take a temporary std::array
-         take_a_span(get_an_array());
-     }
- }
+    {
+        auto get_an_array = []() -> const std::array<int, 4> { return {1, 2, 3, 4}; };
+        auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
+        // try to take a temporary std::array
+        take_a_span(get_an_array());
+    }
+}
 
- TEST(span_test, from_std_array_const_constructor)
- {
-     std::array<const int, 4> arr = {1, 2, 3, 4};
+TEST(span_test, from_std_array_const_constructor)
+{
+    std::array<const int, 4> arr = {1, 2, 3, 4};
 
-     {
-         span<const int> s{arr};
-         EXPECT_TRUE(s.size() == arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 4> s{arr};
-         EXPECT_TRUE(s.size() ==  arr.size());
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int, 4> s{arr};
+        EXPECT_TRUE(s.size() == arr.size());
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<const int, 2> s{arr};
-         EXPECT_TRUE(s.size() == 2);
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<const int, 2> s{arr};
+        EXPECT_TRUE(s.size() == 2);
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 0> s{arr};
-         EXPECT_TRUE(s.size() == 0);
-         EXPECT_TRUE(s.data() == arr.data());
-     }
+    {
+        span<const int, 0> s{arr};
+        EXPECT_TRUE(s.size() == 0);
+        EXPECT_TRUE(s.data() == arr.data());
+    }
 
-     {
-         span<const int, 5> s{arr};
-     }
+    {
+        span<const int, 5> s{arr};
+    }
 
-     {
-         span<int, 4> s{arr};
-     }
- #endif
- }
+    {
+        span<int, 4> s{arr};
+    }
+#endif
+}
 
- TEST(span_test, from_container_constructor)
- {
-     std::vector<int> v = {1, 2, 3};
-     const std::vector<int> cv = v;
+TEST(span_test, from_container_constructor)
+{
+    std::vector<int> v = {1, 2, 3};
+    const std::vector<int> cv = v;
 
-     {
-         span<int> s{v};
-         EXPECT_TRUE(s.size() == v.size());
-         EXPECT_TRUE(s.data() == v.data());
+    {
+        span<int> s{v};
+        EXPECT_TRUE(s.size() == v.size());
+        EXPECT_TRUE(s.data() == v.data());
 
-         span<const int> cs{v};
-         EXPECT_TRUE(cs.size() == v.size());
-         EXPECT_TRUE(cs.data() == v.data());
-     }
+        span<const int> cs{v};
+        EXPECT_TRUE(cs.size() == v.size());
+        EXPECT_TRUE(cs.data() == v.data());
+    }
 
-     std::string str = "hello";
-     const std::string cstr = "hello";
+    std::string str = "hello";
+    const std::string cstr = "hello";
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         span<char> s{str};
-         EXPECT_TRUE(s.size() == str.size());
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        span<char> s{str};
+        EXPECT_TRUE(s.size() == str.size());
          EXPECT_TRUE(s.data() == str.data()));
- #endif
+#endif
          span<const char> cs{str};
          EXPECT_TRUE(cs.size() == str.size());
          EXPECT_TRUE(cs.data() == str.data());
-     }
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         span<char> s{cstr};
- #endif
-         span<const char> cs{cstr};
-         EXPECT_TRUE(cs.size() == cstr.size());
-         EXPECT_TRUE(cs.data() == cstr.data());
-     }
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        span<char> s{cstr};
+#endif
+        span<const char> cs{cstr};
+        EXPECT_TRUE(cs.size() == cstr.size());
+        EXPECT_TRUE(cs.data() == cstr.data());
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         auto get_temp_vector = []() -> std::vector<int> { return {}; };
-         auto use_span = [](span<int> s) { static_cast<void>(s); };
-         use_span(get_temp_vector());
- #endif
-     }
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        auto get_temp_vector = []() -> std::vector<int> { return {}; };
+        auto use_span = [](span<int> s) { static_cast<void>(s); };
+        use_span(get_temp_vector());
+#endif
+    }
 
-     {
-         auto get_temp_vector = []() -> std::vector<int> { return {}; };
-         auto use_span = [](span<const int> s) { static_cast<void>(s); };
-         use_span(get_temp_vector());
-     }
+    {
+        auto get_temp_vector = []() -> std::vector<int> { return {}; };
+        auto use_span = [](span<const int> s) { static_cast<void>(s); };
+        use_span(get_temp_vector());
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         auto get_temp_string = []() -> std::string { return {}; };
-         auto use_span = [](span<char> s) { static_cast<void>(s); };
-         use_span(get_temp_string());
- #endif
-     }
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        auto get_temp_string = []() -> std::string { return {}; };
+        auto use_span = [](span<char> s) { static_cast<void>(s); };
+        use_span(get_temp_string());
+#endif
+    }
 
-     {
-         auto get_temp_string = []() -> std::string { return {}; };
-         auto use_span = [](span<const char> s) { static_cast<void>(s); };
-         use_span(get_temp_string());
-     }
+    {
+        auto get_temp_string = []() -> std::string { return {}; };
+        auto use_span = [](span<const char> s) { static_cast<void>(s); };
+        use_span(get_temp_string());
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         auto get_temp_vector = []() -> const std::vector<int> { return {}; };
-         auto use_span = [](span<const char> s) { static_cast<void>(s); };
-         use_span(get_temp_vector());
- #endif
-     }
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        auto get_temp_vector = []() -> const std::vector<int> { return {}; };
+        auto use_span = [](span<const char> s) { static_cast<void>(s); };
+        use_span(get_temp_vector());
+#endif
+    }
 
-     {
-         auto get_temp_string = []() -> const std::string { return {}; };
-         auto use_span = [](span<const char> s) { static_cast<void>(s); };
-         use_span(get_temp_string());
-     }
+    {
+        auto get_temp_string = []() -> const std::string { return {}; };
+        auto use_span = [](span<const char> s) { static_cast<void>(s); };
+        use_span(get_temp_string());
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         std::map<int, int> m;
-         span<int> s{m};
- #endif
-     }
- }
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        std::map<int, int> m;
+        span<int> s{m};
+#endif
+    }
+}
 
- TEST(span_test, from_convertible_span_constructor){{span<DerivedClass> avd;
- span<const DerivedClass> avcd = avd;
- static_cast<void>(avcd);
- }
+TEST(span_test, from_convertible_span_constructor){{span<DerivedClass> avd;
+span<const DerivedClass> avcd = avd;
+static_cast<void>(avcd);
+}
 
- {
- #ifdef CONFIRM_COMPILATION_ERRORS
-     span<DerivedClass> avd;
-     span<BaseClass> avb = avd;
-     static_cast<void>(avb);
- #endif
- }
+{
+#ifdef CONFIRM_COMPILATION_ERRORS
+    span<DerivedClass> avd;
+    span<BaseClass> avb = avd;
+    static_cast<void>(avb);
+#endif
+}
 
- #ifdef CONFIRM_COMPILATION_ERRORS
- {
-     span<int> s;
-     span<unsigned int> s2 = s;
-     static_cast<void>(s2);
- }
+#ifdef CONFIRM_COMPILATION_ERRORS
+{
+    span<int> s;
+    span<unsigned int> s2 = s;
+    static_cast<void>(s2);
+}
 
- {
-     span<int> s;
-     span<const unsigned int> s2 = s;
-     static_cast<void>(s2);
- }
+{
+    span<int> s;
+    span<const unsigned int> s2 = s;
+    static_cast<void>(s2);
+}
 
- {
-     span<int> s;
-     span<short> s2 = s;
-     static_cast<void>(s2);
- }
- #endif
- }
+{
+    span<int> s;
+    span<short> s2 = s;
+    static_cast<void>(s2);
+}
+#endif
+}
 
- TEST(span_test, copy_move_and_assignment)
- {
-     span<int> s1;
-     EXPECT_TRUE(s1.empty());
+TEST(span_test, copy_move_and_assignment)
+{
+    span<int> s1;
+    EXPECT_TRUE(s1.empty());
 
-     int arr[] = {3, 4, 5};
+    int arr[] = {3, 4, 5};
 
-     span<const int> s2 = arr;
-     EXPECT_TRUE(s2.size() ==  3);
-     EXPECT_TRUE(s2.data() == &arr[0]);
+    span<const int> s2 = arr;
+    EXPECT_TRUE(s2.size() == 3);
+    EXPECT_TRUE(s2.data() == &arr[0]);
 
-     s2 = s1;
-     EXPECT_TRUE(s2.empty());
+    s2 = s1;
+    EXPECT_TRUE(s2.empty());
 
-     auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
-     auto use_span = [&](span<const int> s) {
-         EXPECT_TRUE(s.size() ==  2);
-         EXPECT_TRUE(s.data() == &arr[1]);
-     }; use_span(get_temp_span());
+    auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
+    auto use_span = [&](span<const int> s) {
+        EXPECT_TRUE(s.size() == 2);
+        EXPECT_TRUE(s.data() == &arr[1]);
+    };
+    use_span(get_temp_span());
 
-     s1 = get_temp_span();
-     EXPECT_TRUE(s1.size() ==  2);
-     EXPECT_TRUE(s1.data() == &arr[1]);
- }
+    s1 = get_temp_span();
+    EXPECT_TRUE(s1.size() == 2);
+    EXPECT_TRUE(s1.data() == &arr[1]);
+}
 
- TEST(span_test, first)
- {
+TEST(span_test, first)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. first";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.first<2>().size() == 2);
-         EXPECT_TRUE(av.first(2).size() == 2);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.first<2>().size() == 2);
+        EXPECT_TRUE(av.first(2).size() == 2);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.first<0>().size() == 0);
-         EXPECT_TRUE(av.first(0).size() == 0);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.first<0>().size() == 0);
+        EXPECT_TRUE(av.first(0).size() == 0);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.first<5>().size() == 5);
-         EXPECT_TRUE(av.first(5).size() == 5);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.first<5>().size() == 5);
+        EXPECT_TRUE(av.first(5).size() == 5);
+    }
 
-     {
-         span<int, 5> av = arr;
- #ifdef CONFIRM_COMPILATION_ERRORS
-         EXPECT_TRUE(av.first<6>().size() == 6);
-         EXPECT_TRUE(av.first<-1>().size() == -1);
- #endif
-         EXPECT_DEATH(av.first(6).size(), expected);
-     }
+    {
+        span<int, 5> av = arr;
+#ifdef CONFIRM_COMPILATION_ERRORS
+        EXPECT_TRUE(av.first<6>().size() == 6);
+        EXPECT_TRUE(av.first<-1>().size() == -1);
+#endif
+        EXPECT_DEATH(av.first(6).size(), expected);
+    }
 
-     {
-         span<int> av;
-         EXPECT_TRUE(av.first<0>().size() == 0);
-         EXPECT_TRUE(av.first(0).size() == 0);
-     }
- }
+    {
+        span<int> av;
+        EXPECT_TRUE(av.first<0>().size() == 0);
+        EXPECT_TRUE(av.first(0).size() == 0);
+    }
+}
 
- TEST(span_test, last)
- {
+TEST(span_test, last)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. last";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.last<2>().size() == 2);
-         EXPECT_TRUE(av.last(2).size() == 2);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.last<2>().size() == 2);
+        EXPECT_TRUE(av.last(2).size() == 2);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.last<0>().size() == 0);
-         EXPECT_TRUE(av.last(0).size() == 0);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.last<0>().size() == 0);
+        EXPECT_TRUE(av.last(0).size() == 0);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.last<5>().size() == 5);
-         EXPECT_TRUE(av.last(5).size() == 5);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.last<5>().size() == 5);
+        EXPECT_TRUE(av.last(5).size() == 5);
+    }
 
-     {
-         span<int, 5> av = arr;
- #ifdef CONFIRM_COMPILATION_ERRORS
-         EXPECT_TRUE(av.last<6>().size() == 6);
- #endif
-         EXPECT_DEATH(av.last(6).size(), expected);
-     }
+    {
+        span<int, 5> av = arr;
+#ifdef CONFIRM_COMPILATION_ERRORS
+        EXPECT_TRUE(av.last<6>().size() == 6);
+#endif
+        EXPECT_DEATH(av.last(6).size(), expected);
+    }
 
-     {
-         span<int> av;
-         EXPECT_TRUE(av.last<0>().size() == 0);
-         EXPECT_TRUE(av.last(0).size() == 0);
-     }
- }
+    {
+        span<int> av;
+        EXPECT_TRUE(av.last<0>().size() == 0);
+        EXPECT_TRUE(av.last(0).size() == 0);
+    }
+}
 
- TEST(span_test, subspan)
- {
+TEST(span_test, subspan)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. subspan";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE((av.subspan<2, 2>().size()) == 2);
-         EXPECT_TRUE(decltype(av.subspan<2, 2>())::extent == 2);
-         EXPECT_TRUE(av.subspan(2, 2).size() == 2);
-         EXPECT_TRUE(av.subspan(2, 3).size() == 3);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE((av.subspan<2, 2>().size()) == 2);
+        EXPECT_TRUE(decltype(av.subspan<2, 2>())::extent == 2);
+        EXPECT_TRUE(av.subspan(2, 2).size() == 2);
+        EXPECT_TRUE(av.subspan(2, 3).size() == 3);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
-         EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
-         EXPECT_TRUE(av.subspan(0, 0).size() == 0);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
+        EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
+        EXPECT_TRUE(av.subspan(0, 0).size() == 0);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE((av.subspan<0, 5>().size()) == 5);
-         EXPECT_TRUE(decltype(av.subspan<0, 5>())::extent == 5);
-         EXPECT_TRUE(av.subspan(0, 5).size() == 5);
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE((av.subspan<0, 5>().size()) == 5);
+        EXPECT_TRUE(decltype(av.subspan<0, 5>())::extent == 5);
+        EXPECT_TRUE(av.subspan(0, 5).size() == 5);
 
-         EXPECT_DEATH(av.subspan(0, 6).size(), expected);
-         EXPECT_DEATH(av.subspan(1, 5).size(), expected);
-     }
+        EXPECT_DEATH(av.subspan(0, 6).size(), expected);
+        EXPECT_DEATH(av.subspan(1, 5).size(), expected);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE((av.subspan<4, 0>().size()) == 0);
-         EXPECT_TRUE(decltype(av.subspan<4, 0>())::extent == 0);
-         EXPECT_TRUE(av.subspan(4, 0).size() == 0);
-         EXPECT_TRUE(av.subspan(5, 0).size() == 0);
-         EXPECT_DEATH(av.subspan(6, 0).size(), expected);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE((av.subspan<4, 0>().size()) == 0);
+        EXPECT_TRUE(decltype(av.subspan<4, 0>())::extent == 0);
+        EXPECT_TRUE(av.subspan(4, 0).size() == 0);
+        EXPECT_TRUE(av.subspan(5, 0).size() == 0);
+        EXPECT_DEATH(av.subspan(6, 0).size(), expected);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.subspan<1>().size() == 4);
-         EXPECT_TRUE(decltype(av.subspan<1>())::extent == 4);
-     }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.subspan<1>().size() == 4);
+        EXPECT_TRUE(decltype(av.subspan<1>())::extent == 4);
+    }
 
-     {
-         span<int> av;
-         EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
-         EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
-         EXPECT_TRUE(av.subspan(0, 0).size() == 0);
-         EXPECT_DEATH((av.subspan<1, 0>().size()), expected);
-     }
+    {
+        span<int> av;
+        EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
+        EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
+        EXPECT_TRUE(av.subspan(0, 0).size() == 0);
+        EXPECT_DEATH((av.subspan<1, 0>().size()), expected);
+    }
 
-     {
-         span<int> av;
-         EXPECT_TRUE(av.subspan(0).size() == 0);
-         EXPECT_DEATH(av.subspan(1).size(), expected);
-     }
+    {
+        span<int> av;
+        EXPECT_TRUE(av.subspan(0).size() == 0);
+        EXPECT_DEATH(av.subspan(1).size(), expected);
+    }
 
-     {
-         span<int> av = arr;
-         EXPECT_TRUE(av.subspan(0).size() == 5);
-         EXPECT_TRUE(av.subspan(1).size() == 4);
-         EXPECT_TRUE(av.subspan(4).size() == 1);
-         EXPECT_TRUE(av.subspan(5).size() == 0);
-         EXPECT_DEATH(av.subspan(6).size(), expected);
-         const auto av2 = av.subspan(1);
-         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
-     }
+    {
+        span<int> av = arr;
+        EXPECT_TRUE(av.subspan(0).size() == 5);
+        EXPECT_TRUE(av.subspan(1).size() == 4);
+        EXPECT_TRUE(av.subspan(4).size() == 1);
+        EXPECT_TRUE(av.subspan(5).size() == 0);
+        EXPECT_DEATH(av.subspan(6).size(), expected);
+        const auto av2 = av.subspan(1);
+        for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
+    }
 
-     {
-         span<int, 5> av = arr;
-         EXPECT_TRUE(av.subspan(0).size() == 5);
-         EXPECT_TRUE(av.subspan(1).size() == 4);
-         EXPECT_TRUE(av.subspan(4).size() == 1);
-         EXPECT_TRUE(av.subspan(5).size() == 0);
-         EXPECT_DEATH(av.subspan(6).size(), expected);
-         const auto av2 = av.subspan(1);
-         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
-     }
- }
+    {
+        span<int, 5> av = arr;
+        EXPECT_TRUE(av.subspan(0).size() == 5);
+        EXPECT_TRUE(av.subspan(1).size() == 4);
+        EXPECT_TRUE(av.subspan(4).size() == 1);
+        EXPECT_TRUE(av.subspan(5).size() == 0);
+        EXPECT_DEATH(av.subspan(6).size(), expected);
+        const auto av2 = av.subspan(1);
+        for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
+    }
+}
 
- TEST(span_test, iterator_default_init)
- {
-     span<int>::iterator it1;
-     span<int>::iterator it2;
-     EXPECT_TRUE(it1 == it2);
- }
+TEST(span_test, iterator_default_init)
+{
+    span<int>::iterator it1;
+    span<int>::iterator it2;
+    EXPECT_TRUE(it1 == it2);
+}
 
- TEST(span_test, iterator_comparisons)
- {
-     int a[] = {1, 2, 3, 4};
-     {
-         span<int> s = a;
-         span<int>::iterator it = s.begin();
-         auto it2 = it + 1;
+TEST(span_test, iterator_comparisons)
+{
+    int a[] = {1, 2, 3, 4};
+    {
+        span<int> s = a;
+        span<int>::iterator it = s.begin();
+        auto it2 = it + 1;
 
-         EXPECT_TRUE(it == it);
-         EXPECT_TRUE(it == s.begin());
-         EXPECT_TRUE(s.begin() == it);
+        EXPECT_TRUE(it == it);
+        EXPECT_TRUE(it == s.begin());
+        EXPECT_TRUE(s.begin() == it);
 
-         EXPECT_TRUE(it != it2);
-         EXPECT_TRUE(it2 != it);
-         EXPECT_TRUE(it != s.end());
-         EXPECT_TRUE(it2 != s.end());
-         EXPECT_TRUE(s.end() != it);
+        EXPECT_TRUE(it != it2);
+        EXPECT_TRUE(it2 != it);
+        EXPECT_TRUE(it != s.end());
+        EXPECT_TRUE(it2 != s.end());
+        EXPECT_TRUE(s.end() != it);
 
-         EXPECT_TRUE(it < it2);
-         EXPECT_TRUE(it <= it2);
-         EXPECT_TRUE(it2 <= s.end());
-         EXPECT_TRUE(it < s.end());
+        EXPECT_TRUE(it < it2);
+        EXPECT_TRUE(it <= it2);
+        EXPECT_TRUE(it2 <= s.end());
+        EXPECT_TRUE(it < s.end());
 
-         EXPECT_TRUE(it2 > it);
-         EXPECT_TRUE(it2 >= it);
-         EXPECT_TRUE(s.end() > it2);
-         EXPECT_TRUE(s.end() >= it2);
-     }
- }
+        EXPECT_TRUE(it2 > it);
+        EXPECT_TRUE(it2 >= it);
+        EXPECT_TRUE(s.end() > it2);
+        EXPECT_TRUE(s.end() >= it2);
+    }
+}
 
- TEST(span_test, incomparable_iterators)
- {
-     const auto terminateHandler = std::set_terminate([] {
-         std::cerr << "Expected Death. incomparable_iterators";
-         std::abort();
-     });
+TEST(span_test, incomparable_iterators)
+{
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. incomparable_iterators";
+        std::abort();
+    });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     int a[] = {1, 2, 3, 4};
-     int b[] = {1, 2, 3, 4};
-     {
-         span<int> s = a;
-         span<int> s2 = b;
+    int a[] = {1, 2, 3, 4};
+    int b[] = {1, 2, 3, 4};
+    {
+        span<int> s = a;
+        span<int> s2 = b;
 #if (__cplusplus > 201402L)
-         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() == s2.begin()), expected);
-         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() <= s2.begin()), expected);
+        EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() == s2.begin()), expected);
+        EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() <= s2.begin()), expected);
 #else
-         EXPECT_DEATH(bool _ = (s.begin() == s2.begin()), expected);
-         EXPECT_DEATH(bool _ = (s.begin() <= s2.begin()), expected);
+        EXPECT_DEATH(bool _ = (s.begin() == s2.begin()), expected);
+        EXPECT_DEATH(bool _ = (s.begin() <= s2.begin()), expected);
 #endif
-     }
- }
+    }
+}
 
- TEST(span_test, begin_end)
- {
+TEST(span_test, begin_end)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. begin_end";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-         span<int>::iterator it = s.begin();
-         span<int>::iterator it2 = std::begin(s);
-         EXPECT_TRUE(it == it2);
+        span<int>::iterator it = s.begin();
+        span<int>::iterator it2 = std::begin(s);
+        EXPECT_TRUE(it == it2);
 
-         it = s.end();
-         it2 = std::end(s);
-         EXPECT_TRUE(it == it2);
-     }
+        it = s.end();
+        it2 = std::end(s);
+        EXPECT_TRUE(it == it2);
+    }
 
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-         auto it = s.begin();
-         auto first = it;
-         EXPECT_TRUE(it == first);
-         EXPECT_TRUE(*it == 1);
+        auto it = s.begin();
+        auto first = it;
+        EXPECT_TRUE(it == first);
+        EXPECT_TRUE(*it == 1);
 
-         auto beyond = s.end();
-         EXPECT_TRUE(it != beyond);
-         EXPECT_DEATH(*beyond, expected);
+        auto beyond = s.end();
+        EXPECT_TRUE(it != beyond);
+        EXPECT_DEATH(*beyond, expected);
 
-         EXPECT_TRUE(beyond - first == 4);
-         EXPECT_TRUE(first - first == 0);
-         EXPECT_TRUE(beyond - beyond == 0);
+        EXPECT_TRUE(beyond - first == 4);
+        EXPECT_TRUE(first - first == 0);
+        EXPECT_TRUE(beyond - beyond == 0);
 
-         ++it;
-         EXPECT_TRUE(it - first == 1);
-         EXPECT_TRUE(*it == 2);
-         *it = 22;
-         EXPECT_TRUE(*it == 22);
-         EXPECT_TRUE(beyond - it == 3);
+        ++it;
+        EXPECT_TRUE(it - first == 1);
+        EXPECT_TRUE(*it == 2);
+        *it = 22;
+        EXPECT_TRUE(*it == 22);
+        EXPECT_TRUE(beyond - it == 3);
 
-         it = first;
-         EXPECT_TRUE(it == first);
-         while (it != s.end())
-         {
-             *it = 5;
-             ++it;
-         }
+        it = first;
+        EXPECT_TRUE(it == first);
+        while (it != s.end())
+        {
+            *it = 5;
+            ++it;
+        }
 
-         EXPECT_TRUE(it == beyond);
-         EXPECT_TRUE(it - beyond == 0);
+        EXPECT_TRUE(it == beyond);
+        EXPECT_TRUE(it - beyond == 0);
 
-         for (const auto& n : s) { EXPECT_TRUE(n == 5); }
-     }
- }
+        for (const auto& n : s) { EXPECT_TRUE(n == 5); }
+    }
+}
 
- TEST(span_test, rbegin_rend)
- {
+TEST(span_test, rbegin_rend)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. rbegin_rend";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     {
-         int a[] = {1, 2, 3, 4};
-         span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-         auto it = s.rbegin();
-         auto first = it;
-         EXPECT_TRUE(it == first);
-         EXPECT_TRUE(*it == 4);
+        auto it = s.rbegin();
+        auto first = it;
+        EXPECT_TRUE(it == first);
+        EXPECT_TRUE(*it == 4);
 
-         auto beyond = s.rend();
-         EXPECT_TRUE(it != beyond);
+        auto beyond = s.rend();
+        EXPECT_TRUE(it != beyond);
 #if (__cplusplus > 201402L)
-        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond , expected);
+        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond, expected);
 #else
-        EXPECT_DEATH(auto _ = *beyond , expected);
+        EXPECT_DEATH(auto _ = *beyond, expected);
 #endif
 
-         EXPECT_TRUE(beyond - first == 4);
-         EXPECT_TRUE(first - first == 0);
-         EXPECT_TRUE(beyond - beyond == 0);
+        EXPECT_TRUE(beyond - first == 4);
+        EXPECT_TRUE(first - first == 0);
+        EXPECT_TRUE(beyond - beyond == 0);
 
-         ++it;
-         EXPECT_TRUE(it - s.rbegin() == 1);
-         EXPECT_TRUE(*it == 3);
-         *it = 22;
-         EXPECT_TRUE(*it == 22);
-         EXPECT_TRUE(beyond - it == 3);
+        ++it;
+        EXPECT_TRUE(it - s.rbegin() == 1);
+        EXPECT_TRUE(*it == 3);
+        *it = 22;
+        EXPECT_TRUE(*it == 22);
+        EXPECT_TRUE(beyond - it == 3);
 
-         it = first;
-         EXPECT_TRUE(it == first);
-         while (it != s.rend())
-         {
-             *it = 5;
-             ++it;
-         }
+        it = first;
+        EXPECT_TRUE(it == first);
+        while (it != s.rend())
+        {
+            *it = 5;
+            ++it;
+        }
 
-         EXPECT_TRUE(it == beyond);
-         EXPECT_TRUE(it - beyond == 0);
+        EXPECT_TRUE(it == beyond);
+        EXPECT_TRUE(it - beyond == 0);
 
-         for (const auto& n : s) { EXPECT_TRUE(n == 5); }
-     }
- }
+        for (const auto& n : s) { EXPECT_TRUE(n == 5); }
+    }
+}
 
- TEST(span_test, as_bytes)
- {
-     const auto terminateHandler = std::set_terminate([] {
-         std::cerr << "Expected Death. as_bytes";
-         std::abort();
-     });
+TEST(span_test, as_bytes)
+{
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. as_bytes";
+        std::abort();
+    });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
+    int a[] = {1, 2, 3, 4};
+    {
+        const span<const int> s = a;
+        EXPECT_TRUE(s.size() == 4);
+        const span<const byte> bs = as_bytes(s);
+        EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        EXPECT_TRUE(bs.size() == s.size_bytes());
+    }
 
-     int a[] = {1, 2, 3, 4};
-     {
-         const span<const int> s = a;
-         EXPECT_TRUE(s.size() == 4);
-         const span<const byte> bs = as_bytes(s);
-         EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-         EXPECT_TRUE(bs.size() == s.size_bytes());
-     }
+    {
+        span<int> s;
+        const auto bs = as_bytes(s);
+        EXPECT_TRUE(bs.size() == s.size());
+        EXPECT_TRUE(bs.size() == 0);
+        EXPECT_TRUE(bs.size_bytes() == 0);
+        EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        EXPECT_TRUE(bs.data() == nullptr);
+    }
 
-     {
-         span<int> s;
-         const auto bs = as_bytes(s);
-         EXPECT_TRUE(bs.size() == s.size());
-         EXPECT_TRUE(bs.size() == 0);
-         EXPECT_TRUE(bs.size_bytes() == 0);
-         EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-         EXPECT_TRUE(bs.data() == nullptr);
-     }
+    {
+        span<int> s = a;
+        const auto bs = as_bytes(s);
+        EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
+        EXPECT_TRUE(bs.size() == s.size_bytes());
+    }
 
-     {
-         span<int> s = a;
-         const auto bs = as_bytes(s);
-         EXPECT_TRUE(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-         EXPECT_TRUE(bs.size() == s.size_bytes());
-     }
+    int b[5] = {1, 2, 3, 4, 5};
+    {
+        span<int> sp(begin(b), static_cast<size_t>(-2));
+        EXPECT_DEATH((void) sp.size_bytes(), expected);
+    }
+}
 
-     int b[5] = {1, 2, 3, 4, 5};
-     {
-         span<int> sp(begin(b), static_cast<size_t>(-2));
-         EXPECT_DEATH((void) sp.size_bytes(), expected);
-     }
- }
+TEST(span_test, as_writable_bytes)
+{
+    int a[] = {1, 2, 3, 4};
 
- TEST(span_test, as_writable_bytes)
- {
-     int a[] = {1, 2, 3, 4};
+    {
+#ifdef CONFIRM_COMPILATION_ERRORS
+        // you should not be able to get writeable bytes for const objects
+        span<const int> s = a;
+        EXPECT_TRUE(s.size() == 4);
+        span<const byte> bs = as_writable_bytes(s);
+        EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        EXPECT_TRUE(bs.size() == s.size_bytes());
+#endif
+    }
 
-     {
- #ifdef CONFIRM_COMPILATION_ERRORS
-         // you should not be able to get writeable bytes for const objects
-         span<const int> s = a;
-         EXPECT_TRUE(s.size() == 4);
-         span<const byte> bs = as_writable_bytes(s);
-         EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-         EXPECT_TRUE(bs.size() == s.size_bytes());
- #endif
-     }
+    {
+        span<int> s;
+        const auto bs = as_writable_bytes(s);
+        EXPECT_TRUE(bs.size() == s.size());
+        EXPECT_TRUE(bs.size() == 0);
+        EXPECT_TRUE(bs.size_bytes() == 0);
+        EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        EXPECT_TRUE(bs.data() == nullptr);
+    }
 
-     {
-         span<int> s;
-         const auto bs = as_writable_bytes(s);
-         EXPECT_TRUE(bs.size() == s.size());
-         EXPECT_TRUE(bs.size() == 0);
-         EXPECT_TRUE(bs.size_bytes() == 0);
-         EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-         EXPECT_TRUE(bs.data() == nullptr);
-     }
+    {
+        span<int> s = a;
+        const auto bs = as_writable_bytes(s);
+        EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        EXPECT_TRUE(bs.size() == s.size_bytes());
+    }
+}
 
-     {
-         span<int> s = a;
-         const auto bs = as_writable_bytes(s);
-         EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-         EXPECT_TRUE(bs.size() == s.size_bytes());
-     }
- }
-
- TEST(span_test, fixed_size_conversions)
- {
+TEST(span_test, fixed_size_conversions)
+{
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. fixed_size_conversions";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-     int arr[] = {1, 2, 3, 4};
+    int arr[] = {1, 2, 3, 4};
 
-     // converting to an span from an equal size array is ok
-     span<int, 4> s4 = arr;
-     EXPECT_TRUE(s4.size() == 4);
+    // converting to an span from an equal size array is ok
+    span<int, 4> s4 = arr;
+    EXPECT_TRUE(s4.size() == 4);
 
-     // converting to dynamic_range is always ok
-     {
-         span<int> s = s4;
-         EXPECT_TRUE(s.size() == s4.size());
-         static_cast<void>(s);
-     }
+    // converting to dynamic_range is always ok
+    {
+        span<int> s = s4;
+        EXPECT_TRUE(s.size() == s4.size());
+        static_cast<void>(s);
+    }
 
- // initialization or assignment to static span that REDUCES size is NOT ok
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<int, 2> s = arr;
-     }
-     {
-         span<int, 2> s2 = s4;
-         static_cast<void>(s2);
-     }
- #endif
+// initialization or assignment to static span that REDUCES size is NOT ok
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<int, 2> s = arr;
+    }
+    {
+        span<int, 2> s2 = s4;
+        static_cast<void>(s2);
+    }
+#endif
 
-     // even when done dynamically
-     {
-         /*
-         // this now results in a compile-time error, rather than runtime.
-         // There is no suitable conversion from dynamic span to fixed span.
-         span<int> s = arr;
-         auto f = [&]() {
-             const span<int, 2> s2 = s;
-             static_cast<void>(s2);
-         };
-         EXPECT_DEATH(f(), expected);
-         */
-     }
+    // even when done dynamically
+    {
+        /*
+        // this now results in a compile-time error, rather than runtime.
+        // There is no suitable conversion from dynamic span to fixed span.
+        span<int> s = arr;
+        auto f = [&]() {
+            const span<int, 2> s2 = s;
+            static_cast<void>(s2);
+        };
+        EXPECT_DEATH(f(), expected);
+        */
+    }
 
-     // but doing so explicitly is ok
+    // but doing so explicitly is ok
 
-     // you can convert statically
-     {
-         const span<int, 2> s2{&arr[0], 2};
-         static_cast<void>(s2);
-     }
-     {
-         const span<int, 1> s1 = s4.first<1>();
-         static_cast<void>(s1);
-     }
+    // you can convert statically
+    {
+        const span<int, 2> s2{&arr[0], 2};
+        static_cast<void>(s2);
+    }
+    {
+        const span<int, 1> s1 = s4.first<1>();
+        static_cast<void>(s1);
+    }
 
     /*
      // this is not a legal operation in std::span, so we are no longer supporting it
@@ -1196,28 +1195,29 @@ TEST(span_test, from_array_constructor)
      }
      */
 
-     // initialization or assignment to static span that requires size INCREASE is not ok.
-     int arr2[2] = {1, 2};
+    // initialization or assignment to static span that requires size INCREASE is not ok.
+    int arr2[2] = {1, 2};
 
- #ifdef CONFIRM_COMPILATION_ERRORS
-     {
-         span<int, 4> s3 = arr2;
-     }
-     {
-         span<int, 2> s2 = arr2;
-         span<int, 4> s4a = s2;
-     }
- #endif
-     {
-         auto f = [&]() {
-             const span<int, 4> _s4{arr2, 2};
-             static_cast<void>(_s4);
-         };
-         EXPECT_DEATH(f(), expected);
-     }
+#ifdef CONFIRM_COMPILATION_ERRORS
+    {
+        span<int, 4> s3 = arr2;
+    }
+    {
+        span<int, 2> s2 = arr2;
+        span<int, 4> s4a = s2;
+    }
+#endif
+    {
+        auto f = [&]() {
+            const span<int, 4> _s4{arr2, 2};
+            static_cast<void>(_s4);
+        };
+        EXPECT_DEATH(f(), expected);
+    }
 
     /*
-     // This no longer compiles. There is no suitable conversion from dynamic span to a fixed size span.
+     // This no longer compiles. There is no suitable conversion from dynamic span to a fixed size
+     span.
      // this should fail - we are trying to assign a small dynamic span to a fixed_size larger one
      span<int> av = arr2; auto f = [&]() {
          const span<int, 4> _s4 = av;
@@ -1225,44 +1225,44 @@ TEST(span_test, from_array_constructor)
      };
      EXPECT_DEATH(f(), expected);
      */
- }
+}
 
- TEST(span_test, interop_with_std_regex)
- {
-     char lat[] = {'1', '2', '3', '4', '5', '6', 'E', 'F', 'G'};
-     span<char> s = lat;
-     const auto f_it = s.begin() + 7;
+TEST(span_test, interop_with_std_regex)
+{
+    char lat[] = {'1', '2', '3', '4', '5', '6', 'E', 'F', 'G'};
+    span<char> s = lat;
+    const auto f_it = s.begin() + 7;
 
-     std::match_results<span<char>::iterator> match;
+    std::match_results<span<char>::iterator> match;
 
-     std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
-     EXPECT_TRUE(match.ready());
-     EXPECT_FALSE(match.empty());
-     EXPECT_TRUE(match[0].matched);
-     EXPECT_TRUE(match[0].first == s.begin());
-     EXPECT_TRUE(match[0].second == s.end());
+    std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
+    EXPECT_TRUE(match.ready());
+    EXPECT_FALSE(match.empty());
+    EXPECT_TRUE(match[0].matched);
+    EXPECT_TRUE(match[0].first == s.begin());
+    EXPECT_TRUE(match[0].second == s.end());
 
-     std::regex_search(s.begin(), s.end(), match, std::regex("F"));
-     EXPECT_TRUE(match.ready());
-     EXPECT_FALSE(match.empty());
-     EXPECT_TRUE(match[0].matched);
-     EXPECT_TRUE(match[0].first == f_it);
-     EXPECT_TRUE(match[0].second == (f_it + 1));
- }
+    std::regex_search(s.begin(), s.end(), match, std::regex("F"));
+    EXPECT_TRUE(match.ready());
+    EXPECT_FALSE(match.empty());
+    EXPECT_TRUE(match[0].matched);
+    EXPECT_TRUE(match[0].first == f_it);
+    EXPECT_TRUE(match[0].second == (f_it + 1));
+}
 
- TEST(span_test, default_constructible)
- {
-     EXPECT_TRUE((std::is_default_constructible<span<int>>::value));
-     EXPECT_TRUE((std::is_default_constructible<span<int, 0>>::value));
-     EXPECT_FALSE((std::is_default_constructible<span<int, 42>>::value));
- }
+TEST(span_test, default_constructible)
+{
+    EXPECT_TRUE((std::is_default_constructible<span<int>>::value));
+    EXPECT_TRUE((std::is_default_constructible<span<int, 0>>::value));
+    EXPECT_FALSE((std::is_default_constructible<span<int, 42>>::value));
+}
 
- TEST(span_test, std_container_ctad)
- {
+TEST(span_test, std_container_ctad)
+{
 #if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
     // this test is just to verify that these compile
     {
-        std::vector<int> v{1,2,3,4};
+        std::vector<int> v{1, 2, 3, 4};
         gsl::span sp{v};
         static_assert(std::is_same<decltype(sp), gsl::span<int>>::value);
     }
@@ -1279,11 +1279,11 @@ TEST(span_test, from_array_constructor)
     }
 #endif
 #endif
- }
+}
 
- TEST(span_test, front_back)
- {
-    int arr[5] = {1,2,3,4,5};
+TEST(span_test, front_back)
+{
+    int arr[5] = {1, 2, 3, 4, 5};
     span<int> s{arr};
     EXPECT_TRUE(s.front() == 1);
     EXPECT_TRUE(s.back() == 5);
@@ -1297,4 +1297,4 @@ TEST(span_test, from_array_constructor)
     span<int> s2;
     EXPECT_DEATH(s2.front(), expected);
     EXPECT_DEATH(s2.back(), expected);
- }
+}

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -41,12 +41,13 @@
 #endif // __has_include
 #endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
 
+#include "deathTestCommon.h"
+
 using namespace std;
 using namespace gsl;
 
 namespace
 {
-static constexpr char deathstring[] = "Expected Death";
 
 struct BaseClass
 {
@@ -111,10 +112,12 @@ TEST(span_test, size_optimization)
 
 TEST(span_test, from_nullptr_size_constructor)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. from_nullptr_size_constructor";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     {
         span<int> s{nullptr, narrow_cast<span<int>::size_type>(0)};
         EXPECT_TRUE(s.size() == 0);
@@ -128,21 +131,21 @@ TEST(span_test, from_nullptr_size_constructor)
         auto workaround_macro = []() {
             const span<int, 1> s{nullptr, narrow_cast<span<int>::size_type>(0)};
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
     {
         auto workaround_macro = []() { const span<int> s{nullptr, 1}; };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
 
         auto const_workaround_macro = []() { const span<const int> s{nullptr, 1}; };
-        EXPECT_DEATH(const_workaround_macro(), deathstring);
+        EXPECT_DEATH(const_workaround_macro(), expected);
     }
     {
         auto workaround_macro = []() { const span<int, 0> s{nullptr, 1}; };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
 
         auto const_workaround_macro = []() { const span<const int, 0> s{nullptr, 1}; };
-        EXPECT_DEATH(const_workaround_macro(), deathstring);
+        EXPECT_DEATH(const_workaround_macro(), expected);
     }
     {
         span<int*> s{nullptr, narrow_cast<span<int>::size_type>(0)};
@@ -157,10 +160,12 @@ TEST(span_test, from_nullptr_size_constructor)
 
 TEST(span_test, from_pointer_length_constructor)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. from_pointer_length_constructor";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     int arr[4] = {1, 2, 3, 4};
 
     {
@@ -204,7 +209,7 @@ TEST(span_test, from_pointer_length_constructor)
     {
         int* p = nullptr;
         auto workaround_macro = [=]() { const span<int> s{p, 2}; };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 }
 
@@ -242,14 +247,14 @@ TEST(span_test, from_pointer_pointer_construction)
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
     //{
     //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
-    //    EXPECT_DEATH(workaround_macro(), deathstring);
+    //    EXPECT_DEATH(workaround_macro(), expected);
     //}
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
     //{
     //    int* p = nullptr;
     //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), deathstring);
+    //    EXPECT_DEATH(workaround_macro(), expected);
     //}
 
     {
@@ -270,7 +275,7 @@ TEST(span_test, from_pointer_pointer_construction)
     //{
     //    int* p = nullptr;
     //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), deathstring);
+    //    EXPECT_DEATH(workaround_macro(), expected);
     //}
 }
 
@@ -701,10 +706,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, first)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. first";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      int arr[5] = {1, 2, 3, 4, 5};
 
      {
@@ -731,7 +738,7 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(av.first<6>().size() == 6);
          EXPECT_TRUE(av.first<-1>().size() == -1);
  #endif
-         EXPECT_DEATH(av.first(6).size(), deathstring);
+         EXPECT_DEATH(av.first(6).size(), expected);
      }
 
      {
@@ -743,10 +750,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, last)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. last";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      int arr[5] = {1, 2, 3, 4, 5};
 
      {
@@ -772,7 +781,7 @@ TEST(span_test, from_array_constructor)
  #ifdef CONFIRM_COMPILATION_ERRORS
          EXPECT_TRUE(av.last<6>().size() == 6);
  #endif
-         EXPECT_DEATH(av.last(6).size(), deathstring);
+         EXPECT_DEATH(av.last(6).size(), expected);
      }
 
      {
@@ -784,10 +793,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, subspan)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. subspan";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      int arr[5] = {1, 2, 3, 4, 5};
 
      {
@@ -811,8 +822,8 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(decltype(av.subspan<0, 5>())::extent == 5);
          EXPECT_TRUE(av.subspan(0, 5).size() == 5);
 
-         EXPECT_DEATH(av.subspan(0, 6).size(), deathstring);
-         EXPECT_DEATH(av.subspan(1, 5).size(), deathstring);
+         EXPECT_DEATH(av.subspan(0, 6).size(), expected);
+         EXPECT_DEATH(av.subspan(1, 5).size(), expected);
      }
 
      {
@@ -821,7 +832,7 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(decltype(av.subspan<4, 0>())::extent == 0);
          EXPECT_TRUE(av.subspan(4, 0).size() == 0);
          EXPECT_TRUE(av.subspan(5, 0).size() == 0);
-         EXPECT_DEATH(av.subspan(6, 0).size(), deathstring);
+         EXPECT_DEATH(av.subspan(6, 0).size(), expected);
      }
 
      {
@@ -835,13 +846,13 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
          EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
          EXPECT_TRUE(av.subspan(0, 0).size() == 0);
-         EXPECT_DEATH((av.subspan<1, 0>().size()), deathstring);
+         EXPECT_DEATH((av.subspan<1, 0>().size()), expected);
      }
 
      {
          span<int> av;
          EXPECT_TRUE(av.subspan(0).size() == 0);
-         EXPECT_DEATH(av.subspan(1).size(), deathstring);
+         EXPECT_DEATH(av.subspan(1).size(), expected);
      }
 
      {
@@ -850,7 +861,7 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(av.subspan(1).size() == 4);
          EXPECT_TRUE(av.subspan(4).size() == 1);
          EXPECT_TRUE(av.subspan(5).size() == 0);
-         EXPECT_DEATH(av.subspan(6).size(), deathstring);
+         EXPECT_DEATH(av.subspan(6).size(), expected);
          const auto av2 = av.subspan(1);
          for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
      }
@@ -861,7 +872,7 @@ TEST(span_test, from_array_constructor)
          EXPECT_TRUE(av.subspan(1).size() == 4);
          EXPECT_TRUE(av.subspan(4).size() == 1);
          EXPECT_TRUE(av.subspan(5).size() == 0);
-         EXPECT_DEATH(av.subspan(6).size(), deathstring);
+         EXPECT_DEATH(av.subspan(6).size(), expected);
          const auto av2 = av.subspan(1);
          for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
      }
@@ -906,10 +917,11 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, incomparable_iterators)
  {
-     std::set_terminate([] {
+     const auto terminateHandler = std::set_terminate([] {
          std::cerr << "Expected Death. incomparable_iterators";
          std::abort();
      });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
      int a[] = {1, 2, 3, 4};
      int b[] = {1, 2, 3, 4};
@@ -917,21 +929,23 @@ TEST(span_test, from_array_constructor)
          span<int> s = a;
          span<int> s2 = b;
 #if (__cplusplus > 201402L)
-         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() == s2.begin()), deathstring);
-         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() <= s2.begin()), deathstring);
+         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() == s2.begin()), expected);
+         EXPECT_DEATH([[maybe_unused]] bool _ = (s.begin() <= s2.begin()), expected);
 #else
-         EXPECT_DEATH(bool _ = (s.begin() == s2.begin()), deathstring);
-         EXPECT_DEATH(bool _ = (s.begin() <= s2.begin()), deathstring);
+         EXPECT_DEATH(bool _ = (s.begin() == s2.begin()), expected);
+         EXPECT_DEATH(bool _ = (s.begin() <= s2.begin()), expected);
 #endif
      }
  }
 
  TEST(span_test, begin_end)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. begin_end";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      {
          int a[] = {1, 2, 3, 4};
          span<int> s = a;
@@ -956,7 +970,7 @@ TEST(span_test, from_array_constructor)
 
          auto beyond = s.end();
          EXPECT_TRUE(it != beyond);
-         EXPECT_DEATH(*beyond, deathstring);
+         EXPECT_DEATH(*beyond, expected);
 
          EXPECT_TRUE(beyond - first == 4);
          EXPECT_TRUE(first - first == 0);
@@ -986,10 +1000,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, rbegin_rend)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. rbegin_rend";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      {
          int a[] = {1, 2, 3, 4};
          span<int> s = a;
@@ -1002,9 +1018,9 @@ TEST(span_test, from_array_constructor)
          auto beyond = s.rend();
          EXPECT_TRUE(it != beyond);
 #if (__cplusplus > 201402L)
-        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond , deathstring);
+        EXPECT_DEATH([[maybe_unused]] auto _ = *beyond , expected);
 #else
-        EXPECT_DEATH(auto _ = *beyond , deathstring);
+        EXPECT_DEATH(auto _ = *beyond , expected);
 #endif
 
          EXPECT_TRUE(beyond - first == 4);
@@ -1035,10 +1051,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, as_bytes)
  {
-     std::set_terminate([] {
+     const auto terminateHandler = std::set_terminate([] {
          std::cerr << "Expected Death. as_bytes";
          std::abort();
      });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
 
      int a[] = {1, 2, 3, 4};
      {
@@ -1069,7 +1087,7 @@ TEST(span_test, from_array_constructor)
      int b[5] = {1, 2, 3, 4, 5};
      {
          span<int> sp(begin(b), static_cast<size_t>(-2));
-         EXPECT_DEATH((void) sp.size_bytes(), deathstring);
+         EXPECT_DEATH((void) sp.size_bytes(), expected);
      }
  }
 
@@ -1108,10 +1126,12 @@ TEST(span_test, from_array_constructor)
 
  TEST(span_test, fixed_size_conversions)
  {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. fixed_size_conversions";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
      int arr[] = {1, 2, 3, 4};
 
      // converting to an span from an equal size array is ok
@@ -1146,7 +1166,7 @@ TEST(span_test, from_array_constructor)
              const span<int, 2> s2 = s;
              static_cast<void>(s2);
          };
-         EXPECT_DEATH(f(), deathstring);
+         EXPECT_DEATH(f(), expected);
          */
      }
 
@@ -1193,7 +1213,7 @@ TEST(span_test, from_array_constructor)
              const span<int, 4> _s4{arr2, 2};
              static_cast<void>(_s4);
          };
-         EXPECT_DEATH(f(), deathstring);
+         EXPECT_DEATH(f(), expected);
      }
 
     /*
@@ -1203,7 +1223,7 @@ TEST(span_test, from_array_constructor)
          const span<int, 4> _s4 = av;
          static_cast<void>(_s4);
      };
-     EXPECT_DEATH(f(), deathstring);
+     EXPECT_DEATH(f(), expected);
      */
  }
 
@@ -1268,11 +1288,13 @@ TEST(span_test, from_array_constructor)
     EXPECT_TRUE(s.front() == 1);
     EXPECT_TRUE(s.back() == 5);
 
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. front_back";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     span<int> s2;
-    EXPECT_DEATH(s2.front(), deathstring);
-    EXPECT_DEATH(s2.back(), deathstring);
+    EXPECT_DEATH(s2.front(), expected);
+    EXPECT_DEATH(s2.back(), expected);
  }

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -14,8 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <gsl/pointers> // for not_null, operator<, operator<=, operator>
 #include <gtest/gtest.h>
-#include <gsl/pointers>           // for not_null, operator<, operator<=, operator>
 
 #include "deathTestCommon.h"
 
@@ -23,16 +23,24 @@ using namespace gsl;
 
 namespace
 {
-GSL_SUPPRESS(f.4)  // NO-FORMAT: attribute
+// clang-format off
+GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format on
 bool helper(not_null<int*> p) { return *p == 12; }
 
+// clang-format off
 GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format on
 bool helper_const(not_null<const int*> p) { return *p == 12; }
 
+// clang-format off
 GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format on
 bool strict_helper(strict_not_null<int*> p) { return *p == 12; }
 
+// clang-format off
 GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
+// clang-format on
 bool strict_helper_const(strict_not_null<const int*> p) { return *p == 12; }
 
 #ifdef CONFIRM_COMPILATION_ERRORS

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 #include <gsl/pointers>           // for not_null, operator<, operator<=, operator>
 
+#include "deathTestCommon.h"
+
 using namespace gsl;
 
 namespace
@@ -123,17 +125,14 @@ TEST(strict_notnull_tests, TestStrictNotNull)
 }
 
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
-namespace
-{
-static constexpr char deathstring[] = "Expected Death";
-}
 
 TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. TestStrictNotNullConstructorTypeDeduction";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     {
         int i = 42;
@@ -161,7 +160,7 @@ TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
             int* p1 = nullptr;
             const strict_not_null x{p1};
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
@@ -169,14 +168,14 @@ TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
             const int* p1 = nullptr;
             const strict_not_null x{p1};
         };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     {
         int* p = nullptr;
 
-        EXPECT_DEATH(helper(strict_not_null{p}), deathstring);
-        EXPECT_DEATH(helper_const(strict_not_null{p}), deathstring);
+        EXPECT_DEATH(helper(strict_not_null{p}), expected);
+        EXPECT_DEATH(helper_const(strict_not_null{p}), expected);
     }
 
 #ifdef CONFIRM_COMPILATION_ERRORS

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include <gsl/assert>  // for Expects, fail_fast (ptr only)
+#include <gsl/assert>      // for Expects, fail_fast (ptr only)
 #include <gsl/pointers>    // for owner
 #include <gsl/span>        // for span, dynamic_extent
 #include <gsl/string_span> // for basic_string_span, operator==, ensure_z
@@ -74,8 +74,7 @@ T create()
 
 template <class T>
 void use(basic_string_span<T, gsl::dynamic_extent>)
-{
-}
+{}
 #endif
 
 czstring_span<> CreateTempName(string_span<> span)
@@ -83,7 +82,8 @@ czstring_span<> CreateTempName(string_span<> span)
     Expects(span.size() > 1);
 
     std::size_t last = 0;
-    if (span.size() > 4) {
+    if (span.size() > 4)
+    {
         span[0] = 't';
         span[1] = 'm';
         span[2] = 'p';
@@ -100,7 +100,8 @@ cwzstring_span<> CreateTempNameW(wstring_span<> span)
     Expects(span.size() > 1);
 
     std::size_t last = 0;
-    if (span.size() > 4) {
+    if (span.size() > 4)
+    {
         span[0] = L't';
         span[1] = L'm';
         span[2] = L'p';
@@ -117,7 +118,8 @@ cu16zstring_span<> CreateTempNameU16(u16string_span<> span)
     Expects(span.size() > 1);
 
     std::size_t last = 0;
-    if (span.size() > 4) {
+    if (span.size() > 4)
+    {
         span[0] = u't';
         span[1] = u'm';
         span[2] = u'p';
@@ -134,7 +136,8 @@ cu32zstring_span<> CreateTempNameU32(u32string_span<> span)
     Expects(span.size() > 1);
 
     std::size_t last = 0;
-    if (span.size() > 4) {
+    if (span.size() > 4)
+    {
         span[0] = U't';
         span[1] = U'm';
         span[2] = U'p';
@@ -980,7 +983,8 @@ TEST(string_span_tests, zstring)
         char buf[10];
 
         auto name = CreateTempName({buf, 10});
-        if (!name.empty()) {
+        if (!name.empty())
+        {
             czstring<> str = name.assume_z();
             EXPECT_TRUE(generic::strlen(str) == 3);
             EXPECT_TRUE(*(str + 3) == '\0');
@@ -1022,7 +1026,8 @@ TEST(string_span_tests, wzstring)
         wchar_t buf[10];
 
         const auto name = CreateTempNameW({buf, 10});
-        if (!name.empty()) {
+        if (!name.empty())
+        {
             cwzstring<> str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');
@@ -1064,7 +1069,8 @@ TEST(string_span_tests, u16zstring)
         char16_t buf[10];
 
         const auto name = CreateTempNameU16({buf, 10});
-        if (!name.empty()) {
+        if (!name.empty())
+        {
             cu16zstring<> str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');
@@ -1106,7 +1112,8 @@ TEST(string_span_tests, u32zstring)
         char32_t buf[10];
 
         const auto name = CreateTempNameU32({buf, 10});
-        if (!name.empty()) {
+        if (!name.empty())
+        {
             cu32zstring<> str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -28,13 +28,11 @@
 #include <type_traits> // for remove_reference<>::type
 #include <vector>      // for vector, allocator
 
+#include "deathTestCommon.h"
+
 using namespace std;
 using namespace gsl;
 
-namespace
-{
-static constexpr char deathstring[] = "Expected Death";
-}
 // Generic string functions
 
 namespace generic
@@ -950,10 +948,11 @@ TEST(string_span_tests, Conversion)
 
 TEST(string_span_tests, zstring)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. zstring";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     // create zspan from zero terminated string
     {
@@ -973,7 +972,7 @@ TEST(string_span_tests, zstring)
         buf[0] = 'a';
 
         auto workaround_macro = [&]() { const zstring_span<> zspan({buf, 1}); };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     // usage scenario: create zero-terminated temp file name and pass to a legacy API
@@ -991,10 +990,11 @@ TEST(string_span_tests, zstring)
 
 TEST(string_span_tests, wzstring)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. wzstring";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     // create zspan from zero terminated string
     {
@@ -1014,7 +1014,7 @@ TEST(string_span_tests, wzstring)
         buf[0] = L'a';
 
         const auto workaround_macro = [&]() { const wzstring_span<> zspan({buf, 1}); };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     // usage scenario: create zero-terminated temp file name and pass to a legacy API
@@ -1032,10 +1032,11 @@ TEST(string_span_tests, wzstring)
 
 TEST(string_span_tests, u16zstring)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. u16zstring";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     // create zspan from zero terminated string
     {
@@ -1055,7 +1056,7 @@ TEST(string_span_tests, u16zstring)
         buf[0] = u'a';
 
         const auto workaround_macro = [&]() { const u16zstring_span<> zspan({buf, 1}); };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     // usage scenario: create zero-terminated temp file name and pass to a legacy API
@@ -1073,10 +1074,11 @@ TEST(string_span_tests, u16zstring)
 
 TEST(string_span_tests, u32zstring)
 {
-    std::set_terminate([] {
+    const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. u31zstring";
         std::abort();
     });
+    const auto expected = GetExpectedDeathString(terminateHandler);
 
     // create zspan from zero terminated string
     {
@@ -1096,7 +1098,7 @@ TEST(string_span_tests, u32zstring)
         buf[0] = u'a';
 
         const auto workaround_macro = [&]() { const u32zstring_span<> zspan({buf, 1}); };
-        EXPECT_DEATH(workaround_macro(), deathstring);
+        EXPECT_DEATH(workaround_macro(), expected);
     }
 
     // usage scenario: create zero-terminated temp file name and pass to a legacy API

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -123,6 +123,7 @@ TEST(utils_tests, narrow_cast)
     EXPECT_TRUE(uc == 44);
 }
 
+#ifndef GSL_KERNEL_MODE
 TEST(utils_tests, narrow)
 {
     int n = 120;
@@ -145,3 +146,4 @@ TEST(utils_tests, narrow)
     n = -42;
     EXPECT_THROW(narrow<unsigned>(n), narrowing_error);
 }
+#endif // GSL_KERNEL_MODE

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -16,14 +16,14 @@
 
 #include <gtest/gtest.h>
 
-#include <gsl/util>     // finally, narrow_cast
-#include <gsl/narrow>   // for narrow, narrowing_error
 #include <algorithm>   // for move
+#include <cstddef>     // for std::ptrdiff_t
 #include <functional>  // for reference_wrapper, _Bind_helper<>::type
+#include <gsl/narrow>  // for narrow, narrowing_error
+#include <gsl/util>    // finally, narrow_cast
 #include <limits>      // for numeric_limits
 #include <stdint.h>    // for uint32_t, int32_t
 #include <type_traits> // for is_same
-#include <cstddef>     // for std::ptrdiff_t
 
 using namespace gsl;
 
@@ -32,8 +32,7 @@ namespace
 void f(int& i) { i += 1; }
 static int j = 0;
 void g() { j += 1; }
-}
-
+} // namespace
 
 TEST(utils_tests, sanity_check_for_gsl_index_typedef)
 {


### PR DESCRIPTION
Changed the file location of gsl::span specialization for gsl::at from <gsl/span_ext> to <gsl/span>, addressing #983.
Changed first parameter of gsl::span specialization for gsl::at to take the span by reference, addressing #984.