### PR TITLE
strict_not_null for unique_ptr

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -275,19 +275,19 @@ class strict_not_null : public not_null<T>
 {
 public:
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
-    constexpr explicit strict_not_null(U&& u) : not_null<T>(std::forward<U>(u))
+    constexpr explicit strict_not_null(U&& u) noexcept(std::is_nothrow_move_constructible<T>::value) : not_null<T>(std::forward<U>(u))
     {}
 
     template <typename = std::enable_if_t<!std::is_same<std::nullptr_t, T>::value>>
-    constexpr explicit strict_not_null(T u) : not_null<T>(u)
+    constexpr explicit strict_not_null(T u) noexcept(std::is_nothrow_move_constructible<T>::value) : not_null<T>(std::move(u))
     {}
 
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
-    constexpr strict_not_null(const not_null<U>& other) : not_null<T>(other)
+    constexpr strict_not_null(const not_null<U>& other) noexcept(std::is_nothrow_move_constructible<T>::value) : not_null<T>(other)
     {}
 
     template <typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
-    constexpr strict_not_null(const strict_not_null<U>& other) : not_null<T>(other)
+    constexpr strict_not_null(const strict_not_null<U>& other) noexcept(std::is_nothrow_move_constructible<T>::value) : not_null<T>(other)
     {}
 
     // To avoid invalidating the "not null" invariant, the contained pointer is actually copied

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -179,6 +179,14 @@ TEST(notnull_tests, TestNotNullConstructors)
     }
 
     {
+        // from unique pointer
+        not_null<std::unique_ptr<int>> x(
+            std::make_unique<int>(10)); // unique_ptr<int> is nullptr assignable
+
+        EXPECT_DEATH((not_null<std::unique_ptr<int>>(std::unique_ptr<int>{})), expected);
+    }
+
+    {
         // from pointer to local
         int t = 42;
 

--- a/tests/pointers_tests.cpp
+++ b/tests/pointers_tests.cpp
@@ -25,22 +25,50 @@ struct NotMoveAssignableCustomPtr
 TEST(pointers_test, swap)
 {
     // taken from gh-1129:
-    gsl::not_null<std::unique_ptr<int>> a(std::make_unique<int>(0));
-    gsl::not_null<std::unique_ptr<int>> b(std::make_unique<int>(1));
+    {
+        gsl::not_null<std::unique_ptr<int>> a(std::make_unique<int>(0));
+        gsl::not_null<std::unique_ptr<int>> b(std::make_unique<int>(1));
 
-    EXPECT_TRUE(*a == 0);
-    EXPECT_TRUE(*b == 1);
+        EXPECT_TRUE(*a == 0);
+        EXPECT_TRUE(*b == 1);
 
-    gsl::swap(a, b);
+        gsl::swap(a, b);
 
-    EXPECT_TRUE(*a == 1);
-    EXPECT_TRUE(*b == 0);
+        EXPECT_TRUE(*a == 1);
+        EXPECT_TRUE(*b == 0);
 
-    // Make sure our custom ptr can be used with not_null. The shared_pr is to prevent "unused"
-    // compiler warnings.
-    const auto shared_custom_ptr{std::make_shared<NotMoveAssignableCustomPtr>()};
-    gsl::not_null<NotMoveAssignableCustomPtr> c{*shared_custom_ptr};
-    EXPECT_TRUE(c.get() != nullptr);
+        // Make sure our custom ptr can be used with not_null. The shared_pr is to prevent "unused"
+        // compiler warnings.
+        const auto shared_custom_ptr{std::make_shared<NotMoveAssignableCustomPtr>()};
+        gsl::not_null<NotMoveAssignableCustomPtr> c{*shared_custom_ptr};
+        EXPECT_TRUE(c.get() != nullptr);
+    }
+
+    {
+        gsl::strict_not_null<std::unique_ptr<int>> a{std::make_unique<int>(0)};
+        gsl::strict_not_null<std::unique_ptr<int>> b{std::make_unique<int>(1)};
+
+        EXPECT_TRUE(*a == 0);
+        EXPECT_TRUE(*b == 1);
+
+        gsl::swap(a, b);
+
+        EXPECT_TRUE(*a == 1);
+        EXPECT_TRUE(*b == 0);
+    }
+
+    {
+        gsl::not_null<std::unique_ptr<int>> a{std::make_unique<int>(0)};
+        gsl::strict_not_null<std::unique_ptr<int>> b{std::make_unique<int>(1)};
+
+        EXPECT_TRUE(*a == 0);
+        EXPECT_TRUE(*b == 1);
+
+        gsl::swap(a, b);
+
+        EXPECT_TRUE(*a == 1);
+        EXPECT_TRUE(*b == 0);
+    }
 }
 
 #if __cplusplus >= 201703l


### PR DESCRIPTION
- `strict_not_null<std::unique_ptr<int>>{ std::make_unique<int>()}` failed to compile
  - `strict_not_null` ctor needs to move the passed `unique_ptr`, not copy
  - Copied `not_null` `TestNotNullConstructors` for `strict_not_null`
- The `noexcept` specifiers on the `strict_not_null` and `not_null` constructors were out of sync.
- Added unit test for `not_null<unique_ptr<T>>` and for `strict_not_null<unique_ptr<T>>`
- Added unit test for `gsl::swap` for two `strict_not_null`
- Added unit test for `gsl::swap` for `not_null` and `strict_not_null`
