### PR TITLE
quoted form of #include when GSL includes GSL files

### DIFF
--- a/include/gsl/algorithm
+++ b/include/gsl/algorithm
@@ -17,8 +17,8 @@
 #ifndef GSL_ALGORITHM_H
 #define GSL_ALGORITHM_H
 
-#include <gsl/assert> // for Expects
-#include <gsl/span>   // for dynamic_extent, span
+#include "assert" // for Expects
+#include "span"   // for dynamic_extent, span
 
 #include <algorithm>   // for copy_n
 #include <cstddef>     // for ptrdiff_t

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -17,16 +17,16 @@
 #ifndef GSL_GSL_H
 #define GSL_GSL_H
 
-#include <gsl/algorithm>   // copy
-#include <gsl/assert>      // Ensures/Expects
-#include <gsl/byte>        // byte
-#include <gsl/pointers>    // owner, not_null
-#include <gsl/span>        // span
-#include <gsl/string_span> // zstring, string_span, zstring_builder...
-#include <gsl/util>        // finally()/narrow_cast()...
+#include "algorithm"   // copy
+#include "assert"      // Ensures/Expects
+#include "byte"        // byte
+#include "pointers"    // owner, not_null
+#include "span"        // span
+#include "string_span" // zstring, string_span, zstring_builder...
+#include "util"        // finally()/narrow_cast()...
 
 #ifdef __cpp_exceptions
-#include <gsl/narrow> // narrow()
+#include "narrow" // narrow()
 #endif
 
 #endif // GSL_GSL_H

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -1,4 +1,4 @@
 #pragma once
 #pragma message(                                                                                   \
     "This header will soon be removed. Use <gsl/algorithm> instead of <gsl/gsl_algorithm>")
-#include <gsl/algorithm>
+#include "algorithm"

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -1,3 +1,3 @@
 #pragma once
 #pragma message("This header will soon be removed. Use <gsl/assert> instead of <gsl/gsl_assert>")
-#include <gsl/assert>
+#include "assert"

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -1,3 +1,3 @@
 #pragma once
 #pragma message("This header will soon be removed. Use <gsl/byte> instead of <gsl/gsl_byte>")
-#include <gsl/byte>
+#include "byte"

--- a/include/gsl/gsl_narrow
+++ b/include/gsl/gsl_narrow
@@ -1,3 +1,3 @@
 #pragma once
 #pragma message("This header will soon be removed. Use <gsl/narrow> instead of <gsl/gsl_narrow>")
-#include <gsl/narrow>
+#include "narrow"

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -1,3 +1,3 @@
 #pragma once
 #pragma message("This header will soon be removed. Use <gsl/util> instead of <gsl/gsl_util>")
-#include <gsl/util>
+#include "util"

--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -16,8 +16,8 @@
 
 #ifndef GSL_NARROW_H
 #define GSL_NARROW_H
-#include <gsl/assert> // for Expects
-#include <gsl/util>   // for narrow_cast
+#include "assert" // for Expects
+#include "util"   // for narrow_cast
 namespace gsl
 {
 struct narrowing_error : public std::exception

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -17,7 +17,7 @@
 #ifndef GSL_POINTERS_H
 #define GSL_POINTERS_H
 
-#include <gsl/assert> // for Ensures, Expects
+#include "assert" // for Ensures, Expects
 
 #include <algorithm>    // for forward
 #include <cstddef>      // for ptrdiff_t, nullptr_t, size_t

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -17,15 +17,15 @@
 #ifndef GSL_SPAN_H
 #define GSL_SPAN_H
 
-#include <gsl/assert> // for Expects
-#include <gsl/byte>   // for byte
-#include <gsl/util>   // for narrow_cast
+#include "assert"   // for Expects
+#include "byte"     // for byte
+#include "span_ext" // for span specialization of gsl::at and other span-related extensions
+#include "util"     // for narrow_cast
 
-#include <array>        // for array
-#include <cstddef>      // for ptrdiff_t, size_t, nullptr_t
-#include <gsl/span_ext> // for span specialization of gsl::at and other span-related extensions
-#include <iterator>     // for reverse_iterator, distance, random_access_...
-#include <type_traits>  // for enable_if_t, declval, is_convertible, inte...
+#include <array>       // for array
+#include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
+#include <iterator>    // for reverse_iterator, distance, random_access_...
+#include <type_traits> // for enable_if_t, declval, is_convertible, inte...
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -27,8 +27,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <gsl/assert> // GSL_KERNEL_MODE
-#include <gsl/util>   // for narrow_cast, narrow
+#include "assert" // GSL_KERNEL_MODE
+#include "util"   // for narrow_cast, narrow
 
 #include <cstddef> // for ptrdiff_t, size_t
 #include <utility>

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -17,9 +17,9 @@
 #ifndef GSL_STRING_SPAN_H
 #define GSL_STRING_SPAN_H
 
-#include <gsl/assert>   // for Ensures, Expects
-#include <gsl/span_ext> // for operator!=, operator==, dynamic_extent
-#include <gsl/util>     // for narrow_cast
+#include "assert"   // for Ensures, Expects
+#include "span_ext" // for operator!=, operator==, dynamic_extent
+#include "util"     // for narrow_cast
 
 #include <algorithm> // for equal, lexicographical_compare
 #include <array>     // for array

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -17,7 +17,7 @@
 #ifndef GSL_UTIL_H
 #define GSL_UTIL_H
 
-#include <gsl/assert> // for Expects
+#include "assert" // for Expects
 
 #include <array>
 #include <cstddef>          // for ptrdiff_t, size_t


### PR DESCRIPTION
[SF.12: Prefer the quoted form of #include for files relative to the including file and the angle bracket form everywhere else](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rs-incform)

Additionally changed #include order in `span` so that all `span_ext` is in the GSL include block and not in the STL include block.

Fixes issues #1025.