### PR TITLE
Fix `max` macro collision

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -111,7 +111,7 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
-    static_assert(N <= static_cast<std::size_t>((std::numeric_limits<std::ptrdiff_t>::max())()), "We only support arrays up to PTRDIFF_MAX bytes.");
+    static_assert(N <= static_cast<std::size_t>((std::numeric_limits<std::ptrdiff_t>::max)()), "We only support arrays up to PTRDIFF_MAX bytes.");
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -111,7 +111,7 @@ GSL_SUPPRESS(bounds.2) // NO-FORMAT: attribute
     // clang-format on
     constexpr T& at(T (&arr)[N], const index i)
 {
-    static_assert(N <= static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()), "We only support arrays up to PTRDIFF_MAX bytes.");
+    static_assert(N <= static_cast<std::size_t>((std::numeric_limits<std::ptrdiff_t>::max())()), "We only support arrays up to PTRDIFF_MAX bytes.");
     Expects(i >= 0 && i < narrow_cast<index>(N));
     return arr[narrow_cast<std::size_t>(i)];
 }


### PR DESCRIPTION
PR https://github.com/microsoft/GSL/pull/1076 introduced a usage of `numeric_limits::max()` function, which seems to have [issues interacting with some Windows headers](https://github.com/skypjack/entt/wiki/Frequently-Asked-Questions#warning-c4003-the-min-the-max-and-the-macro). This PR implements [a simple fix](https://stackoverflow.com/questions/1394132/macro-and-member-function-conflict), which is to wrap the invocations in parentheses. This offloads the fix from the users of the library.