### PR TITLE
fix: direct-init const ref instead of list-init

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -117,7 +117,7 @@ public:
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
     constexpr details::value_or_reference_return_t<T> get() const
-        noexcept(noexcept(details::value_or_reference_return_t<T>{std::declval<T&>()}))
+        noexcept(noexcept(details::value_or_reference_return_t<T>(std::declval<T&>())))
     {
         return ptr_;
     }


### PR DESCRIPTION
fixes: https://github.com/microsoft/GSL/issues/1162

gcc has a bug that generates a call to the copy constructor when list initializing a const reference. This PR offers a workaround which is to direct initialize the value.

see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117900