### PR TITLE
Fix SFINAE on `gsl::owner`.

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -75,7 +75,7 @@ using std::unique_ptr;
 // T must be a pointer type
 // - disallow construction from any type other than pointer type
 //
-template <class T, class = std::enable_if_t<std::is_pointer<T>::value>>
+template <class T, std::enable_if_t<std::is_pointer<T>::value, bool> = true>
 using owner = T;
 
 //


### PR DESCRIPTION
`std::enable_if_t` must not be used as a default template argument, otherwise the instantiator will be able to override it freely with something that doesn't fail substitution. Instead, `std::enable_if_t` itself must be the type of the template argument.

More information in the examples here: https://en.cppreference.com/w/cpp/types/enable_if