### PR TITLE
Remove null-check Expects assertion inside not_null::get

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -117,7 +117,6 @@ public:
     not_null& operator=(const not_null& other) = default;
     constexpr details::value_or_reference_return_t<T> get() const
     {
-        Ensures(ptr_ != nullptr);
         return ptr_;
     }
 


### PR DESCRIPTION
[Guidelines issue 2006](https://github.com/isocpp/CppCoreGuidelines/issues/2006) removes the null check inside `not_null::get`, since the contained pointer is already guaranteed to be not-null upon construction. 

Resolves #1051 