### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create build directory
         run: mkdir -p build

--- a/.github/workflows/cmake_find_package.yml
+++ b/.github/workflows/cmake_find_package.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
         with:
           cmakeVersion: 3.14.0

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create build directory
         run: mkdir -p build


### PR DESCRIPTION
This fixes annotations on task runs like the following:

    The following actions uses node12 which is deprecated and will be forced
    to run on node16: actions/checkout@v2. For more info:
    https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/