### PR TITLE
Fix build failure with gcc 11+

### DIFF
--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           389cb68b87193358358ae87cc56d257fd0d80189
+  GIT_TAG           1b18723e874b256c1e39378c6774a90701d70f7a
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Fixes https://github.com/microsoft/GSL/issues/1014. The issue was resolved in https://github.com/google/googletest/pull/3024. Pulling latest googletest.