### PR TITLE
gsl::at variadic version

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -144,6 +144,13 @@ constexpr auto at(std::span<T, extent> sp, const index i) -> decltype(sp[sp.size
     return sp[gsl::narrow_cast<size_t>(i)];
 }
 #endif // __cpp_lib_span >= 202002L
+
+template <class Cont, class... Args>
+constexpr decltype(auto) at(Cont&& cont, const index i, Args&&... args)
+{
+    return at(at(std::forward<Cont>(cont), i), std::forward<Args>(args)...);
+}
+
 } // namespace gsl
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -147,6 +147,34 @@ TEST(at_tests, std_span)
 }
 #endif // defined(FORCE_STD_SPAN_TESTS) || defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
 
+TEST(at_tests, VariadicTemplate)
+{
+    std::array<std::vector<int>, 4> a;
+    for (int i = 0; i < 4; ++i)
+    {
+        a[i] = std::vector<int>(4, i + 1);
+    }
+
+    for (int i = 0; i < 4; ++i)
+    {
+        EXPECT_TRUE(gsl::at(a, i, i) == i + 1);
+    }
+
+    gsl::at(a, 0, 0) = 0;
+    EXPECT_TRUE(gsl::at(a, 0, 0) == 0);
+
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. VariadicTemplate";
+        std::abort();
+    });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
+    EXPECT_DEATH(gsl::at(a, -1, 0), expected);
+    EXPECT_DEATH(gsl::at(a, 0, -1), expected);
+    EXPECT_DEATH(gsl::at(a, 4, 0), expected);
+    EXPECT_DEATH(gsl::at(a, 0, 4), expected);
+}
+
 #if !defined(_MSC_VER) || defined(__clang__) || _MSC_VER >= 1910
 static constexpr bool test_constexpr()
 {

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -149,11 +149,7 @@ TEST(at_tests, std_span)
 
 TEST(at_tests, VariadicTemplate)
 {
-    std::array<std::vector<int>, 4> a;
-    for (int i = 0; i < 4; ++i)
-    {
-        a[i] = std::vector<int>(4, i + 1);
-    }
+    std::array<std::vector<int>, 4> a{{{1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}, {4, 4, 4, 4}}};
 
     for (int i = 0; i < 4; ++i)
     {


### PR DESCRIPTION
[SL.Con.3](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rsl-bounds) encourages the use bounds-checked functions such as `.at()` and `gsl::at()` over the use of `operator[]`. However, this becomes inconvenient when trying to access values inside multi-dimensional arrays.

For example, assume we have a 3-dimensional array named memo, which caches the values for some expensive function. To access a value, we would need to write `memo.at(x).at(y).at(z)`, or `at(at(at(memo, x), y), z)` when using the GSL function. By using the new variadic template, we can simply write `at(memo, x, y, z)`.