### PR TITLE
remove gcc noexcept warning

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -117,6 +117,7 @@ public:
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
     constexpr details::value_or_reference_return_t<T> get() const
+        noexcept(noexcept(details::value_or_reference_return_t<T>{ptr_}))
     {
         return ptr_;
     }


### PR DESCRIPTION
Without this change a `gsl::not_null<class_type>` triggers these `noexcept` warnings:
```
.../gsl/include/gsl/pointers:162:50: warning: noexcept-expression evaluates to ‘false’ because of a call to ‘constexpr gsl::details::value_or_reference_return_t<T> gsl::not_null<T>::get() const [with T = class_type*; gsl::details::value_or_reference_return_t<T> = class_type* const]’ [-Wnoexcept]
  162 |                 const not_null<U>& rhs) noexcept(noexcept(lhs.get() == rhs.get()))
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../gsl/include/gsl/pointers:119:55: note: but ‘constexpr gsl::details::value_or_reference_return_t<T> gsl::not_null<T>::get() const [with T = class_type*; gsl::details::value_or_reference_return_t<T> = class_type* const]’ does not throw; perhaps it should be declared ‘noexcept’
  119 |     constexpr details::value_or_reference_return_t<T> get() const
      |                                                       ^~~
```