### PR TITLE
Add a MS GSL disambiguation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,7 @@ target_link_libraries(foobar PRIVATE Microsoft.GSL::GSL)
 ## Debugging visualization support
 
 For Visual Studio users, the file [GSL.natvis](./GSL.natvis) in the root directory of the repository can be added to your project if you would like more helpful visualization of GSL types in the Visual Studio debugger than would be offered by default.
+
+## See Also
+
+For information on [Microsoft Gray Systems Lab (GSL)](https://aka.ms/gsl) of applied data management and system research see <https://aka.ms/gsl>.


### PR DESCRIPTION
Adds a comment and link to the bottom of the `README.md` for details on a different GSL at Microsoft.