### PR TITLE
Add tests for VS2022 with LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ Compiler |Toolset Versions Currently Tested
  GCC | 11.1.0 & 10.3.0
  Clang | 11.0.0 & 10.0.0
  Visual Studio with MSVC | VS2019 (16.11) & VS2022 (17.0)
- Visual Studio with LLVM | VS2019 (16.11)
-
-- Support for Visual Studio 2022 with LLVM will be added in the near future
+ Visual Studio with LLVM | VS2019 (16.11) & VS2022 (17.0)
 
 ---
 If you successfully port GSL to another platform, we would love to hear from you!

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,62 +5,64 @@ pr:
   autoCancel: true
 
 stages:
-- stage: GCC
-  dependsOn: []
-  jobs:
-  - template: ./pipelines/jobs.yml
-    parameters:
-      compiler: gcc
-      image: ubuntu-20.04
-      compilerVersions: [ 11, 10 ]
-      setupfile: 'setup_gcc.yml'
-
-- stage: Clang
-  dependsOn: []
-  jobs:
-  - template: ./pipelines/jobs.yml
-    parameters:
-      compiler: clang
-      image: ubuntu-20.04
-      compilerVersions: [ 11, 10 ]
-      setupfile: 'setup_clang.yml'
-
-- stage: Xcode
-  dependsOn: []
-  jobs:
-  - template: ./pipelines/jobs.yml
-    parameters:
-      compiler: 'Xcode'
-      image: macOS-11
-      compilerVersions: [ '12.5.1', '13.1' ]
-      setupfile: 'setup_apple.yml'
-
-- stage: VS_MSVC
-  dependsOn: []
-  jobs:
-  - template: ./pipelines/jobs.yml
-    parameters:
-      compiler: 'VS2019 (16.11)'
-      compilerVersions: [ 'MSVC' ]
-      image: windows-2019
-  - template: ./pipelines/jobs.yml
-    parameters:
-      compiler: 'VS2022 (17.0)'
-      compilerVersions: [ 'MSVC' ]
-      image: windows-2022
+# - stage: GCC
+#   dependsOn: []
+#   jobs:
+#   - template: ./pipelines/jobs.yml
+#     parameters:
+#       compiler: gcc
+#       image: ubuntu-20.04
+#       compilerVersions: [ 11, 10 ]
+#       setupfile: 'setup_gcc.yml'
+#
+# - stage: Clang
+#   dependsOn: []
+#   jobs:
+#   - template: ./pipelines/jobs.yml
+#     parameters:
+#       compiler: clang
+#       image: ubuntu-20.04
+#       compilerVersions: [ 11, 10 ]
+#       setupfile: 'setup_clang.yml'
+#
+# - stage: Xcode
+#   dependsOn: []
+#   jobs:
+#   - template: ./pipelines/jobs.yml
+#     parameters:
+#       compiler: 'Xcode'
+#       image: macOS-11
+#       compilerVersions: [ '12.5.1', '13.1' ]
+#       setupfile: 'setup_apple.yml'
+#
+# - stage: VS_MSVC
+#   dependsOn: []
+#   jobs:
+#   - template: ./pipelines/jobs.yml
+#     parameters:
+#       compiler: 'VS2019 (16.11)'
+#       compilerVersions: [ 'MSVC' ]
+#       image: windows-2019
+#   - template: ./pipelines/jobs.yml
+#     parameters:
+#       compiler: 'VS2022 (17.0)'
+#       compilerVersions: [ 'MSVC' ]
+#       image: windows-2022
 
 - stage: VS_LLVM
   dependsOn: []
   jobs:
+  # - template: ./pipelines/jobs.yml
+  #   parameters:
+  #     compiler: 'VS2019 (16.11)'
+  #     compilerVersions: [ 'LLVM' ]
+  #     image: windows-2019
+  #     extraCmakeArgs: '-T ClangCL'
   - template: ./pipelines/jobs.yml
     parameters:
-      compiler: 'VS2019 (16.11)'
+      compiler: 'VS2022 (17.0)'
       compilerVersions: [ 'LLVM' ]
-      image: windows-2019
+      image: windows-2022
       extraCmakeArgs: '-T ClangCL'
-- template: ./pipelines/jobs.yml
-  parameters:
-    compiler: 'VS2022 (17.0)'
-    compilerVersions: [ 'LLVM' ]
-    image: windows-2022
-    extraCmakeArgs: '-T ClangCL'
+      CXXVersions: [ 14 ]
+      buildTypes: [ Release ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,14 +58,9 @@ stages:
       compilerVersions: [ 'LLVM' ]
       image: windows-2019
       extraCmakeArgs: '-T ClangCL'
-
-# The *same* config as with 2019 but on 2022 yields an error.
-# Tracking issue: https://github.com/actions/virtual-environments/issues/4716
-# - template: ./pipelines/jobs.yml
-#   parameters:
-#     compiler: 'VS2022 LLVM'
-#     compilerVersions: [ '17.0' ]
-#     image: windows-2022
-#     extraCmakeArgs: '-T ClangCL'
-#     CXXVersions: [ 14 ]
-#     buildTypes: [ Release ]
+- template: ./pipelines/jobs.yml
+  parameters:
+    compiler: 'VS2022 (17.0)'
+    compilerVersions: [ 'LLVM' ]
+    image: windows-2022
+    extraCmakeArgs: '-T ClangCL'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,5 +64,3 @@ stages:
       compilerVersions: [ 'LLVM' ]
       image: windows-2022
       extraCmakeArgs: '-T ClangCL'
-      CXXVersions: [ 14 ]
-      buildTypes: [ Release ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,59 +5,59 @@ pr:
   autoCancel: true
 
 stages:
-# - stage: GCC
-#   dependsOn: []
-#   jobs:
-#   - template: ./pipelines/jobs.yml
-#     parameters:
-#       compiler: gcc
-#       image: ubuntu-20.04
-#       compilerVersions: [ 11, 10 ]
-#       setupfile: 'setup_gcc.yml'
-#
-# - stage: Clang
-#   dependsOn: []
-#   jobs:
-#   - template: ./pipelines/jobs.yml
-#     parameters:
-#       compiler: clang
-#       image: ubuntu-20.04
-#       compilerVersions: [ 11, 10 ]
-#       setupfile: 'setup_clang.yml'
-#
-# - stage: Xcode
-#   dependsOn: []
-#   jobs:
-#   - template: ./pipelines/jobs.yml
-#     parameters:
-#       compiler: 'Xcode'
-#       image: macOS-11
-#       compilerVersions: [ '12.5.1', '13.1' ]
-#       setupfile: 'setup_apple.yml'
-#
-# - stage: VS_MSVC
-#   dependsOn: []
-#   jobs:
-#   - template: ./pipelines/jobs.yml
-#     parameters:
-#       compiler: 'VS2019 (16.11)'
-#       compilerVersions: [ 'MSVC' ]
-#       image: windows-2019
-#   - template: ./pipelines/jobs.yml
-#     parameters:
-#       compiler: 'VS2022 (17.0)'
-#       compilerVersions: [ 'MSVC' ]
-#       image: windows-2022
+- stage: GCC
+  dependsOn: []
+  jobs:
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: gcc
+      image: ubuntu-20.04
+      compilerVersions: [ 11, 10 ]
+      setupfile: 'setup_gcc.yml'
+
+- stage: Clang
+  dependsOn: []
+  jobs:
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: clang
+      image: ubuntu-20.04
+      compilerVersions: [ 11, 10 ]
+      setupfile: 'setup_clang.yml'
+
+- stage: Xcode
+  dependsOn: []
+  jobs:
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: 'Xcode'
+      image: macOS-11
+      compilerVersions: [ '12.5.1', '13.1' ]
+      setupfile: 'setup_apple.yml'
+
+- stage: VS_MSVC
+  dependsOn: []
+  jobs:
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: 'VS2019 (16.11)'
+      compilerVersions: [ 'MSVC' ]
+      image: windows-2019
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: 'VS2022 (17.0)'
+      compilerVersions: [ 'MSVC' ]
+      image: windows-2022
 
 - stage: VS_LLVM
   dependsOn: []
   jobs:
-  # - template: ./pipelines/jobs.yml
-  #   parameters:
-  #     compiler: 'VS2019 (16.11)'
-  #     compilerVersions: [ 'LLVM' ]
-  #     image: windows-2019
-  #     extraCmakeArgs: '-T ClangCL'
+  - template: ./pipelines/jobs.yml
+    parameters:
+      compiler: 'VS2019 (16.11)'
+      compilerVersions: [ 'LLVM' ]
+      image: windows-2019
+      extraCmakeArgs: '-T ClangCL'
   - template: ./pipelines/jobs.yml
     parameters:
       compiler: 'VS2022 (17.0)'


### PR DESCRIPTION
The Windows-2022 Clang rollout seems to be under way -- the documentation hasn't been updated yet but it looks like the changes to the VMs are in? Let's try them out