### PR TITLE
Fix/implement C++2020 compilation, tests, and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,14 @@ This is based on [CppCoreGuidelines semi-specification](https://github.com/isocp
 
 # Quick Start
 ## Supported Compilers
-The GSL officially supports the current and previous major release of MSVC, GCC, Clang, and XCode's Apple-Clang.
-See our latest test results for the most up-to-date list of supported configurations.
+The GSL officially supports the following versions of MSVC, GCC, Clang, and XCode's Apple-Clang.
 
 Compiler |Toolset Versions Currently Tested
 :------- |--:
- XCode |11.4 & 10.3
- GCC |9 & 8
- Clang |11 &  10
- Visual Studio with MSVC | VS2017 (15.9) & VS2019 (16.4) 
- Visual Studio with LLVM | VS2017 (Clang 9) & VS2019 (Clang 10)
+ XCode | 12.4 & 11.3
+ GCC | 9.3.0 & 7.5.0
+ Clang | 11.0.0 & 9.0.0
+ Visual Studio with MSVC | VS2017 (15.9.21) & VS2019 (16.11.2)
 
 ---
 If you successfully port GSL to another platform, we would love to hear from you!

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,12 @@ stages:
     parameters:
       jobName: 'Validate GCC latest'
       imageName: ubuntu-20.04
+      CXXVersions: [ 14, 17 ]
   - template: ./pipelines/jobs.yml
     parameters:
       jobName: 'Validate GCC Previous'
       imageName: ubuntu-18.04
+      CXXVersions: [ 14, 17 ]
 
 # Clang
 - stage: Clang
@@ -40,6 +42,7 @@ stages:
     parameters:
       jobName: 'Validate Clang Previous'
       imageName: ubuntu-18.04
+      CXXVersions: [ 14, 17 ]
 
 # MSVC
 - stage: MSVC
@@ -53,6 +56,7 @@ stages:
     parameters:
       jobName: 'Validate MSVC Previous'
       imageName: vs2017-win2016
+      CXXVersions: [ 14, 17 ]
 
 # Apple-Clang
 - stage: Apple_Clang
@@ -62,7 +66,9 @@ stages:
     parameters:
       jobName: 'Validate Apple-Clang latest'
       imageName: macos-10.15
+      CXXVersions: [ 14, 17 ]
   - template: ./pipelines/jobs.yml
     parameters:
       jobName: 'Validate Apple-Clang Previous'
       imageName: macos-10.14
+      CXXVersions: [ 14, 17 ]

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -143,10 +143,10 @@ GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
 
 #if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 template <class T, size_t extent = std::dynamic_extent>
-constexpr auto at(std::span<T, extent> sp, const index i)
+constexpr auto at(std::span<T, extent> sp, const index i) -> decltype(sp[sp.size()])
 {
-    Expects(i >= 0 && i < narrow_cast<i>(sp.size()));
-    return sp[i];
+    Expects(i >= 0 && i < narrow_cast<index>(sp.size()));
+    return sp[gsl::narrow_cast<size_t>(i)];
 }
 #endif // __cpp_lib_span >= 202002L
 } // namespace gsl

--- a/pipelines/jobs.yml
+++ b/pipelines/jobs.yml
@@ -11,24 +11,23 @@ jobs:
     matrix:
       14_debug:
         GSL_CXX_STANDARD: '14'
-        CMAKE_CXX_STANDARD: '14'
         BUILD_TYPE: 'Debug'
       14_release:
         GSL_CXX_STANDARD: '14'
-        CMAKE_CXX_STANDARD: '14'
         BUILD_TYPE: 'Release'
       17_debug:
         GSL_CXX_STANDARD: '17'
-        CMAKE_CXX_STANDARD: '17'
         BUILD_TYPE: 'Debug'
       17_release:
         GSL_CXX_STANDARD: '17'
-        CMAKE_CXX_STANDARD: '17'
         BUILD_TYPE: 'Release'
+      # Note: Currently, only some C++20 features are supported by GSL
       20_debug:
-        GSL_CXX_STANDARD: '17'
-        CMAKE_CXX_STANDARD: '20'
+        GSL_CXX_STANDARD: '20'
         BUILD_TYPE: 'Debug'
+      20_release:
+        GSL_CXX_STANDARD: '20'
+        BUILD_TYPE: 'Release'
   continueOnError: false
   steps:
   - template: ./steps.yml

--- a/pipelines/jobs.yml
+++ b/pipelines/jobs.yml
@@ -1,33 +1,19 @@
 parameters:
   jobName: ''
   imageName: ''
+  CXXVersions: [ 14, 17, 20 ]
+  buildTypes: [ 'Debug', 'Release' ]
 
 jobs:
-- job:
-  displayName: ${{ parameters.imageName }}
-  pool:
-    vmImage: ${{ parameters.imageName }}
-  strategy:
-    matrix:
-      14_debug:
-        GSL_CXX_STANDARD: '14'
-        BUILD_TYPE: 'Debug'
-      14_release:
-        GSL_CXX_STANDARD: '14'
-        BUILD_TYPE: 'Release'
-      17_debug:
-        GSL_CXX_STANDARD: '17'
-        BUILD_TYPE: 'Debug'
-      17_release:
-        GSL_CXX_STANDARD: '17'
-        BUILD_TYPE: 'Release'
-      # Note: Currently, only some C++20 features are supported by GSL
-      20_debug:
-        GSL_CXX_STANDARD: '20'
-        BUILD_TYPE: 'Debug'
-      20_release:
-        GSL_CXX_STANDARD: '20'
-        BUILD_TYPE: 'Release'
-  continueOnError: false
-  steps:
-  - template: ./steps.yml
+- ${{ each CXXVersion in parameters.CXXVersions }}:
+  - ${{ each buildType in parameters.buildTypes }}:
+    - job:
+      displayName: ${{ format('{0} {1} C++{2}', parameters.imageName, buildType, CXXVersion) }}
+      pool:
+        vmImage: ${{ parameters.imageName }}
+      continueOnError: false
+      steps:
+      - template: ./steps.yml
+        parameters:
+          buildType: ${{ buildType }}
+          CXXVersion: ${{ CXXVersion }}

--- a/pipelines/jobs.yml
+++ b/pipelines/jobs.yml
@@ -11,16 +11,24 @@ jobs:
     matrix:
       14_debug:
         GSL_CXX_STANDARD: '14'
+        CMAKE_CXX_STANDARD: '14'
         BUILD_TYPE: 'Debug'
       14_release:
         GSL_CXX_STANDARD: '14'
+        CMAKE_CXX_STANDARD: '14'
         BUILD_TYPE: 'Release'
       17_debug:
         GSL_CXX_STANDARD: '17'
+        CMAKE_CXX_STANDARD: '17'
         BUILD_TYPE: 'Debug'
       17_release:
         GSL_CXX_STANDARD: '17'
+        CMAKE_CXX_STANDARD: '17'
         BUILD_TYPE: 'Release'
+      20_debug:
+        GSL_CXX_STANDARD: '17'
+        CMAKE_CXX_STANDARD: '20'
+        BUILD_TYPE: 'Debug'
   continueOnError: false
   steps:
   - template: ./steps.yml

--- a/pipelines/steps.yml
+++ b/pipelines/steps.yml
@@ -3,7 +3,7 @@ steps:
     name: Configure
     inputs:
       workingDirectory: build
-      cmakeArgs: '-DCMAKE_CXX_STANDARD=$(CMAKE_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
+      cmakeArgs: '-DGSL_CXX_STANDARD=$(GSL_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
 
   - task: CMake@1
     name: Build

--- a/pipelines/steps.yml
+++ b/pipelines/steps.yml
@@ -3,7 +3,7 @@ steps:
     name: Configure
     inputs:
       workingDirectory: build
-      cmakeArgs: '-DCMAKE_CXX_STANDARD=$(GSL_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
+      cmakeArgs: '-DCMAKE_CXX_STANDARD=$(CMAKE_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
 
   - task: CMake@1
     name: Build

--- a/pipelines/steps.yml
+++ b/pipelines/steps.yml
@@ -1,9 +1,13 @@
+parameters:
+    buildType: ''
+    CXXVersion: ''
+
 steps:
   - task: CMake@1
     name: Configure
     inputs:
       workingDirectory: build
-      cmakeArgs: '-DGSL_CXX_STANDARD=$(GSL_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
+      cmakeArgs: '-DGSL_CXX_STANDARD=${{ parameters.CXXVersion }} -DCMAKE_BUILD_TYPE=${{ parameters.buildType }} -DCI_TESTING:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -Werror=dev .. '
 
   - task: CMake@1
     name: Build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,12 @@ else()
             -Wno-unused-member-function
             -Wno-unused-variable
           >
+          $<$<BOOL:${CMAKE_CXX_STANDARD}>:
+            $<$<EQUAL:${CMAKE_CXX_STANDARD},20>:
+                -Wno-zero-as-null-pointer-constant # Very noisy, minor, and just so
+                -Wno-sign-conversion                                                                   # happens to trigger on googletest
+          >
+        >
         >
         $<$<CXX_COMPILER_ID:Clang>:
           $<$<AND:$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,4.99>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6>>:
@@ -232,6 +238,11 @@ else()
         -Wpedantic
         -Wshadow
         -Wsign-conversion
+        $<$<BOOL:${CMAKE_CXX_STANDARD}>:                                                           # happens to trigger on googletest
+          $<$<EQUAL:${CMAKE_CXX_STANDARD},20>:
+              -Wno-sign-conversion                                                                   # happens to trigger on googletest
+          >
+        >
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ include(ExternalProject)
 # will make visual studio generated project group files
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if(CI_TESTING AND GSL_CXX_STANDARD EQUAL 20)
+    add_compile_definitions(FORCE_STD_SPAN_TESTS=1)
+endif()
+
 if(IOS)
     add_compile_definitions(GTEST_HAS_DEATH_TEST=1 IOS_PROCESS_DELAY_WORKAROUND=1)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     find_package(Microsoft.GSL REQUIRED)
 endif()
 
-if (MSVC AND (GSL_CXX_STANDARD EQUAL 17))
+if (MSVC AND (GSL_CXX_STANDARD GREATER_EQUAL 17))
     set(GSL_CPLUSPLUS_OPT -Zc:__cplusplus -permissive-)
 endif()
 
@@ -130,16 +130,15 @@ else()
             -Wno-unused-member-function
             -Wno-unused-variable
           >
-          $<$<BOOL:${CMAKE_CXX_STANDARD}>:
-            $<$<EQUAL:${CMAKE_CXX_STANDARD},20>:
-                -Wno-zero-as-null-pointer-constant # Very noisy, minor, and just so
-                -Wno-sign-conversion                                                                   # happens to trigger on googletest
-          >
-        >
         >
         $<$<CXX_COMPILER_ID:Clang>:
           $<$<AND:$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,4.99>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6>>:
             $<$<EQUAL:${GSL_CXX_STANDARD},17>:-Wno-undefined-func-template>
+          >
+          $<$<AND:$<EQUAL:${GSL_CXX_STANDARD},20>,$<CXX_COMPILER_VERSION:11.0.0>>:
+              -Wno-zero-as-null-pointer-constant  # failing Clang Ubuntu 20.04 tests, seems to be a bug with clang 11.0.0
+                                                  # (operator< is being re-written by the compiler as operator<=> and
+                                                  # raising the warning)
           >
         >
         $<$<CXX_COMPILER_ID:AppleClang>:
@@ -238,11 +237,6 @@ else()
         -Wpedantic
         -Wshadow
         -Wsign-conversion
-        $<$<BOOL:${CMAKE_CXX_STANDARD}>:                                                           # happens to trigger on googletest
-          $<$<EQUAL:${CMAKE_CXX_STANDARD},20>:
-              -Wno-sign-conversion                                                                   # happens to trigger on googletest
-          >
-        >
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -27,7 +27,6 @@ namespace gsl
 struct fail_fast;
 } // namespace gsl
 
-using namespace std;
 using namespace gsl;
 
 TEST(algorithm_tests, same_type)
@@ -73,8 +72,8 @@ TEST(algorithm_tests, same_type)
         std::array<int, 5> src{1, 2, 3, 4, 5};
         std::array<int, 10> dst{};
 
-        const span<int> src_span(src);
-        const span<int, 10> dst_span(dst);
+        const gsl::span<int> src_span(src);
+        const gsl::span<int, 10> dst_span(dst);
 
         copy(src_span, dst_span);
         copy(src_span, dst_span.subspan(src_span.size()));

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -119,7 +119,7 @@ TEST(at_tests, InitializerList)
     EXPECT_DEATH(gsl::at({1, 2, 3, 4}, 4), expected);
 }
 
-#if defined(__cplusplus) && __cplusplus >= 202002L
+#if defined(FORCE_STD_SPAN_TESTS) || defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 TEST(at_tests, std_span)
 {
     std::vector<int> vec{1, 2, 3, 4, 5};
@@ -145,7 +145,7 @@ TEST(at_tests, std_span)
     EXPECT_DEATH(gsl::at(csp, -1), expected);
     EXPECT_DEATH(gsl::at(csp, gsl::narrow_cast<gsl::index>(sp.size())), expected);
 }
-#endif // __cplusplus >= 202002L
+#endif // defined(FORCE_STD_SPAN_TESTS) || defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 
 #if !defined(_MSC_VER) || defined(__clang__) || _MSC_VER >= 1910
 static constexpr bool test_constexpr()

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -128,16 +128,22 @@ TEST(at_tests, std_span)
     std::vector<int> cvec{1, 2, 3, 4, 5};
     std::span csp{cvec};
 
-    for (size_t i = 0, i < vec.size(); ++i)
+    for (gsl::index i = 0; i < gsl::narrow_cast<gsl::index>(vec.size()); ++i)
     {
-        EXPECT_TRUE(&gsl::at(sp, i) == &vec[i]);
-        EXPECT_TRUE(&gsl::at(csp, i) == &cvec[i]);
+        EXPECT_TRUE(&gsl::at(sp, i) == &vec[gsl::narrow_cast<size_t>(i)]);
+        EXPECT_TRUE(&gsl::at(csp, i) == &cvec[gsl::narrow_cast<size_t>(i)]);
     }
 
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. std_span";
+        std::abort();
+    });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     EXPECT_DEATH(gsl::at(sp, -1), expected);
-    EXPECT_DEATH(gsl::at(sp, sp.size()), expected);
+    EXPECT_DEATH(gsl::at(sp, gsl::narrow_cast<gsl::index>(sp.size())), expected);
     EXPECT_DEATH(gsl::at(csp, -1), expected);
-    EXPECT_DEATH(gsl::at(csp, sp.size()), expected);
+    EXPECT_DEATH(gsl::at(csp, gsl::narrow_cast<gsl::index>(sp.size())), expected);
 }
 #endif // __cplusplus >= 202002L
 

--- a/tests/span_compatibility_tests.cpp
+++ b/tests/span_compatibility_tests.cpp
@@ -55,14 +55,14 @@ void ArrayConvertibilityCheck()
         EXPECT_TRUE(sp_const_nullptr_1.data() == stl_nullptr.data());
         EXPECT_TRUE(sp_const_nullptr_1.size() == 3);
 
-        span<const T* const> sp_const_nullptr_2{std::as_const(stl_nullptr)};
+        gsl::span<const T* const> sp_const_nullptr_2{std::as_const(stl_nullptr)};
         EXPECT_TRUE(sp_const_nullptr_2.data() == stl_nullptr.data());
         EXPECT_TRUE(sp_const_nullptr_2.size() == 3);
 
-        static_assert(std::is_same<decltype(span{stl_nullptr}), span<T*, 3>>::value,
+        static_assert(std::is_same<decltype(gsl::span{stl_nullptr}), gsl::span<T*, 3>>::value,
                       "std::is_same< decltype(span{stl_nullptr}), span<T*, 3>>::value");
         static_assert(
-            std::is_same<decltype(span{std::as_const(stl_nullptr)}), span<T* const, 3>>::value,
+            std::is_same<decltype(gsl::span{std::as_const(stl_nullptr)}), gsl::span<T* const, 3>>::value,
             "std::is_same< decltype(span{std::as_const(stl_nullptr)}), span<T* const, "
             "3>>::value");
     }

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -48,7 +48,7 @@ TEST(span_ext_test, make_span_from_pointer_length_constructor)
 
     {
         int* p = nullptr;
-        auto s = make_span(p, narrow_cast<span<int>::size_type>(0));
+        auto s = make_span(p, narrow_cast<gsl::span<int>::size_type>(0));
         EXPECT_TRUE(s.size() == 0);
         EXPECT_TRUE(s.data() == nullptr);
     }
@@ -136,9 +136,9 @@ TEST(span_ext_test, make_span_from_std_array_constructor)
 
     // This test checks for the bug found in gcc 6.1, 6.2, 6.3, 6.4, 6.5 7.1, 7.2, 7.3 - issue #590
     {
-        span<int> s1 = make_span(arr);
+        gsl::span<int> s1 = make_span(arr);
 
-        static span<int> s2;
+        static gsl::span<int> s2;
         s2 = s1;
 
 #if defined(__GNUC__) && __GNUC__ == 6 && (__GNUC_MINOR__ == 4 || __GNUC_MINOR__ == 5) &&          \
@@ -194,7 +194,7 @@ TEST(span_ext_test, make_span_from_container_constructor)
 TEST(span_test, interop_with_gsl_at)
 {
     int arr[5] = {1, 2, 3, 4, 5};
-    span<int> s{arr};
+    gsl::span<int> s{arr};
     EXPECT_TRUE(at(s, 0) == 1);
     EXPECT_TRUE(at(s, 1) == 2);
 }
@@ -202,7 +202,7 @@ TEST(span_test, interop_with_gsl_at)
 TEST(span_ext_test, iterator_free_functions)
 {
     int a[] = {1, 2, 3, 4};
-    span<int> s{a};
+    gsl::span<int> s{a};
 
     EXPECT_TRUE((std::is_same<decltype(s.begin()), decltype(begin(s))>::value));
     EXPECT_TRUE((std::is_same<decltype(s.end()), decltype(end(s))>::value));
@@ -232,7 +232,7 @@ TEST(span_ext_test, iterator_free_functions)
 TEST(span_ext_test, ssize_free_function)
 {
     int a[] = {1, 2, 3, 4};
-    span<int> s{a};
+    gsl::span<int> s{a};
 
     EXPECT_FALSE((std::is_same<decltype(s.size()), decltype(ssize(s))>::value));
     EXPECT_TRUE(s.size() == static_cast<std::size_t>(ssize(s)));
@@ -242,8 +242,8 @@ TEST(span_ext_test, ssize_free_function)
 TEST(span_ext_test, comparison_operators)
 {
     {
-        span<int> s1;
-        span<int> s2;
+        gsl::span<int> s1;
+        gsl::span<int> s2;
         EXPECT_TRUE(s1 == s2);
         EXPECT_FALSE(s1 != s2);
         EXPECT_FALSE(s1 < s2);
@@ -260,8 +260,8 @@ TEST(span_ext_test, comparison_operators)
 
     {
         int arr[] = {2, 1};
-        span<int> s1 = arr;
-        span<int> s2 = arr;
+        gsl::span<int> s1 = arr;
+        gsl::span<int> s2 = arr;
 
         EXPECT_TRUE(s1 == s2);
         EXPECT_FALSE(s1 != s2);
@@ -280,8 +280,8 @@ TEST(span_ext_test, comparison_operators)
     {
         int arr[] = {2, 1}; // bigger
 
-        span<int> s1;
-        span<int> s2 = arr;
+        gsl::span<int> s1;
+        gsl::span<int> s2 = arr;
 
         EXPECT_TRUE(s1 != s2);
         EXPECT_TRUE(s2 != s1);
@@ -300,8 +300,8 @@ TEST(span_ext_test, comparison_operators)
     {
         int arr1[] = {1, 2};
         int arr2[] = {1, 2};
-        span<int> s1 = arr1;
-        span<int> s2 = arr2;
+        gsl::span<int> s1 = arr1;
+        gsl::span<int> s2 = arr2;
 
         EXPECT_TRUE(s1 == s2);
         EXPECT_FALSE(s1 != s2);
@@ -320,8 +320,8 @@ TEST(span_ext_test, comparison_operators)
     {
         int arr[] = {1, 2, 3};
 
-        span<int> s1 = {&arr[0], 2}; // shorter
-        span<int> s2 = arr;          // longer
+        gsl::span<int> s1 = {&arr[0], 2}; // shorter
+        gsl::span<int> s2 = arr;          // longer
 
         EXPECT_TRUE(s1 != s2);
         EXPECT_TRUE(s2 != s1);
@@ -341,8 +341,8 @@ TEST(span_ext_test, comparison_operators)
         int arr1[] = {1, 2}; // smaller
         int arr2[] = {2, 1}; // bigger
 
-        span<int> s1 = arr1;
-        span<int> s2 = arr2;
+        gsl::span<int> s1 = arr1;
+        gsl::span<int> s2 = arr2;
 
         EXPECT_TRUE(s1 != s2);
         EXPECT_TRUE(s2 != s1);

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -43,7 +43,6 @@
 
 #include "deathTestCommon.h"
 
-using namespace std;
 using namespace gsl;
 
 namespace
@@ -1085,7 +1084,7 @@ TEST(span_test, as_bytes)
 
     int b[5] = {1, 2, 3, 4, 5};
     {
-        span<int> sp(begin(b), static_cast<size_t>(-2));
+        span<int> sp(std::begin(b), static_cast<size_t>(-2));
         EXPECT_DEATH((void) sp.size_bytes(), expected);
     }
 }

--- a/tests/string_span_tests.cpp
+++ b/tests/string_span_tests.cpp
@@ -30,7 +30,6 @@
 
 #include "deathTestCommon.h"
 
-using namespace std;
 using namespace gsl;
 
 // Generic string functions


### PR DESCRIPTION
The C++2020 features (`std::span` support) were not enabled in the CI. As a result, the code had compilation issues that were never caught. Furthermore, the compiler versions in the README did not match up to the compilers that were actually being tested. For instance, the minimum GCC version advertised is 8, but we are testing 7.5.0 instead. The precise versions we *should* be testing will be re-visited in a later PR. But for now, this PR simply updates the README to be accurate to what is currently being tested.

Compiler | Advertised (before this PR) | Actually Tested
:------- | :-- | :-- 
 XCode |11.4 & 10.3 | 12.4 & 11.3 
 GCC |9 & 8| 9.3.0 & 7.5.0 
 Clang |11 &  10 | 11.0.0 & 9.0.0
 Visual Studio with MSVC | VS2017 (15.9) & VS2019 (16.4) | VS2017 (15.9.21) & VS2019 (16.11.2)
 Visual Studio with LLVM | VS2017 (Clang 9) & VS2019 (Clang 10) | none | none |

Previously, the guard for the span tests was `__cplusplus >= 202002L`. Unfortunately, this does not work for all compilers. For instance, in `GCC 10`, running with `-std=c++20` will *fail* the above condition (`__cplusplus` will still be at 2017), and yet `__cpp_lib_span >= 202002L` will be true. But for `GCC 9` and `GCC 8`, `__cplusplus` will still be at 2017 and `__cpp_lib_span` is undefined (neither have `<span>` support). In all cases above, the span tests will be silently skipped.
To avoid this confusing / incorrect (in the case of `GCC 10`) behavior, make the span tests execute unconditionally if running in CI mode with C++20 enabled. If a compiler version does not support span, the C++20 version should be explicitly removed from its CI jobs.


