### PR TITLE
Update Clang GSL_SUPPRESS to stringize parameter instead of using fixed string literal.

### DIFF
--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -46,7 +46,7 @@
 // Hopefully temporary until suppression standardization occurs
 //
 #if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
 #else
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(x)]]

--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -17,20 +17,6 @@
 #ifndef GSL_BYTE_H
 #define GSL_BYTE_H
 
-//
-// make suppress attributes work for some compilers
-// Hopefully temporary until suppression standardization occurs
-//
-#if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
-#define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
-#else
-#define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
-
 #include <type_traits>
 
 // VS2017 15.8 added support for the __cpp_lib_byte definition

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -37,9 +37,6 @@ TEST(byte_tests, construction)
         EXPECT_TRUE(static_cast<unsigned char>(b) == 4);
     }
 
-    // clang-format off
-    GSL_SUPPRESS(es.49)
-    // clang-format on
     {
         const byte b = byte(12);
         EXPECT_TRUE(static_cast<unsigned char>(b) == 12);


### PR DESCRIPTION
Fix #1130.