### PR TITLE
Fix C26467(es.46) warning in gsl::narrow implementation

### DIFF
--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -43,7 +43,7 @@ GSL_SUPPRESS(p.2) // NO-FORMAT: attribute // don't rely on undefined behavior
                                    // and cannot fit into the destination integral type), the resultant behavior is benign on the platforms
                                    // that we target (i.e., no hardware trap representations are hit).
 
-    if (static_cast<U>(t) != u || (is_different_signedness && ((t < T{}) != (u < U{}))))
+    if (narrow_cast<U>(t) != u || (is_different_signedness && ((t < T{}) != (u < U{}))))
     {
         throw narrowing_error{};
     }


### PR DESCRIPTION
The static_cast is an intended implementation detail of gsl::narrow. However, MSVC correctly
raises warning C26467 and suggests to use `gsl::narrow_cast`. Use the suggestion, especially since
gsl::narrow_cast is being used to make the initial U -> T conversion. 

Also, while the CoreGuidelines use `static_cast` in their definition of `gsl::narrow`, `gsl::narrow_cast` is officially defined as `static_cast`, so no functional nor semantic regression results from this change.

Fixes #1036