### PR TITLE
Resolve MSVC warning C5260

### DIFF
--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -41,7 +41,7 @@ namespace gsl
 {
 
 // [span.views.constants], constants
-inline constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
+GSL_INLINE constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
 
 template <class ElementType, std::size_t Extent = dynamic_extent>
 class span;

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -41,7 +41,7 @@ namespace gsl
 {
 
 // [span.views.constants], constants
-constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
+inline constexpr const std::size_t dynamic_extent = narrow_cast<std::size_t>(-1);
 
 template <class ElementType, std::size_t Extent = dynamic_extent>
 class span;

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -45,6 +45,12 @@
 #define GSL_NODISCARD
 #endif // defined(__cplusplus) && (__cplusplus >= 201703L)
 
+#if defined(__cpp_inline_variables)
+#define GSL_INLINE inline
+#else
+#define GSL_INLINE
+#endif
+
 namespace gsl
 {
 //


### PR DESCRIPTION
MSVC warning C5260 says namespace-scope `constexpr` variables should be marked `inline` or `static` for C++20 header units. 
("warning C5260: the constant variable 'X' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit").
