### PR TITLE
Suppress es.46 warning in implementation of gsl::narrow

### DIFF
--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -31,6 +31,10 @@ template <class T, class U, typename std::enable_if<std::is_arithmetic<T>::value
 // clang-format off
 GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
 GSL_SUPPRESS(f.6) // NO-FORMAT: attribute // TODO: MSVC /analyze does not recognise noexcept(false)
+GSL_SUPPRESS(es.46) // NO-FORMAT: attribute // The warning suggests that a floating->unsigned conversion can occur
+                                            // in the static_cast below, and that gsl::narrow should be used instead.
+                                            // Suppress this warning, since gsl::narrow is defined in terms of
+                                            // static_cast
     // clang-format on
     constexpr T narrow(U u) noexcept(false)
 {


### PR DESCRIPTION
As per the CoreGuidelines, gsl::narrow is defined in terms of static_cast.
Suppress es.46, which suggests converting the static_cast into gsl::narrow.

This resolves #1036