### PR TITLE
Use the implementation-defined strict total order for pointer comparisons with `not_null`

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -175,34 +175,34 @@ auto operator!=(const not_null<T>& lhs,
 
 template <class T, class U>
 auto operator<(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(std::less(lhs.get(), rhs.get())))
-    -> decltype(std::less(lhs.get(), rhs.get()))
+               const not_null<U>& rhs) noexcept(noexcept(std::less{}(lhs.get(), rhs.get())))
+    -> decltype(std::less{}(lhs.get(), rhs.get()))
 {
-    return std::less(lhs.get(), rhs.get());
+    return std::less{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator<=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(std::less_equal(lhs.get(), rhs.get())))
-    -> decltype(std::less_equal(lhs.get(), rhs.get()))
+                const not_null<U>& rhs) noexcept(noexcept(std::less_equal{}(lhs.get(), rhs.get())))
+    -> decltype(std::less_equal{}(lhs.get(), rhs.get()))
 {
-    return std::less_equal(lhs.get(), rhs.get());
+    return std::less_equal{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(std::greater(lhs.get(), rhs.get())))
-    -> decltype(std::greater(lhs.get(), rhs.get()))
+               const not_null<U>& rhs) noexcept(noexcept(std::greater{}(lhs.get(), rhs.get())))
+    -> decltype(std::greater{}(lhs.get(), rhs.get()))
 {
-    return std::greater(lhs.get(), rhs.get());
+    return std::greater{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(std::greater_equal(lhs.get(), rhs.get())))
-    -> decltype(std::greater_equal(lhs.get(), rhs.get()))
+                const not_null<U>& rhs) noexcept(noexcept(std::greater_equal{}(lhs.get(), rhs.get())))
+    -> decltype(std::greater_equal{}(lhs.get(), rhs.get()))
 {
-    return std::greater_equal(lhs.get(), rhs.get());
+    return std::greater_equal{}(lhs.get(), rhs.get());
 }
 
 // more unwanted operators

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -175,34 +175,34 @@ auto operator!=(const not_null<T>& lhs,
 
 template <class T, class U>
 auto operator<(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(lhs.get() < rhs.get()))
-    -> decltype(lhs.get() < rhs.get())
+               const not_null<U>& rhs) noexcept(noexcept(std::less(lhs.get(), rhs.get())))
+    -> decltype(std::less(lhs.get(), rhs.get()))
 {
-    return lhs.get() < rhs.get();
+    return std::less(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator<=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(lhs.get() <= rhs.get()))
-    -> decltype(lhs.get() <= rhs.get())
+                const not_null<U>& rhs) noexcept(noexcept(std::less_equal(lhs.get(), rhs.get())))
+    -> decltype(std::less_equal(lhs.get(), rhs.get()))
 {
-    return lhs.get() <= rhs.get();
+    return std::less_equal(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(lhs.get() > rhs.get()))
-    -> decltype(lhs.get() > rhs.get())
+               const not_null<U>& rhs) noexcept(noexcept(std::greater(lhs.get(), rhs.get())))
+    -> decltype(std::greater(lhs.get(), rhs.get()))
 {
-    return lhs.get() > rhs.get();
+    return std::greater(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(lhs.get() >= rhs.get()))
-    -> decltype(lhs.get() >= rhs.get())
+                const not_null<U>& rhs) noexcept(noexcept(std::greater_equal(lhs.get(), rhs.get())))
+    -> decltype(std::greater_equal(lhs.get(), rhs.get()))
 {
-    return lhs.get() >= rhs.get();
+    return std::greater_equal(lhs.get(), rhs.get());
 }
 
 // more unwanted operators

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -175,34 +175,34 @@ auto operator!=(const not_null<T>& lhs,
 
 template <class T, class U>
 auto operator<(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(std::less{}(lhs.get(), rhs.get())))
-    -> decltype(std::less{}(lhs.get(), rhs.get()))
+               const not_null<U>& rhs) noexcept(noexcept(std::less<>{}(lhs.get(), rhs.get())))
+    -> decltype(std::less<>{}(lhs.get(), rhs.get()))
 {
-    return std::less{}(lhs.get(), rhs.get());
+    return std::less<>{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator<=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(std::less_equal{}(lhs.get(), rhs.get())))
-    -> decltype(std::less_equal{}(lhs.get(), rhs.get()))
+                const not_null<U>& rhs) noexcept(noexcept(std::less_equal<>{}(lhs.get(), rhs.get())))
+    -> decltype(std::less_equal<>{}(lhs.get(), rhs.get()))
 {
-    return std::less_equal{}(lhs.get(), rhs.get());
+    return std::less_equal<>{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>(const not_null<T>& lhs,
-               const not_null<U>& rhs) noexcept(noexcept(std::greater{}(lhs.get(), rhs.get())))
-    -> decltype(std::greater{}(lhs.get(), rhs.get()))
+               const not_null<U>& rhs) noexcept(noexcept(std::greater<>{}(lhs.get(), rhs.get())))
+    -> decltype(std::greater<>{}(lhs.get(), rhs.get()))
 {
-    return std::greater{}(lhs.get(), rhs.get());
+    return std::greater<>{}(lhs.get(), rhs.get());
 }
 
 template <class T, class U>
 auto operator>=(const not_null<T>& lhs,
-                const not_null<U>& rhs) noexcept(noexcept(std::greater_equal{}(lhs.get(), rhs.get())))
-    -> decltype(std::greater_equal{}(lhs.get(), rhs.get()))
+                const not_null<U>& rhs) noexcept(noexcept(std::greater_equal<>{}(lhs.get(), rhs.get())))
+    -> decltype(std::greater_equal<>{}(lhs.get(), rhs.get()))
 {
-    return std::greater_equal{}(lhs.get(), rhs.get());
+    return std::greater_equal<>{}(lhs.get(), rhs.get());
 }
 
 // more unwanted operators


### PR DESCRIPTION
Using `<`,`<=`,`>`,`>=` to compare unrelated pointers gives an unspecified result according to standard.
This PR replaces the usage of these operators in `gsl::not_null` with the STL counterparts, which would leverage any implementation-defined strict total ordering for pointers.

Resolves #880