### PR TITLE
Properly handle finally(actual_function)

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -87,7 +87,7 @@ private:
 template <class F>
 GSL_NODISCARD auto finally(F&& f) noexcept
 {
-    return final_action<std::remove_cv_t<std::remove_reference_t<F>>>{std::forward<F>(f)};
+    return final_action<std::decay_t<F>>{std::forward<F>(f)};
 }
 
 // narrow_cast(): a searchable way to do narrowing casts of values

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -112,6 +112,16 @@ TEST(utils_tests, finally_function_ptr)
     EXPECT_TRUE(j == 1);
 }
 
+TEST(utils_tests, finally_function)
+{
+    j = 0;
+    {
+        auto _ = finally(g);
+        EXPECT_TRUE(j == 0);
+    }
+    EXPECT_TRUE(j == 1);
+}
+
 TEST(utils_tests, narrow_cast)
 {
     int n = 120;


### PR DESCRIPTION
`finally` needs to use `decay_t` instead of `remove_cvref_t` so it can properly accept non-object function arguments by decaying to function pointer type. Adds test coverage for this use case which was previously missing.