### PR TITLE
make value_or_reference_return_t non-const T or const T&

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -47,14 +47,15 @@ namespace details
     {
     };
 
-    // Resolves to the more efficient of `const T` or `const T&`, in the context of returning a const-qualified value
+    // Resolves to the more efficient of `T` or `const T&`, in the context of returning a const-qualified value
     // of type T.
     //
-    // Copied from cppfront's implementation of the CppCoreGuidelines F.16 (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in)
+    // Copied from cppfront's implementation of the CppCoreGuidelines F.16 (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in),
+    // but modified.
     template<typename T>
     using value_or_reference_return_t = std::conditional_t<
                                             sizeof(T) < 2*sizeof(void*) && std::is_trivially_copy_constructible<T>::value,
-                                            const T,
+                                            T,
                                             const T&>;
 
 } // namespace details


### PR DESCRIPTION
Returning a `const T` is not better than returning a `T`. In fact it is worse because it prevents moving the returned temporary. So let `value_or_reference_return_t` be either `T` or `const T&`, and not `const T` or `const T&` (which would be a good match for an in parameter, but not for a return value).