### PR TITLE
Suppress warning C26481

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -214,6 +214,7 @@ namespace details
             if (n != 0) Expects(begin_ && current_ && end_);
             if (n > 0) Expects(current_ - begin_ >= n);
             if (n < 0) Expects(end_ - current_ >= -n);
+            GSL_SUPPRESS(bounds .1)
             current_ -= n;
             return *this;
         }


### PR DESCRIPTION
Suppress "warning C26481: Don't use pointer arithmetic. Use span instead (bounds.1)." in the code that impements `span`.