### PR TITLE
Ignore ABI compatibility warnings with old GCC

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,6 +195,18 @@ target_link_libraries(gsl_tests
 )
 add_test(gsl_tests gsl_tests)
 
+# Ignore uninteresting warning about ABI change somewhere inside std::regex. GSL never supported GCC 5.
+# The warning was removed in GCC 12, see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93011
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le"  # PowerPC 64-bit Little-Endian
+    AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"   # GNU Compiler Collection
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    if (CMAKE_MINOR_VERSION GREATER 10)
+        set_property(SOURCE span_tests.cpp APPEND PROPERTY COMPILE_OPTIONS "-Wno-psabi")
+    else()
+        target_compile_options(gsl_tests PRIVATE "-Wno-psabi")
+    endif()
+endif()
+
 # No exception tests
 
 foreach(flag_var


### PR DESCRIPTION
We can see "note: the layout of aggregates containing vectors with 4-byte alignment has changed in GCC 5" on the standard <regex> header when compiling for PowerPC 64-bit LE target. This results in a test failure due to output to stderr. The warning looks useless since GSL does not support so old GCC 5.

The diagnostic is emitted on -O3 optimization level because of std::regex constructor. Do you think it is worth having this suppression in the upstream CMake script?
