### PR TITLE
fix various pipeline failures

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Emulator starting in background"
 
       - name: Configure
-        run: cmake -Werror=dev -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
+        run: cmake -Werror=dev -Wno-error=deprecated -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
 
       - name: Build
         run: cmake --build . --parallel

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Emulator starting in background"
 
       - name: Configure
-        run: cmake -Werror=dev -Wno-error=deprecated -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
+        run: cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
 
       - name: Build
         run: cmake --build . --parallel

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -54,7 +54,7 @@ jobs:
   xcode:
     strategy:
       matrix:
-        xcode_version: [ '15.4', '16.1' ]
+        xcode_version: [ '15.4' ]
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
     runs-on: macos-latest

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -29,7 +29,7 @@ jobs:
           - gcc_version: 12
             cxx_version: 20
           - gcc_version: 12
-            cxx_version: 20
+            cxx_version: 23
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -23,7 +23,14 @@ jobs:
         exclude:
           - gcc_version: 10
             cxx_version: 23
-    runs-on: ubuntu-latest
+          # https://github.com/google/googletest/issues/4232
+          # Looks like GoogleTest is not interested in making version 1.14
+          # work with gcc-12.
+          - gcc_version: 12
+            cxx_version: 20
+          - gcc_version: 12
+            cxx_version: 20
+ runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -30,7 +30,7 @@ jobs:
             cxx_version: 20
           - gcc_version: 12
             cxx_version: 20
- runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ if(MSVC) # MSVC or simulating MSVC
           -Wno-shift-sign-overflow # GTest gtest-port.h
           -Wno-undef # GTest
           -Wno-used-but-marked-unused # GTest EXPECT_DEATH
+          -Wno-switch-default # GTest EXPECT_DEATH
           $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
             -Wno-unused-member-function
             -Wno-unused-variable

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           v1.15.2
+  GIT_TAG           v1.14.0
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.10)
 project(googletest-download NONE)
 
 include(ExternalProject)

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           1b18723e874b256c1e39378c6774a90701d70f7a
+  GIT_TAG           v1.15.2
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
CI checks are failing because the cmake version requires cmake minimum requires >= 3.10. This PR addresses that issue.

Looks like https://github.com/actions/runner-images/issues/10703 took away support for xcode 14. That is why the latest action failed. There an active PR adding support for xcode 16 to the macos runner (https://github.com/actions/runner-images/pull/10967). This commit will fail until that has been merged, but it is probably worth waiting for. Edit: Looks like that PR was closed, so we won't wait.