### PR TITLE
add not_null and strict_not_null tests for const

### DIFF
--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -442,11 +442,36 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
     }
 
     {
+        const int i = 42;
+
+        not_null x{&i};
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(not_null{&i});
+#endif
+        helper_const(not_null{&i});
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
         int i = 42;
         int* p = &i;
 
         not_null x{p};
         helper(not_null{p});
+        helper_const(not_null{p});
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
+        const int i = 42;
+        const int* p = &i;
+
+        not_null x{p};
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(not_null{p});
+#endif
         helper_const(not_null{p});
 
         EXPECT_TRUE(*x == 42);
@@ -504,11 +529,36 @@ TEST(notnull_tests, TestMakeNotNull)
     }
 
     {
+        const int i = 42;
+
+        const auto x = make_not_null(&i);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(make_not_null(&i));
+#endif
+        helper_const(make_not_null(&i));
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
         int i = 42;
         int* p = &i;
 
         const auto x = make_not_null(p);
         helper(make_not_null(p));
+        helper_const(make_not_null(p));
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
+        const int i = 42;
+        const int* p = &i;
+
+        const auto x = make_not_null(p);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(make_not_null(p));
+#endif
         helper_const(make_not_null(p));
 
         EXPECT_TRUE(*x == 42);
@@ -556,15 +606,31 @@ TEST(notnull_tests, TestMakeNotNull)
 
 TEST(notnull_tests, TestStdHash)
 {
-    int x = 42;
-    int y = 99;
-    not_null<int*> nn{&x};
-    const not_null<int*> cnn{&x};
+    {
+        int x = 42;
+        int y = 99;
+        not_null<int*> nn{&x};
+        const not_null<int*> cnn{&x};
 
-    std::hash<not_null<int*>> hash_nn;
-    std::hash<int*> hash_intptr;
+        std::hash<not_null<int*>> hash_nn;
+        std::hash<int*> hash_intptr;
 
-    EXPECT_TRUE(hash_nn(nn) == hash_intptr(&x));
-    EXPECT_FALSE(hash_nn(nn) == hash_intptr(&y));
-    EXPECT_FALSE(hash_nn(nn) == hash_intptr(nullptr));
+        EXPECT_TRUE(hash_nn(nn) == hash_intptr(&x));
+        EXPECT_FALSE(hash_nn(nn) == hash_intptr(&y));
+        EXPECT_FALSE(hash_nn(nn) == hash_intptr(nullptr));
+    }
+
+    {
+        const int x = 42;
+        const int y = 99;
+        not_null<const int*> nn{&x};
+        const not_null<const int*> cnn{&x};
+
+        std::hash<not_null<const int*>> hash_nn;
+        std::hash<const int*> hash_intptr;
+
+        EXPECT_TRUE(hash_nn(nn) == hash_intptr(&x));
+        EXPECT_FALSE(hash_nn(nn) == hash_intptr(&y));
+        EXPECT_FALSE(hash_nn(nn) == hash_intptr(nullptr));
+    }
 }

--- a/tests/strict_notnull_tests.cpp
+++ b/tests/strict_notnull_tests.cpp
@@ -72,6 +72,28 @@ TEST(strict_notnull_tests, TestStrictNotNull)
     }
 
     {
+        // raw ptr <-> strict_not_null
+        const int x = 42;
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        strict_not_null<int*> snn = &x;
+        strict_helper(&x);
+        strict_helper_const(&x);
+        strict_helper(return_pointer());
+        strict_helper_const(return_pointer_const());
+#endif
+
+        const strict_not_null<const int*> snn1{&x};
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(snn1);
+#endif
+        helper_const(snn1);
+
+        EXPECT_TRUE(*snn1 == 42);
+    }
+
+    {
         // strict_not_null -> strict_not_null
         int x = 42;
 
@@ -79,6 +101,22 @@ TEST(strict_notnull_tests, TestStrictNotNull)
         const strict_not_null<int*> snn2{&x};
 
         strict_helper(snn1);
+        strict_helper_const(snn1);
+        strict_helper_const(snn2);
+
+        EXPECT_TRUE(snn1 == snn2);
+    }
+
+    {
+        // strict_not_null -> strict_not_null
+        const int x = 42;
+
+        strict_not_null<const int*> snn1{&x};
+        const strict_not_null<const int*> snn2{&x};
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        strict_helper(snn1);
+#endif
         strict_helper_const(snn1);
         strict_helper_const(snn2);
 
@@ -102,6 +140,24 @@ TEST(strict_notnull_tests, TestStrictNotNull)
     }
 
     {
+        // strict_not_null -> not_null
+        const int x = 42;
+
+        strict_not_null<const int*> snn{&x};
+
+        const not_null<const int*> nn1 = snn;
+        const not_null<const int*> nn2{snn};
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(snn);
+#endif
+        helper_const(snn);
+
+        EXPECT_TRUE(snn == nn1);
+        EXPECT_TRUE(snn == nn2);
+    }
+
+    {
         // not_null -> strict_not_null
         int x = 42;
 
@@ -118,6 +174,32 @@ TEST(strict_notnull_tests, TestStrictNotNull)
 
         std::hash<strict_not_null<int*>> hash_snn;
         std::hash<not_null<int*>> hash_nn;
+
+        EXPECT_TRUE(hash_nn(snn1) == hash_nn(nn));
+        EXPECT_TRUE(hash_snn(snn1) == hash_nn(nn));
+        EXPECT_TRUE(hash_nn(snn1) == hash_nn(snn2));
+        EXPECT_TRUE(hash_snn(snn1) == hash_snn(nn));
+    }
+
+    {
+        // not_null -> strict_not_null
+        const int x = 42;
+
+        not_null<const int*> nn{&x};
+
+        const strict_not_null<const int*> snn1{nn};
+        const strict_not_null<const int*> snn2{nn};
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        strict_helper(nn);
+#endif
+        strict_helper_const(nn);
+
+        EXPECT_TRUE(snn1 == nn);
+        EXPECT_TRUE(snn2 == nn);
+
+        std::hash<strict_not_null<const int*>> hash_snn;
+        std::hash<not_null<const int*>> hash_nn;
 
         EXPECT_TRUE(hash_nn(snn1) == hash_nn(nn));
         EXPECT_TRUE(hash_snn(snn1) == hash_nn(nn));
@@ -153,11 +235,36 @@ TEST(strict_notnull_tests, TestStrictNotNullConstructorTypeDeduction)
     }
 
     {
+        const int i = 42;
+
+        strict_not_null x{&i};
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(strict_not_null{&i});
+#endif
+        helper_const(strict_not_null{&i});
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
         int i = 42;
         int* p = &i;
 
         strict_not_null x{p};
         helper(strict_not_null{p});
+        helper_const(strict_not_null{p});
+
+        EXPECT_TRUE(*x == 42);
+    }
+
+    {
+        const int i = 42;
+        const int* p = &i;
+
+        strict_not_null x{p};
+#ifdef CONFIRM_COMPILATION_ERRORS
+        helper(strict_not_null{p});
+#endif
         helper_const(strict_not_null{p});
 
         EXPECT_TRUE(*x == 42);


### PR DESCRIPTION
While writing the docs I found a `remove_cv_t` in `make_null`/`make_strict_not_null` which made me wonder if we want to make sure that the code works well with const pointers.