### PR TITLE
Document potentially confusing behavior in gsl::narrow

### DIFF
--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -52,7 +52,7 @@ GSL_SUPPRESS(p.2) // NO-FORMAT: attribute // don't rely on undefined behavior
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-    // Note: NaN will always throw
+    // Note: NaN will always throw, since NaN != NaN
     if (static_cast<U>(t) != u || (is_different_signedness && ((t < T{}) != (u < U{}))))
     {
         throw narrowing_error{};

--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -52,6 +52,7 @@ GSL_SUPPRESS(p.2) // NO-FORMAT: attribute // don't rely on undefined behavior
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
+    // Note: NaN will always throw
     if (static_cast<U>(t) != u || (is_different_signedness && ((t < T{}) != (u < U{}))))
     {
         throw narrowing_error{};


### PR DESCRIPTION
NaN != Nan, so the comparisons used in `gsl::narrow` will always throw when attempting to cast a NaN value. This may be surprising, so document it.

Resolves https://github.com/microsoft/GSL/issues/1069