### PR TITLE
Deprecate the smartpointer make_span overloads

### DIFF
--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -123,12 +123,14 @@ constexpr span<const typename Container::value_type> make_span(const Container& 
 }
 
 template <class Ptr>
+[[deprecated("This function is deprecated. See GSL issue #1092.")]]
 constexpr span<typename Ptr::element_type> make_span(Ptr& cont, std::size_t count)
 {
     return span<typename Ptr::element_type>(cont, count);
 }
 
 template <class Ptr>
+[[deprecated("This function is deprecated. See GSL issue #1092.")]]
 constexpr span<typename Ptr::element_type> make_span(Ptr& cont)
 {
     return span<typename Ptr::element_type>(cont);


### PR DESCRIPTION
These overloads don't seem to be in a usable state, and their original purpose is no longer clear. Prepare to remove them via deprecation.
Resolves #1092