### PR TITLE
Suppress -Wfloat-equal warning

### DIFF
--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -43,10 +43,17 @@ GSL_SUPPRESS(p.2) // NO-FORMAT: attribute // don't rely on undefined behavior
                                    // and cannot fit into the destination integral type), the resultant behavior is benign on the platforms
                                    // that we target (i.e., no hardware trap representations are hit).
 
+#if defined(__clang__) || defined(__GNUC__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
     if (static_cast<U>(t) != u || (is_different_signedness && ((t < T{}) != (u < U{}))))
     {
         throw narrowing_error{};
     }
+#if defined(__clang__) || defined(__GNUC__)
+    #pragma GCC diagnostic pop
+#endif
 
     return t;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ if(MSVC) # MSVC or simulating MSVC
         >
         $<$<CXX_COMPILER_ID:Clang>:
           -Weverything
+          -Wfloat-equal
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
           -Wno-covered-switch-default # GTest
@@ -122,6 +123,7 @@ else()
         -Wpedantic
         -Wshadow
         -Wsign-conversion
+        -Wfloat-equal
         -Wno-deprecated-declarations # Allow tests for [[deprecated]] elements
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
@@ -227,6 +229,7 @@ if(MSVC) # MSVC or simulating MSVC
         >
         $<$<CXX_COMPILER_ID:Clang>:
           -Weverything
+          -Wfloat-equal
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
           -Wno-missing-prototypes
@@ -250,6 +253,7 @@ else()
         -Wpedantic
         -Wshadow
         -Wsign-conversion
+        -Wfloat-equal
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -149,5 +149,7 @@ TEST(utils_tests, narrow)
     EXPECT_TRUE(
         narrow<std::complex<float>>(std::complex<double>(4, 2)) == std::complex<float>(4, 2));
     EXPECT_THROW(narrow<std::complex<float>>(std::complex<double>(4.2)), narrowing_error);
+
+    EXPECT_TRUE(narrow<int>(float(1)) == 1);
 }
 #endif // GSL_KERNEL_MODE


### PR DESCRIPTION
`-Wfloat-equal` is concerned with the floating-point comparison in `gsl::narrow`. However, the use of this comparison is by design.

Resolves #1038 