### PR TITLE
get back gcc 8.4 compatibility

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -117,7 +117,7 @@ public:
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
     constexpr details::value_or_reference_return_t<T> get() const
-        noexcept(noexcept(details::value_or_reference_return_t<T>{ptr_}))
+        noexcept(noexcept(details::value_or_reference_return_t<T>{std::declval<T&>()}))
     {
         return ptr_;
     }


### PR DESCRIPTION
Before my PR #1122 `gsl/pointers` was gcc 8.4 compatible. Now it is not. This commit makes it compatible with gcc 8.4 again.