### PR TITLE
Inspect only `__cpp_lib_byte`, drop `_HAS_STD_BYTE`

### DIFF
--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -19,8 +19,6 @@
 
 #include <type_traits>
 
-// VS2017 15.8 added support for the __cpp_lib_byte definition
-// To do: drop _HAS_STD_BYTE when support for pre 15.8 expires
 #ifdef _MSC_VER
 
 #pragma warning(push)
@@ -31,18 +29,15 @@
 
 #ifndef GSL_USE_STD_BYTE
 // this tests if we are under MSVC and the standard lib has std::byte and it is enabled
-#if (defined(_HAS_STD_BYTE) && _HAS_STD_BYTE) ||                                                   \
-    (defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603)
+#if defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603
 
 #define GSL_USE_STD_BYTE 1
 
-#else // (defined(_HAS_STD_BYTE) && _HAS_STD_BYTE) || (defined(__cpp_lib_byte) && __cpp_lib_byte >=
-      // 201603)
+#else // defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603
 
 #define GSL_USE_STD_BYTE 0
 
-#endif // (defined(_HAS_STD_BYTE) && _HAS_STD_BYTE) || (defined(__cpp_lib_byte) && __cpp_lib_byte >=
-       // 201603)
+#endif // defined(__cpp_lib_byte) && __cpp_lib_byte >= 201603
 #endif // GSL_USE_STD_BYTE
 
 #else // _MSC_VER


### PR DESCRIPTION
Long-awaited followup to #822 which addressed #821.

[GSL 4.0.0](https://github.com/microsoft/GSL/releases/tag/v4.0.0), released 2 years ago, dropped support for VS 2017. Only VS 2019 and VS 2022 are supported. Therefore, GSL can now always use the Standard feature-test macro `__cpp_lib_byte` to sense whether MSVC's STL provides `std::byte`. It should no longer inspect the non-Standard macro `_HAS_STD_BYTE` (which is our "control macro").