### PR TITLE
1075 Wrong Expects in gsl::at?

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -111,8 +111,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
-    static_assert(N <= std::numeric_limits<std::size_t>::max() / 2, "We only support arrays up to half the bytes of the address space.");
-    Expects(i >= 0 && narrow_cast<std::size_t>(i) < N);
+    static_assert(N <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()), "We only support arrays up to half the bytes of the address space.");
+    Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }
 
@@ -123,8 +123,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
+    Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     using size_type = decltype(cont.size());
-    Expects(i >= 0 && narrow_cast<size_type>(i) < cont.size());
     return cont[narrow_cast<size_type>(i)];
 }
 
@@ -134,8 +134,7 @@ GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
     // clang-format on
     constexpr T at(const std::initializer_list<T> cont, const index i)
 {
-    using size_type = decltype(cont.size());
-    Expects(i >= 0 && narrow_cast<size_type>(i) < cont.size());
+    Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     return *(cont.begin() + i);
 }
 
@@ -143,7 +142,7 @@ GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
 template <class T, std::size_t extent = std::dynamic_extent>
 constexpr auto at(std::span<T, extent> sp, const index i) -> decltype(sp[sp.size()])
 {
-    Expects(i >= 0 && narrow_cast<std::size_t>(i) < sp.size());
+    Expects(i >= 0 && i < narrow_cast<index>(sp.size()));
     return sp[gsl::narrow_cast<std::size_t>(i)];
 }
 #endif // __cpp_lib_span >= 202002L

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -111,7 +111,7 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
-    static_assert(N <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()), "We only support arrays up to half the bytes of the address space.");
+    static_assert(N <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()), "We only support arrays up to PTRDIFF_MAX bytes.");
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <cstddef>          // for ptrdiff_t, size_t
+#include <limits>           // for numeric_limits
 #include <initializer_list> // for initializer_list
 #include <type_traits>      // for is_signed, integral_constant
 #include <utility>          // for exchange, forward
@@ -110,7 +111,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
-    Expects(i >= 0 && i < narrow_cast<index>(N));
+    static_assert(N <= std::numeric_limits<std::size_t>::max() / 2, "We only support arrays up to half the bytes of the address space.");
+    Expects(i >= 0 && narrow_cast<std::size_t>(i) < N);
     return arr[narrow_cast<std::size_t>(i)];
 }
 
@@ -121,8 +123,8 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr auto at(Cont& cont, const index i) -> decltype(cont[cont.size()])
 {
-    Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
     using size_type = decltype(cont.size());
+    Expects(i >= 0 && narrow_cast<size_type>(i) < cont.size());
     return cont[narrow_cast<size_type>(i)];
 }
 
@@ -132,16 +134,17 @@ GSL_SUPPRESS(bounds.1) // NO-FORMAT: attribute
     // clang-format on
     constexpr T at(const std::initializer_list<T> cont, const index i)
 {
-    Expects(i >= 0 && i < narrow_cast<index>(cont.size()));
+    using size_type = decltype(cont.size());
+    Expects(i >= 0 && narrow_cast<size_type>(i) < cont.size());
     return *(cont.begin() + i);
 }
 
 #if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
-template <class T, size_t extent = std::dynamic_extent>
+template <class T, std::size_t extent = std::dynamic_extent>
 constexpr auto at(std::span<T, extent> sp, const index i) -> decltype(sp[sp.size()])
 {
-    Expects(i >= 0 && i < narrow_cast<index>(sp.size()));
-    return sp[gsl::narrow_cast<size_t>(i)];
+    Expects(i >= 0 && narrow_cast<std::size_t>(i) < sp.size());
+    return sp[gsl::narrow_cast<std::size_t>(i)];
 }
 #endif // __cpp_lib_span >= 202002L
 } // namespace gsl

--- a/tests/at_tests.cpp
+++ b/tests/at_tests.cpp
@@ -20,6 +20,7 @@
 
 #include <array>            // for array
 #include <cstddef>          // for size_t
+#include <exception>        // for terminate
 #include <initializer_list> // for initializer_list
 #include <vector>           // for vector
 #if defined(__cplusplus) && __cplusplus >= 202002L

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -19,9 +19,10 @@
 #include <gsl/span> // for span and span_ext
 #include <gsl/util> // for narrow_cast, at
 
-#include <array>    // for array
-#include <iostream> // for cerr
-#include <vector>   // for vector
+#include <array>     // for array
+#include <exception> // for terminate
+#include <iostream>  // for cerr
+#include <vector>    // for vector
 
 using namespace std;
 using namespace gsl;
@@ -193,10 +194,18 @@ TEST(span_ext_test, make_span_from_container_constructor)
 
 TEST(span_test, interop_with_gsl_at)
 {
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. interop_with_gsl_at";
+        std::abort();
+    });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
     int arr[5] = {1, 2, 3, 4, 5};
     gsl::span<int> s{arr};
     EXPECT_TRUE(at(s, 0) == 1);
     EXPECT_TRUE(at(s, 1) == 2);
+    EXPECT_DEATH(at(s, 5), expected);
+    EXPECT_DEATH(at(s, 6), expected);
 }
 
 TEST(span_ext_test, iterator_free_functions)

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -194,18 +194,28 @@ TEST(span_ext_test, make_span_from_container_constructor)
 
 TEST(span_test, interop_with_gsl_at)
 {
+    std::vector<int> vec{1, 2, 3, 4, 5};
+    gsl::span sp{vec};
+
+    std::vector<int> cvec{1, 2, 3, 4, 5};
+    gsl::span csp{cvec};
+
+    for (gsl::index i = 0; i < gsl::narrow_cast<gsl::index>(vec.size()); ++i)
+    {
+        EXPECT_TRUE(&gsl::at(sp, i) == &vec[gsl::narrow_cast<size_t>(i)]);
+        EXPECT_TRUE(&gsl::at(csp, i) == &cvec[gsl::narrow_cast<size_t>(i)]);
+    }
+
     const auto terminateHandler = std::set_terminate([] {
         std::cerr << "Expected Death. interop_with_gsl_at";
         std::abort();
     });
     const auto expected = GetExpectedDeathString(terminateHandler);
 
-    int arr[5] = {1, 2, 3, 4, 5};
-    gsl::span<int> s{arr};
-    EXPECT_TRUE(at(s, 0) == 1);
-    EXPECT_TRUE(at(s, 1) == 2);
-    EXPECT_DEATH(at(s, 5), expected);
-    EXPECT_DEATH(at(s, 6), expected);
+    EXPECT_DEATH(gsl::at(sp, -1), expected);
+    EXPECT_DEATH(gsl::at(sp, gsl::narrow_cast<gsl::index>(sp.size())), expected);
+    EXPECT_DEATH(gsl::at(csp, -1), expected);
+    EXPECT_DEATH(gsl::at(csp, gsl::narrow_cast<gsl::index>(sp.size())), expected);
 }
 
 TEST(span_ext_test, iterator_free_functions)

--- a/tests/span_ext_tests.cpp
+++ b/tests/span_ext_tests.cpp
@@ -195,10 +195,10 @@ TEST(span_ext_test, make_span_from_container_constructor)
 TEST(span_test, interop_with_gsl_at)
 {
     std::vector<int> vec{1, 2, 3, 4, 5};
-    gsl::span sp{vec};
+    gsl::span<int> sp{vec};
 
     std::vector<int> cvec{1, 2, 3, 4, 5};
-    gsl::span csp{cvec};
+    gsl::span<int> csp{cvec};
 
     for (gsl::index i = 0; i < gsl::narrow_cast<gsl::index>(vec.size()); ++i)
     {


### PR DESCRIPTION
https://github.com/microsoft/GSL/issues/1075
- Add `static_assert` because we only support C style array `at` for up to half of the address space.
- Add `std::` before `size_t`.
- tests:
  - Add `#include <exception>`
  - Implement `span_tests` `interop_with_gsl_at` like `at_tests` `std_span`