### PR TITLE
Suppress some noisy / buggy warnings

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -777,8 +777,15 @@ span(const Container&) -> span<Element>;
 #endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
+#if defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated" // Bug in clang-cl.exe which raises a C++17 -Wdeprecated warning about this static constexpr workaround in C++14 mode.
+#endif // defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)
 template <class ElementType, std::size_t Extent>
 constexpr const typename span<ElementType, Extent>::size_type span<ElementType, Extent>::extent;
+#if defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)
+#pragma clang diagnostic pop
+#endif // defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)
 #endif
 
 namespace details

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ else()
         -Wsign-conversion
         -Wfloat-equal
         -Wno-deprecated-declarations # Allow tests for [[deprecated]] elements
+        -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -252,6 +252,7 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
+          -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
+          -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)
@@ -137,7 +138,6 @@ else()
         -Wsign-conversion
         -Wfloat-equal
         -Wno-deprecated-declarations # Allow tests for [[deprecated]] elements
-        -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
           -Weverything
           -Wno-c++98-compat

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,7 +126,7 @@ if(MSVC) # MSVC or simulating MSVC
     check_cxx_compiler_flag("-Wno-unsafe-buffer-usage" WARN_UNSAFE_BUFFER)
     if (WARN_UNSAFE_BUFFER)
       # This test uses very greedy heuristics such as "no pointer arithmetic on raw buffer"
-      target_compile_options(gsl_tests_config_noexcept INTERFACE "-Wno-unsafe-buffer-usage")
+      target_compile_options(gsl_tests_config INTERFACE "-Wno-unsafe-buffer-usage")
     endif()
 else()
     target_compile_options(gsl_tests_config INTERFACE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,14 +117,16 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
-          $<$<COMPILE_FLAG:-Wno-unsafe-buffer-usage>:
-            -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
-          >
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)
     if (WARN_RESERVED_ID)
-        target_compile_options(gsl_tests_config INTERFACE "-Wno-reserved-identifier")
+      target_compile_options(gsl_tests_config INTERFACE "-Wno-reserved-identifier")
+    endif()
+    check_cxx_compiler_flag("-Wno-unsafe-buffer-usage" WARN_UNSAFE_BUFFER)
+    if (WARN_UNSAFE_BUFFER)
+      # This test uses very greedy heuristics such as "no pointer arithmetic on raw buffer"
+      target_compile_options(gsl_tests_config_noexcept INTERFACE "-Wno-unsafe-buffer-usage")
     endif()
 else()
     target_compile_options(gsl_tests_config INTERFACE
@@ -254,14 +256,16 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
-          $<$<COMPILE_FLAG:-Wno-unsafe-buffer-usage>:
-            -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
-          >
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)
     if (WARN_RESERVED_ID)
-        target_compile_options(gsl_tests_config_noexcept INTERFACE "-Wno-reserved-identifier")
+      target_compile_options(gsl_tests_config_noexcept INTERFACE "-Wno-reserved-identifier")
+    endif()
+    check_cxx_compiler_flag("-Wno-unsafe-buffer-usage" WARN_UNSAFE_BUFFER)
+    if (WARN_UNSAFE_BUFFER)
+      # This test uses very greedy heuristics such as "no pointer arithmetic on raw buffer"
+      target_compile_options(gsl_tests_config_noexcept INTERFACE "-Wno-unsafe-buffer-usage")
     endif()
 else()
     target_compile_options(gsl_tests_config_noexcept INTERFACE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,7 +117,9 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
-          -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
+          $<$<COMPILE_FLAG:-Wno-unsafe-buffer-usage>:
+            -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
+          >
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)
@@ -252,7 +254,9 @@ if(MSVC) # MSVC or simulating MSVC
               -Wno-deprecated # False positive in MSVC Clang 15.0.1 raises a C++17 warning
             >
           >
-          -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
+          $<$<COMPILE_FLAG:-Wno-unsafe-buffer-usage>:
+            -Wno-unsafe-buffer-usage # This test uses very loose and blanket heuristics such as "no pointer arithmetic on raw buffer"
+          >
         >
     )
     check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)


### PR DESCRIPTION
Two warnings were being emitted in the MSVC+LLVM tests. 

The warning `-Wunsafe-buffer-usage` is initially introduced in some capacity here https://reviews.llvm.org/D137346 pointing to documentation at https://discourse.llvm.org/t/rfc-c-buffer-hardening/65734. The warning is a stylistic checker whose goal is to "emit a warning every time an unsafe operation is performed on a raw pointer". This type of programming model is not useful for library implementations of types such as `span`, where direct manipulation of raw pointers is inevitable, so disable the warning altogether.

There is also a false-positive warning https://github.com/llvm/llvm-project/issues/65689 that I've disabled inline.
