### PR TITLE
fix failing macos test

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -54,7 +54,7 @@ jobs:
   xcode:
     strategy:
       matrix:
-        xcode_version: [ '14.3.1', '15.4' ]
+        xcode_version: [ '15.4', '16.1' ]
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
     runs-on: macos-latest


### PR DESCRIPTION
Looks like https://github.com/actions/runner-images/issues/10703 took away support for xcode 14. That is why the latest action failed. There an active PR adding support for xcode 16 to the macos runner (https://github.com/actions/runner-images/pull/10967). This commit will fail until that has been merged, but it is probably worth waiting for.