### PR TITLE
clang-tidy: performance-noexcept-move-constructor

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -267,7 +267,9 @@ public:
     constexpr strict_not_null(const strict_not_null<U>& other) : not_null<T>(other)
     {}
 
-    strict_not_null(strict_not_null&& other) = default;
+    // To avoid invalidating the "not null" invariant, the contained pointer is actually copied
+    // instead of moved. If it is a custom pointer, its constructor could in theory throw exceptions.
+    strict_not_null(strict_not_null&& other) noexcept(std::is_nothrow_copy_constructible<T>::value) = default;
     strict_not_null(const strict_not_null& other) = default;
     strict_not_null& operator=(const strict_not_null& other) = default;
     strict_not_null& operator=(const not_null<T>& other)

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -437,13 +437,13 @@ public:
     constexpr basic_zstring_span(const basic_zstring_span& other) = default;
 
     // move
-    constexpr basic_zstring_span(basic_zstring_span && other) = default;
+    constexpr basic_zstring_span(basic_zstring_span && other) noexcept = default;
 
     // assign
     constexpr basic_zstring_span& operator=(const basic_zstring_span& other) = default;
 
     // move assign
-    constexpr basic_zstring_span& operator=(basic_zstring_span&& other) = default;
+    constexpr basic_zstring_span& operator=(basic_zstring_span&& other) noexcept = default;
 
     constexpr bool empty() const noexcept { return false; }
 


### PR DESCRIPTION
I ran GSL through clang-tidy with the performance-* checks

https://releases.llvm.org/15.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.html