### PR TITLE
Remove deprecated headers

### DIFF
--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -1,4 +1,0 @@
-#pragma once
-#pragma message(                                                                                   \
-    "This header will soon be removed. Use <gsl/algorithm> instead of <gsl/gsl_algorithm>")
-#include "algorithm"

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -1,3 +1,0 @@
-#pragma once
-#pragma message("This header will soon be removed. Use <gsl/assert> instead of <gsl/gsl_assert>")
-#include "assert"

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -1,3 +1,0 @@
-#pragma once
-#pragma message("This header will soon be removed. Use <gsl/byte> instead of <gsl/gsl_byte>")
-#include "byte"

--- a/include/gsl/gsl_narrow
+++ b/include/gsl/gsl_narrow
@@ -1,3 +1,0 @@
-#pragma once
-#pragma message("This header will soon be removed. Use <gsl/narrow> instead of <gsl/gsl_narrow>")
-#include "narrow"

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -1,3 +1,0 @@
-#pragma once
-#pragma message("This header will soon be removed. Use <gsl/util> instead of <gsl/gsl_util>")
-#include "util"


### PR DESCRIPTION
Headers that were previously prefixed with `gsl_` were renamed to drop the `gsl_` prefix in https://github.com/microsoft/GSL/pull/946, and the original version deprecated.
The deprecation happened a long time ago, so it is now time to remove these headers entirely.