### PR TITLE
Fixed C4067 for Visual Studio

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -64,10 +64,12 @@
 #endif
 
 // Turn off clang unsafe buffer warnings as all accessed are guarded by runtime checks
-#if defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif // defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#endif // __has_warning("-Wunsafe-buffer-usage")
+#endif // defined(__clang__)
 
 namespace gsl
 {
@@ -852,8 +854,10 @@ as_writable_bytes(span<ElementType, Extent> s) noexcept
 #pragma GCC diagnostic pop
 #endif // __GNUC__ > 6
 
-#if defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
 #pragma clang diagnostic pop
-#endif
+#endif // __has_warning("-Wunsafe-buffer-usage")
+#endif // defined(__clang__)
 
 #endif // GSL_SPAN_H

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -41,10 +41,12 @@
 #endif // _MSC_VER
 
 // Turn off clang unsafe buffer warnings as all accessed are guarded by runtime checks
-#if defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
-#endif // defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#endif // __has_warning("-Wunsafe-buffer-usage")
+#endif // defined(__clang__)
 
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
 #define GSL_NODISCARD [[nodiscard]]
@@ -160,8 +162,10 @@ constexpr auto at(std::span<T, extent> sp, const index i) -> decltype(sp[sp.size
 
 #endif // _MSC_VER
 
-#if defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
 #pragma clang diagnostic pop
-#endif
+#endif // __has_warning("-Wunsafe-buffer-usage")
+#endif // defined(__clang__)
 
 #endif // GSL_UTIL_H


### PR DESCRIPTION
I have fixed warning C4067 generated from the line mentioned in [ISSUE](https://github.com/microsoft/GSL/issues/1155):
```
#if defined(__clang__) && __has_warning("-Wunsafe-buffer-usage")
```

by moving `__has_warning("-Wunsafe-buffer-usage")` into the #if block.