### PR TITLE
gsl/narrow should include <exception>

### DIFF
--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -16,8 +16,9 @@
 
 #ifndef GSL_NARROW_H
 #define GSL_NARROW_H
-#include "assert" // for Expects
-#include "util"   // for narrow_cast
+#include "assert"    // for Expects
+#include "util"      // for narrow_cast
+#include <exception> // for std::exception
 namespace gsl
 {
 struct narrowing_error : public std::exception


### PR DESCRIPTION
This file uses std::exception, so it should include the appropriate header.

Normally it gets the STL's "exception" header included via the gsl/assert file, but this is skipped with _HAS_EXCEPTIONS=0. I understand _HAS_EXCEPTIONS is undocumented and unsupported, but regardless, the appropriate header should be included here.

Alternatively, gsl/narrow should be modified to support _HAS_EXCEPTIONS=0, like gsl/assert was. But I'm not proposing that change. "exception" does define std::exception even with _HAS_EXCEPTIONS=0.