### PR TITLE
Raise CMake min to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,10 @@
-cmake_minimum_required(VERSION 3.1.3...3.16)
+cmake_minimum_required(VERSION 3.8...3.16)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 include(gsl_functions)
 
-project(GSL
-    VERSION 4.0.0
-    LANGUAGES CXX
-)
+project(GSL VERSION 4.0.0 LANGUAGES CXX)
 
-# Creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
-
-# NOTE: If you want to use GSL prefer to link against GSL using this alias target
-# EX:
-#   target_link_libraries(foobar PRIVATE Microsoft.GSL::GSL)
-#
-# Add Microsoft.GSL::GSL alias for GSL so that dependents can be agnostic about
-# whether GSL was added via `add_subdirectory` or `find_package`
 add_library(Microsoft.GSL::GSL ALIAS GSL)
 
 # https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
@@ -24,14 +13,8 @@ string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_
 option(GSL_INSTALL "Generate and install GSL target" ${PROJECT_IS_TOP_LEVEL})
 option(GSL_TEST "Build and perform GSL tests" ${PROJECT_IS_TOP_LEVEL})
 
-# This GSL implementation generally assumes a platform that implements C++14 support.
-set(gsl_min_cxx_standard "14")
-
-if (PROJECT_IS_TOP_LEVEL)
-    gsl_set_default_cxx_standard(${gsl_min_cxx_standard})
-else()
-    gsl_client_set_cxx_standard(${gsl_min_cxx_standard})
-endif()
+# The implementation generally assumes a platform that implements C++14 support
+target_compile_features(GSL INTERFACE "cxx_std_14")
 
 # Setup include directory
 add_subdirectory(include)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Note: These CI/CD steps are run with each pull request, however failures in them
 ## Building the tests
 To build the tests, you will require the following:
 
-* [CMake](http://cmake.org), version 3.1.3 (3.2.3 for AppleClang) or later to be installed and in your PATH.
+* [CMake](http://cmake.org), version 3.8 or later to be installed and in your PATH.
 
 These steps assume the source code of this repository has been cloned into a directory named `c:\GSL`.
 

--- a/cmake/gsl_functions.cmake
+++ b/cmake/gsl_functions.cmake
@@ -5,68 +5,16 @@
 #
 # Any functions/macros should have a gsl_* prefix to avoid problems
 
-function(gsl_set_default_cxx_standard min_cxx_standard)
-    set(GSL_CXX_STANDARD "${min_cxx_standard}" CACHE STRING "Use c++ standard")
-
-    # when minimum version required is 3.8.0 remove if below
-    # both branches do exactly the same thing
-    if (CMAKE_VERSION VERSION_LESS 3.7.9)
-        if (MSVC)
-            set(GSL_CXX_STD_OPT "-std:c++${GSL_CXX_STANDARD}")
-        else()
-            set(GSL_CXX_STD_OPT "-std=c++${GSL_CXX_STANDARD}")
-        endif()
-
-        include(CheckCXXCompilerFlag)
-        CHECK_CXX_COMPILER_FLAG("${GSL_CXX_STD_OPT}" COMPILER_SUPPORTS_CXX_STANDARD)
-
-        if(COMPILER_SUPPORTS_CXX_STANDARD)
-            target_compile_options(GSL INTERFACE "${GSL_CXX_STD_OPT}")
-        else()
-            message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no c++${GSL_CXX_STANDARD} support. Please use a different C++ compiler.")
-        endif()
-    else()
-        # Compiler must support at least this standard
-        target_compile_features(GSL INTERFACE "cxx_std_${GSL_CXX_STANDARD}")
-        # on *nix systems force the use of -std=c++XX instead of -std=gnu++XX (default)
-        set(CMAKE_CXX_EXTENSIONS OFF)
-    endif()
-endfunction()
-
-# The best way for a project to specify the GSL's C++ standard is by the client specifying
-# the CMAKE_CXX_STANDARD. However, this isn't always ideal. Since the CMAKE_CXX_STANDARD is
-# tied to the cmake version. And many projects have low cmake minimums.
-#
-# So provide an alternative approach in case that doesn't work.
-function(gsl_client_set_cxx_standard min_cxx_standard)
-    if (DEFINED CMAKE_CXX_STANDARD)
-        if (${CMAKE_CXX_STANDARD} VERSION_LESS ${min_cxx_standard})
-            message(FATAL_ERROR "GSL: Requires at least CXX standard ${min_cxx_standard}, user provided ${CMAKE_CXX_STANDARD}")
-        endif()
-
-        # Set the GSL standard to what the client desires
-        set(GSL_CXX_STANDARD "${CMAKE_CXX_STANDARD}" PARENT_SCOPE)
-
-        # Exit out early to avoid extra unneccessary work
-        return()
-    endif()
-
-    # Otherwise pick a reasonable default
-    gsl_set_default_cxx_standard(${min_cxx_standard})
-endfunction()
-
 # Adding the GSL.natvis files improves the debugging experience for users of this library.
 function(gsl_add_native_visualizer_support)
-    if (CMAKE_VERSION VERSION_GREATER 3.7.8)
-        if (MSVC_IDE)
-            option(GSL_VS_ADD_NATIVE_VISUALIZERS "Configure project to use Visual Studio native visualizers" TRUE)
-        else()
-            set(GSL_VS_ADD_NATIVE_VISUALIZERS FALSE CACHE INTERNAL "Native visualizers are Visual Studio extension" FORCE)
-        endif()
+    if (MSVC_IDE)
+        option(GSL_VS_ADD_NATIVE_VISUALIZERS "Configure project to use Visual Studio native visualizers" TRUE)
+    else()
+        set(GSL_VS_ADD_NATIVE_VISUALIZERS FALSE CACHE INTERNAL "Native visualizers are Visual Studio extension" FORCE)
+    endif()
 
-        # add natvis file to the library so it will automatically be loaded into Visual Studio
-        if(GSL_VS_ADD_NATIVE_VISUALIZERS)
-            target_sources(GSL INTERFACE $<BUILD_INTERFACE:${GSL_SOURCE_DIR}/GSL.natvis>)
-        endif()
+    # add natvis file to the library so it will automatically be loaded into Visual Studio
+    if(GSL_VS_ADD_NATIVE_VISUALIZERS)
+        target_sources(GSL INTERFACE $<BUILD_INTERFACE:${GSL_SOURCE_DIR}/GSL.natvis>)
     endif()
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,13 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.8)
 
-project(GSLTests CXX)
+project(GSLTests LANGUAGES CXX)
 enable_testing()  # again, for support standalone testing
+
+set(GSL_CXX_STANDARD "14" CACHE STRING "Use c++ standard")
+
+set(CMAKE_CXX_STANDARD ${GSL_CXX_STANDARD})
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CXX_STANDARD_REQUIRED ON)
 
 include(FindPkgConfig)
 include(ExternalProject)


### PR DESCRIPTION
This avoids propogating -std=c++14 as a compile option

Currently if you use less than CMake 3.8 and you install the project
`-std=c++14` gets added to the INTERFACE_COMPILE_OPTIONS. This forces
users to use C++ 14 or remove the property from the imported target.

The solution is to raise the minimum and use `cxx_std_14`