### PR TITLE
simplify to_byte

### DIFF
--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -174,26 +174,15 @@ constexpr IntegerType to_integer(byte b) noexcept
 
 #endif // GSL_USE_STD_BYTE
 
-template <bool E, typename T>
-constexpr byte to_byte_impl(T t) noexcept
-{
-    static_assert(
-        E, "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
-           "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version.");
-    return static_cast<byte>(t);
-}
-template <>
+template <typename T>
 // NOTE: need suppression since c++14 does not allow "return {t}"
 // GSL_SUPPRESS(type.4) // NO-FORMAT: attribute // TODO: suppression does not work
-constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept
-{
-    return byte(t);
-}
-
-template <typename T>
 constexpr byte to_byte(T t) noexcept
 {
-    return to_byte_impl<std::is_same<T, unsigned char>::value, T>(t);
+    static_assert(std::is_same<T, unsigned char>::value,
+                  "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
+                  "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version.");
+    return byte(t);
 }
 
 template <int I>

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -61,6 +61,12 @@ TEST(byte_tests, construction)
         EXPECT_TRUE(static_cast<unsigned char>(b) == 14);
     }
 #endif
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+    to_byte(char{});
+    to_byte(3);
+    to_byte(3u);
+#endif
 }
 
 TEST(byte_tests, bitwise_operations)


### PR DESCRIPTION
- to_byte_impl is not necessary, the same can be achieved with shorter code
- add test code for things that should not compile