### PR TITLE
Fix NDK version in Android CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Emulator starting"
 
       - name: Configure
-        run: cmake -Werror=dev -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/25.0.8775105/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
+        run: cmake -Werror=dev -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
 
       - name: Build
         run: cmake --build . --parallel


### PR DESCRIPTION
This PR future-proofs the fix made in https://github.com/microsoft/GSL/pull/1053, which is now outdated due to further updates to the NDK version in the Azure VMs used as part of the CI.