### PR TITLE
make zstring family don't require empty angle brackets any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ not_null                           | &#x2611;   | restricts a pointer / smart po
 span                               | &#x2611;   | a view over a contiguous sequence of memory. Based on the standardized verison of `std::span`, however `gsl::span` enforces bounds checking. See the [wiki](https://github.com/microsoft/GSL/wiki/gsl::span-and-std::span) for additional information.
 span_p                             | &#x2610;   | spans a range starting from a pointer to the first place for which the predicate is true
 basic_zstring                      | &#x2611;   | A pointer to a C-string (zero-terminated array) with a templated char type
-zstring                            | &#x2611;   | An alias to `basic_zstring` with a char type of char
-czstring                           | &#x2611;   | An alias to `basic_zstring` with a char type of const char
-wzstring                           | &#x2611;   | An alias to `basic_zstring` with a char type of wchar_t
-cwzstring                          | &#x2611;   | An alias to `basic_zstring` with a char type of const wchar_t
-u16zstring                         | &#x2611;   | An alias to `basic_zstring` with a char type of char16_t
-cu16zstring                        | &#x2611;   | An alias to `basic_zstring` with a char type of const char16_t
-u32zstring                         | &#x2611;   | An alias to `basic_zstring` with a char type of char32_t
-cu32zstring                        | &#x2611;   | An alias to `basic_zstring` with a char type of const char32_t
+zstring                            | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of char
+czstring                           | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of const char
+wzstring                           | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of wchar_t
+cwzstring                          | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of const wchar_t
+u16zstring                         | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of char16_t
+cu16zstring                        | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of const char16_t
+u32zstring                         | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of char32_t
+cu32zstring                        | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of const char32_t
 [**2. Owners**][cg-owners]         |            |
 unique_ptr                         | &#x2611;   | an alias to `std::unique_ptr`
 shared_ptr                         | &#x2611;   | an alias to `std::shared_ptr`

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -59,29 +59,21 @@ namespace gsl
 template <typename CharT, std::size_t Extent = dynamic_extent>
 using basic_zstring = CharT*;
 
-template <std::size_t Extent = dynamic_extent>
-using czstring = basic_zstring<const char, Extent>;
+using czstring = basic_zstring<const char, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using cwzstring = basic_zstring<const wchar_t, Extent>;
+using cwzstring = basic_zstring<const wchar_t, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using cu16zstring = basic_zstring<const char16_t, Extent>;
+using cu16zstring = basic_zstring<const char16_t, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using cu32zstring = basic_zstring<const char32_t, Extent>;
+using cu32zstring = basic_zstring<const char32_t, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using zstring = basic_zstring<char, Extent>;
+using zstring = basic_zstring<char, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using wzstring = basic_zstring<wchar_t, Extent>;
+using wzstring = basic_zstring<wchar_t, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using u16zstring = basic_zstring<char16_t, Extent>;
+using u16zstring = basic_zstring<char16_t, dynamic_extent>;
 
-template <std::size_t Extent = dynamic_extent>
-using u32zstring = basic_zstring<char32_t, Extent>;
+using u32zstring = basic_zstring<char32_t, dynamic_extent>;
 
 namespace details
 {

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -985,7 +985,7 @@ TEST(string_span_tests, zstring)
         auto name = CreateTempName({buf, 10});
         if (!name.empty())
         {
-            czstring<> str = name.assume_z();
+            czstring str = name.assume_z();
             EXPECT_TRUE(generic::strlen(str) == 3);
             EXPECT_TRUE(*(str + 3) == '\0');
         }
@@ -1028,7 +1028,7 @@ TEST(string_span_tests, wzstring)
         const auto name = CreateTempNameW({buf, 10});
         if (!name.empty())
         {
-            cwzstring<> str = name.assume_z();
+            cwzstring str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');
         }
@@ -1071,7 +1071,7 @@ TEST(string_span_tests, u16zstring)
         const auto name = CreateTempNameU16({buf, 10});
         if (!name.empty())
         {
-            cu16zstring<> str = name.assume_z();
+            cu16zstring str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');
         }
@@ -1114,7 +1114,7 @@ TEST(string_span_tests, u32zstring)
         const auto name = CreateTempNameU32({buf, 10});
         if (!name.empty())
         {
-            cu32zstring<> str = name.assume_z();
+            cu32zstring str = name.assume_z();
             EXPECT_TRUE(generic::strnlen(str, 10) == 3);
             EXPECT_TRUE(*(str + 3) == L'\0');
         }


### PR DESCRIPTION
Closes issue #992.