### PR TITLE
More checks for non-compilable code, plus fix for span

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -582,7 +582,7 @@ public:
     template <std::size_t Count>
     constexpr span<element_type, Count> first() const noexcept
     {
-        static_assert(Count <= Extent,
+        static_assert(Extent == dynamic_extent || Count <= Extent,
                       "first() cannot extract more elements from a span than it contains.");
         Expects(Count <= size());
         return span<element_type, Count>{data(), Count};
@@ -594,7 +594,7 @@ public:
         // clang-format on
         constexpr span<element_type, Count> last() const noexcept
     {
-        static_assert(Count <= Extent,
+        static_assert(Extent == dynamic_extent || Count <= Extent,
                       "last() cannot extract more elements from a span than it contains.");
         Expects(Count <= size());
         return span<element_type, Count>{data() + (size() - Count), Count};
@@ -607,7 +607,8 @@ public:
         constexpr auto subspan() const noexcept ->
         typename details::calculate_subspan_type<ElementType, Extent, Offset, Count>::type
     {
-        static_assert(Extent >= Offset && (Count == dynamic_extent || Count <= Extent - Offset),
+        static_assert(Extent == dynamic_extent || (Extent >= Offset && (Count == dynamic_extent ||
+                                                                        Count <= Extent - Offset)),
                       "subspan() cannot extract more elements from a span than it contains.");
         Expects((size() >= Offset) && (Count == dynamic_extent || (Count <= size() - Offset)));
         using type =

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -582,6 +582,8 @@ public:
     template <std::size_t Count>
     constexpr span<element_type, Count> first() const noexcept
     {
+        static_assert(Count <= Extent,
+                      "first() cannot extract more elements from a span than it contains.");
         Expects(Count <= size());
         return span<element_type, Count>{data(), Count};
     }
@@ -592,6 +594,8 @@ public:
         // clang-format on
         constexpr span<element_type, Count> last() const noexcept
     {
+        static_assert(Count <= Extent,
+                      "last() cannot extract more elements from a span than it contains.");
         Expects(Count <= size());
         return span<element_type, Count>{data() + (size() - Count), Count};
     }
@@ -603,6 +607,8 @@ public:
         constexpr auto subspan() const noexcept ->
         typename details::calculate_subspan_type<ElementType, Extent, Offset, Count>::type
     {
+        static_assert(Extent >= Offset && (Count == dynamic_extent || Count <= Extent - Offset),
+                      "subspan() cannot extract more elements from a span than it contains.");
         Expects((size() >= Offset) && (Count == dynamic_extent || (Count <= size() - Offset)));
         using type =
             typename details::calculate_subspan_type<ElementType, Extent, Offset, Count>::type;

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -188,7 +188,7 @@ TEST(algorithm_tests, incompatible_type)
     span<int> src_span_dyn(src);
     span<int, 4> src_span_static(src);
     span<int*> dst_span_dyn(dst);
-    span<int*, 4> dst_span_static(dst);
+    span<int*, 4> dst_span_static(gsl::make_span(dst));
 
     // every line should produce a compilation error
     copy(src_span_dyn, dst_span_dyn);

--- a/tests/byte_tests.cpp
+++ b/tests/byte_tests.cpp
@@ -67,6 +67,8 @@ TEST(byte_tests, construction)
     to_byte(char{});
     to_byte(3);
     to_byte(3u);
+    to_byte<-1>();
+    to_byte<256u>();
 #endif
 }
 
@@ -174,7 +176,3 @@ static constexpr bool
 static_assert(!ToIntegerCompilesFor<float>, "!ToIntegerCompilesFor<float>");
 
 } // namespace
-
-#ifdef CONFIRM_COMPILATION_ERRORS
-copy(src_span_static, dst_span_static);
-#endif

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -30,6 +30,13 @@
 #include "deathTestCommon.h"
 using namespace gsl;
 
+#if __cplusplus >= 201703l
+using std::void_t;
+#else  // __cplusplus >= 201703l
+template <class...>
+using void_t = void;
+#endif // __cplusplus < 201703l
+
 struct MyBase
 {
 };
@@ -142,9 +149,38 @@ bool helper_const(not_null<const int*> p) { return *p == 12; }
 int* return_pointer() { return nullptr; }
 } // namespace
 
+template <typename U, typename = void>
+static constexpr bool CtorCompilesFor_A = false;
+template <typename U>
+static constexpr bool
+    CtorCompilesFor_A<U, void_t<decltype(gsl::not_null<void*>{std::declval<U>()})>> = true;
+
+template <typename U, int N, typename = void>
+static constexpr bool CtorCompilesFor_B = false;
+template <typename U, int N>
+static constexpr bool CtorCompilesFor_B<U, N, void_t<decltype(gsl::not_null<U>{N})>> = true;
+
+template <typename U, typename = void>
+static constexpr bool DefaultCtorCompilesFor = false;
+template <typename U>
+static constexpr bool DefaultCtorCompilesFor<U, void_t<decltype(gsl::not_null<U>{})>> = true;
+
+template <typename U, typename = void>
+static constexpr bool CtorCompilesFor_C = false;
+template <typename U>
+static constexpr bool
+    CtorCompilesFor_C<U, void_t<decltype(gsl::not_null<U*>{std::declval<std::unique_ptr<U>>()})>> =
+        true;
+
 TEST(notnull_tests, TestNotNullConstructors)
 {
     {
+        static_assert(CtorCompilesFor_A<void*>, "CtorCompilesFor_A<void*>");
+        static_assert(!CtorCompilesFor_A<std::nullptr_t>, "!CtorCompilesFor_A<std::nullptr_t>");
+        static_assert(!CtorCompilesFor_B<void*, 0>, "!CtorCompilesFor_B<void*, 0>");
+        static_assert(!DefaultCtorCompilesFor<void*>, "!DefaultCtorCompilesFor<void*>");
+        static_assert(!CtorCompilesFor_C<int>, "CtorCompilesFor_C<int>");
+
 #ifdef CONFIRM_COMPILATION_ERRORS
         // Forbid non-nullptr assignable types
         not_null<std::vector<int>> f(std::vector<int>{1});
@@ -271,6 +307,27 @@ TEST(notnull_tests, TestNotNullostream)
     ostream_helper<std::string>("string");
 }
 
+template <typename U, typename V, typename = void>
+static constexpr bool AssignmentCompilesFor = false;
+template <typename U, typename V>
+static constexpr bool
+    AssignmentCompilesFor<U, V,
+                          void_t<decltype(std::declval<gsl::not_null<U*>&>().operator=(
+                              std::declval<gsl::not_null<V*>&>()))>> = true;
+
+template <typename U, typename V, typename = void>
+static constexpr bool SCastCompilesFor = false;
+template <typename U, typename V>
+static constexpr bool
+    SCastCompilesFor<U, V, void_t<decltype(static_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> =
+        true;
+
+template <typename U, typename V, typename = void>
+static constexpr bool RCastCompilesFor = false;
+template <typename U, typename V>
+static constexpr bool RCastCompilesFor<
+    U, V, void_t<decltype(reinterpret_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> = true;
+
 TEST(notnull_tests, TestNotNullCasting)
 {
     MyBase base;
@@ -283,11 +340,30 @@ TEST(notnull_tests, TestNotNullCasting)
     q = p; // allowed with heterogeneous copy ctor
     EXPECT_TRUE(q == p);
 
+    static_assert(AssignmentCompilesFor<MyBase, MyDerived>,
+                  "AssignmentCompilesFor<MyBase, MyDerived>");
+    static_assert(!AssignmentCompilesFor<MyBase, Unrelated>,
+                  "!AssignmentCompilesFor<MyBase, Unrelated>");
+    static_assert(!AssignmentCompilesFor<Unrelated, MyDerived>,
+                  "!AssignmentCompilesFor<Unrelated, MyDerived>");
+    static_assert(!AssignmentCompilesFor<MyDerived, MyBase>,
+                  "!AssignmentCompilesFor<MyDerived, MyBase>");
+
+    static_assert(SCastCompilesFor<MyDerived, MyDerived>, "SCastCompilesFor<MyDerived, MyDerived>");
+    static_assert(SCastCompilesFor<MyBase, MyDerived>, "SCastCompilesFor<MyBase, MyDerived>");
+    static_assert(!SCastCompilesFor<MyDerived, MyBase>, "!SCastCompilesFor<MyDerived, MyBase>");
+    static_assert(!SCastCompilesFor<Unrelated, MyDerived>,
+                  "!SCastCompilesFor<Unrelated, MyDerived>");
+    static_assert(!RCastCompilesFor<MyDerived, MyDerived>,
+                  "!SCastCompilesFor<MyDerived, MyDerived>");
+    static_assert(!RCastCompilesFor<Unrelated, MyDerived>,
+                  "!SCastCompilesFor<Unrelated, MyDerived>");
+
     not_null<Unrelated*> t(reinterpret_cast<Unrelated*>(p.get()));
     EXPECT_TRUE(reinterpret_cast<void*>(p.get()) == reinterpret_cast<void*>(t.get()));
 
-    (void)static_cast<MyDerived*>(p);
-    (void)static_cast<MyBase*>(p);
+    (void) static_cast<MyDerived*>(p);
+    (void) static_cast<MyBase*>(p);
 }
 
 TEST(notnull_tests, TestNotNullAssignment)
@@ -429,6 +505,18 @@ TEST(notnull_tests, TestNotNullCustomPtrComparison)
 
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
 
+template <typename U, typename = void>
+static constexpr bool TypeDeductionCtorCompilesFor = false;
+template <typename U>
+static constexpr bool
+    TypeDeductionCtorCompilesFor<U, void_t<decltype(not_null{std::declval<U>()})>> = true;
+
+template <typename U, typename = void>
+static constexpr bool TypeDeductionHelperCompilesFor = false;
+template <typename U>
+static constexpr bool
+    TypeDeductionHelperCompilesFor<U, void_t<decltype(helper(not_null{std::declval<U>()}))>> = true;
+
 TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
 {
     {
@@ -445,6 +533,9 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         const int i = 42;
 
         not_null x{&i};
+        static_assert(TypeDeductionHelperCompilesFor<int*>, "TypeDeductionHelperCompilesFor<int*>");
+        static_assert(!TypeDeductionHelperCompilesFor<const int*>,
+                      "!TypeDeductionHelperCompilesFor<const int*>");
         helper_const(not_null{&i});
 
         EXPECT_TRUE(*x == 42);
@@ -499,6 +590,17 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         EXPECT_DEATH(helper(not_null{p}), expected);
         EXPECT_DEATH(helper_const(not_null{p}), expected);
     }
+
+    static_assert(TypeDeductionCtorCompilesFor<void*>, "TypeDeductionCtorCompilesFor<void*>");
+#if defined(_MSC_VER) && !defined(__clang__)
+    // Fails on gcc, clang, xcode, VS clang with
+    // "error : no type named 'type' in 'std::enable_if<false>'; 'enable_if' cannot be used to
+    // disable this declaration"
+    static_assert(!TypeDeductionCtorCompilesFor<std::nullptr_t>,
+                  "!TypeDeductionCtorCompilesFor<std::nullptr_t>");
+    static_assert(!TypeDeductionHelperCompilesFor<std::nullptr_t>,
+                  "!TypeDeductionHelperCompilesFor<std::nullptr_t>");
+#endif
 }
 
 TEST(notnull_tests, TestVariantEmplace)
@@ -512,6 +614,11 @@ TEST(notnull_tests, TestVariantEmplace)
     EXPECT_TRUE(std::get<not_null<int*>>(v) == &i);
 }
 #endif // #if defined(__cplusplus) && (__cplusplus >= 201703L)
+
+template <typename U, typename = void>
+static constexpr bool HelperCompilesFor = false;
+template <typename U>
+static constexpr bool HelperCompilesFor<U, void_t<decltype(helper(std::declval<U>()))>> = true;
 
 TEST(notnull_tests, TestMakeNotNull)
 {
@@ -529,6 +636,8 @@ TEST(notnull_tests, TestMakeNotNull)
         const int i = 42;
 
         const auto x = make_not_null(&i);
+        static_assert(HelperCompilesFor<gsl::not_null<int*>>,
+                      "HelperCompilesFor<gsl::not_null<int*>>");
         helper_const(make_not_null(&i));
 
         EXPECT_TRUE(*x == 42);
@@ -550,6 +659,8 @@ TEST(notnull_tests, TestMakeNotNull)
         const int* p = &i;
 
         const auto x = make_not_null(p);
+        static_assert(!HelperCompilesFor<gsl::not_null<const int*>>,
+                      "!HelperCompilesFor<gsl::not_null<const int*>>");
         helper_const(make_not_null(p));
 
         EXPECT_TRUE(*x == 42);
@@ -625,79 +736,3 @@ TEST(notnull_tests, TestStdHash)
         EXPECT_FALSE(hash_nn(nn) == hash_intptr(nullptr));
     }
 }
-
-#if __cplusplus >= 201703l
-using std::void_t;
-#else  // __cplusplus >= 201703l
-template <class...>
-using void_t = void;
-#endif // __cplusplus < 201703l
-
-template <typename U, typename = void>
-static constexpr bool CtorCompilesFor_A = false;
-template <typename U>
-static constexpr bool
-    CtorCompilesFor_A<U, void_t<decltype(gsl::not_null<void*>{std::declval<U>()})>> = true;
-static_assert(CtorCompilesFor_A<void*>, "CtorCompilesFor_A<void*>");
-static_assert(!CtorCompilesFor_A<std::nullptr_t>, "!CtorCompilesFor_A<std::nullptr_t>");
-
-template <typename U, int N, typename = void>
-static constexpr bool CtorCompilesFor_B = false;
-template <typename U, int N>
-static constexpr bool CtorCompilesFor_B<U, N, void_t<decltype(gsl::not_null<U>{N})>> = true;
-static_assert(!CtorCompilesFor_B<void*, 0>, "!CtorCompilesFor_B<void*, 0>");
-
-template <typename U, typename = void>
-static constexpr bool CtorCompilesFor_C = false;
-template <typename U>
-static constexpr bool
-    CtorCompilesFor_C<U, void_t<decltype(gsl::not_null<U*>{std::declval<std::unique_ptr<U>>()})>> =
-        true;
-static_assert(!CtorCompilesFor_C<int>, "CtorCompilesFor_C<int>");
-
-template <typename U, typename = void>
-static constexpr bool DefaultCtorCompilesFor = false;
-template <typename U>
-static constexpr bool DefaultCtorCompilesFor<U, void_t<decltype(gsl::not_null<U>{})>> = true;
-static_assert(!DefaultCtorCompilesFor<void*>, "!DefaultCtorCompilesFor<void*>");
-
-template <typename U, typename V, typename = void>
-static constexpr bool AssignmentCompilesFor = false;
-template <typename U, typename V>
-static constexpr bool
-    AssignmentCompilesFor<U, V,
-                          void_t<decltype(std::declval<gsl::not_null<U*>&>().operator=(
-                              std::declval<gsl::not_null<V*>&>()))>> = true;
-static_assert(AssignmentCompilesFor<MyBase, MyDerived>, "AssignmentCompilesFor<MyBase, MyDerived>");
-static_assert(!AssignmentCompilesFor<MyBase, Unrelated>,
-              "!AssignmentCompilesFor<MyBase, Unrelated>");
-static_assert(!AssignmentCompilesFor<Unrelated, MyDerived>,
-              "!AssignmentCompilesFor<Unrelated, MyDerived>");
-static_assert(!AssignmentCompilesFor<MyDerived, MyBase>,
-              "!AssignmentCompilesFor<MyDerived, MyBase>");
-
-template <typename U, typename V, typename = void>
-static constexpr bool CastCompilesFor_A = false;
-template <typename U, typename V>
-static constexpr bool CastCompilesFor_A<
-    U, V, void_t<decltype(static_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> = true;
-static_assert(CastCompilesFor_A<MyDerived, MyDerived>, "CastCompilesFor_A<MyDerived, MyDerived>");
-static_assert(CastCompilesFor_A<MyBase, MyDerived>, "CastCompilesFor_A<MyBase, MyDerived>");
-static_assert(!CastCompilesFor_A<MyDerived, MyBase>, "!CastCompilesFor_A<MyDerived, MyBase>");
-static_assert(!CastCompilesFor_A<Unrelated, MyDerived>, "!CastCompilesFor_A<Unrelated, MyDerived>");
-
-template <typename U, typename V, typename = void>
-static constexpr bool CastCompilesFor_B = false;
-template <typename U, typename V>
-static constexpr bool CastCompilesFor_B<
-    U, V, void_t<decltype(reinterpret_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> = true;
-static_assert(!CastCompilesFor_B<MyDerived, MyDerived>, "!CastCompilesFor_A<MyDerived, MyDerived>");
-static_assert(!CastCompilesFor_B<Unrelated, MyDerived>, "!CastCompilesFor_A<Unrelated, MyDerived>");
-
-template <typename U, typename = void>
-static constexpr bool HelperCompilesFor = false;
-template <typename U>
-static constexpr bool HelperCompilesFor<U, void_t<decltype(helper(std::declval<U>()))>> = true;
-static_assert(HelperCompilesFor<gsl::not_null<int*>>, "HelperCompilesFor<gsl::not_null<int*>>");
-static_assert(!HelperCompilesFor<gsl::not_null<const int*>>,
-              "!HelperCompilesFor<gsl::not_null<const int*>>");

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -18,13 +18,14 @@
 
 #include <gsl/pointers> // for not_null, operator<, operator<=, operator>
 
-#include <algorithm> // for addressof
-#include <cstdint>   // for uint16_t
-#include <memory>    // for shared_ptr, make_shared, operator<, opera...
-#include <sstream>   // for operator<<, ostringstream, basic_ostream:...
-#include <string>    // for basic_string, operator==, string, operator<<
-#include <typeinfo>  // for type_info
-#include <variant>   // for variant, monostate, get
+#include <algorithm>   // for addressof
+#include <cstdint>     // for uint16_t
+#include <memory>      // for shared_ptr, make_shared, operator<, opera...
+#include <sstream>     // for operator<<, ostringstream, basic_ostream:...
+#include <string>      // for basic_string, operator==, string, operator<<
+#include <type_traits> // for declval
+#include <typeinfo>    // for type_info
+#include <variant>     // for variant, monostate, get
 
 #include "deathTestCommon.h"
 using namespace gsl;
@@ -145,12 +146,6 @@ TEST(notnull_tests, TestNotNullConstructors)
 {
     {
 #ifdef CONFIRM_COMPILATION_ERRORS
-        not_null<int*> p = nullptr;          // yay...does not compile!
-        not_null<std::vector<char>*> p1 = 0; // yay...does not compile!
-        not_null<int*> p2;                   // yay...does not compile!
-        std::unique_ptr<int> up = std::make_unique<int>(120);
-        not_null<int*> p3 = up;
-
         // Forbid non-nullptr assignable types
         not_null<std::vector<int>> f(std::vector<int>{1});
         not_null<int> z(10);
@@ -288,15 +283,11 @@ TEST(notnull_tests, TestNotNullCasting)
     q = p; // allowed with heterogeneous copy ctor
     EXPECT_TRUE(q == p);
 
-#ifdef CONFIRM_COMPILATION_ERRORS
-    q = u; // no viable conversion possible between MyBase* and Unrelated*
-    p = q; // not possible to implicitly convert MyBase* to MyDerived*
-
-    not_null<Unrelated*> r = p;
-    not_null<Unrelated*> s = reinterpret_cast<Unrelated*>(p);
-#endif
     not_null<Unrelated*> t(reinterpret_cast<Unrelated*>(p.get()));
     EXPECT_TRUE(reinterpret_cast<void*>(p.get()) == reinterpret_cast<void*>(t.get()));
+
+    (void)static_cast<MyDerived*>(p);
+    (void)static_cast<MyBase*>(p);
 }
 
 TEST(notnull_tests, TestNotNullAssignment)
@@ -454,9 +445,6 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         const int i = 42;
 
         not_null x{&i};
-#ifdef CONFIRM_COMPILATION_ERRORS
-        helper(not_null{&i});
-#endif
         helper_const(not_null{&i});
 
         EXPECT_TRUE(*x == 42);
@@ -478,9 +466,6 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         const int* p = &i;
 
         not_null x{p};
-#ifdef CONFIRM_COMPILATION_ERRORS
-        helper(not_null{p});
-#endif
         helper_const(not_null{p});
 
         EXPECT_TRUE(*x == 42);
@@ -514,14 +499,6 @@ TEST(notnull_tests, TestNotNullConstructorTypeDeduction)
         EXPECT_DEATH(helper(not_null{p}), expected);
         EXPECT_DEATH(helper_const(not_null{p}), expected);
     }
-
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        not_null x{nullptr};
-        helper(not_null{nullptr});
-        helper_const(not_null{nullptr});
-    }
-#endif
 }
 
 TEST(notnull_tests, TestVariantEmplace)
@@ -552,9 +529,6 @@ TEST(notnull_tests, TestMakeNotNull)
         const int i = 42;
 
         const auto x = make_not_null(&i);
-#ifdef CONFIRM_COMPILATION_ERRORS
-        helper(make_not_null(&i));
-#endif
         helper_const(make_not_null(&i));
 
         EXPECT_TRUE(*x == 42);
@@ -576,9 +550,6 @@ TEST(notnull_tests, TestMakeNotNull)
         const int* p = &i;
 
         const auto x = make_not_null(p);
-#ifdef CONFIRM_COMPILATION_ERRORS
-        helper(make_not_null(p));
-#endif
         helper_const(make_not_null(p));
 
         EXPECT_TRUE(*x == 42);
@@ -654,3 +625,79 @@ TEST(notnull_tests, TestStdHash)
         EXPECT_FALSE(hash_nn(nn) == hash_intptr(nullptr));
     }
 }
+
+#if __cplusplus >= 201703l
+using std::void_t;
+#else  // __cplusplus >= 201703l
+template <class...>
+using void_t = void;
+#endif // __cplusplus < 201703l
+
+template <typename U, typename = void>
+static constexpr bool CtorCompilesFor_A = false;
+template <typename U>
+static constexpr bool
+    CtorCompilesFor_A<U, void_t<decltype(gsl::not_null<void*>{std::declval<U>()})>> = true;
+static_assert(CtorCompilesFor_A<void*>, "CtorCompilesFor_A<void*>");
+static_assert(!CtorCompilesFor_A<std::nullptr_t>, "!CtorCompilesFor_A<std::nullptr_t>");
+
+template <typename U, int N, typename = void>
+static constexpr bool CtorCompilesFor_B = false;
+template <typename U, int N>
+static constexpr bool CtorCompilesFor_B<U, N, void_t<decltype(gsl::not_null<U>{N})>> = true;
+static_assert(!CtorCompilesFor_B<void*, 0>, "!CtorCompilesFor_B<void*, 0>");
+
+template <typename U, typename = void>
+static constexpr bool CtorCompilesFor_C = false;
+template <typename U>
+static constexpr bool
+    CtorCompilesFor_C<U, void_t<decltype(gsl::not_null<U*>{std::declval<std::unique_ptr<U>>()})>> =
+        true;
+static_assert(!CtorCompilesFor_C<int>, "CtorCompilesFor_C<int>");
+
+template <typename U, typename = void>
+static constexpr bool DefaultCtorCompilesFor = false;
+template <typename U>
+static constexpr bool DefaultCtorCompilesFor<U, void_t<decltype(gsl::not_null<U>{})>> = true;
+static_assert(!DefaultCtorCompilesFor<void*>, "!DefaultCtorCompilesFor<void*>");
+
+template <typename U, typename V, typename = void>
+static constexpr bool AssignmentCompilesFor = false;
+template <typename U, typename V>
+static constexpr bool
+    AssignmentCompilesFor<U, V,
+                          void_t<decltype(std::declval<gsl::not_null<U*>&>().operator=(
+                              std::declval<gsl::not_null<V*>&>()))>> = true;
+static_assert(AssignmentCompilesFor<MyBase, MyDerived>, "AssignmentCompilesFor<MyBase, MyDerived>");
+static_assert(!AssignmentCompilesFor<MyBase, Unrelated>,
+              "!AssignmentCompilesFor<MyBase, Unrelated>");
+static_assert(!AssignmentCompilesFor<Unrelated, MyDerived>,
+              "!AssignmentCompilesFor<Unrelated, MyDerived>");
+static_assert(!AssignmentCompilesFor<MyDerived, MyBase>,
+              "!AssignmentCompilesFor<MyDerived, MyBase>");
+
+template <typename U, typename V, typename = void>
+static constexpr bool CastCompilesFor_A = false;
+template <typename U, typename V>
+static constexpr bool CastCompilesFor_A<
+    U, V, void_t<decltype(static_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> = true;
+static_assert(CastCompilesFor_A<MyDerived, MyDerived>, "CastCompilesFor_A<MyDerived, MyDerived>");
+static_assert(CastCompilesFor_A<MyBase, MyDerived>, "CastCompilesFor_A<MyBase, MyDerived>");
+static_assert(!CastCompilesFor_A<MyDerived, MyBase>, "!CastCompilesFor_A<MyDerived, MyBase>");
+static_assert(!CastCompilesFor_A<Unrelated, MyDerived>, "!CastCompilesFor_A<Unrelated, MyDerived>");
+
+template <typename U, typename V, typename = void>
+static constexpr bool CastCompilesFor_B = false;
+template <typename U, typename V>
+static constexpr bool CastCompilesFor_B<
+    U, V, void_t<decltype(reinterpret_cast<U*>(std::declval<gsl::not_null<V*>&>()))>> = true;
+static_assert(!CastCompilesFor_B<MyDerived, MyDerived>, "!CastCompilesFor_A<MyDerived, MyDerived>");
+static_assert(!CastCompilesFor_B<Unrelated, MyDerived>, "!CastCompilesFor_A<Unrelated, MyDerived>");
+
+template <typename U, typename = void>
+static constexpr bool HelperCompilesFor = false;
+template <typename U>
+static constexpr bool HelperCompilesFor<U, void_t<decltype(helper(std::declval<U>()))>> = true;
+static_assert(HelperCompilesFor<gsl::not_null<int*>>, "HelperCompilesFor<gsl::not_null<int*>>");
+static_assert(!HelperCompilesFor<gsl::not_null<const int*>>,
+              "!HelperCompilesFor<gsl::not_null<const int*>>");

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -222,11 +222,11 @@ TEST(span_test, from_pointer_length_constructor)
 
 TEST(span_test, from_pointer_pointer_construction)
 {
-    // const auto terminateHandler = std::set_terminate([] {
-    //     std::cerr << "Expected Death. from_pointer_pointer_construction";
-    //     std::abort();
-    // });
-    // const auto expected = GetExpectedDeathString(terminateHandler);
+     const auto terminateHandler = std::set_terminate([] {
+         std::cerr << "Expected Death. from_pointer_pointer_construction";
+         std::abort();
+     });
+     const auto expected = GetExpectedDeathString(terminateHandler);
 
     int arr[4] = {1, 2, 3, 4};
 
@@ -258,10 +258,10 @@ TEST(span_test, from_pointer_pointer_construction)
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
     //{

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -589,8 +589,8 @@ TEST(span_test, first)
 
     {
         span<int, 5> av = arr;
-        EXPECT_DEATH(av.first<6>().size(), expected);
-        EXPECT_DEATH(av.first(6).size(), expected);
+        EXPECT_DEATH(av.first<6>(), expected);
+        EXPECT_DEATH(av.first(6), expected);
     }
 
     {
@@ -630,10 +630,8 @@ TEST(span_test, last)
 
     {
         span<int, 5> av = arr;
-#ifdef FAIL_ON_SOME_PLATFORMS
-        EXPECT_TRUE(av.last<6>().size() == 6);
-#endif
-        EXPECT_DEATH(av.last(6).size(), expected);
+        EXPECT_DEATH(av.last<6>(), expected);
+        EXPECT_DEATH(av.last(6), expected);
     }
 
     {
@@ -674,8 +672,8 @@ TEST(span_test, subspan)
         EXPECT_TRUE(decltype(av.subspan<0, 5>())::extent == 5);
         EXPECT_TRUE(av.subspan(0, 5).size() == 5);
 
-        EXPECT_DEATH(av.subspan(0, 6).size(), expected);
-        EXPECT_DEATH(av.subspan(1, 5).size(), expected);
+        EXPECT_DEATH(av.subspan(0, 6), expected);
+        EXPECT_DEATH(av.subspan(1, 5), expected);
     }
 
     {
@@ -684,7 +682,7 @@ TEST(span_test, subspan)
         EXPECT_TRUE(decltype(av.subspan<4, 0>())::extent == 0);
         EXPECT_TRUE(av.subspan(4, 0).size() == 0);
         EXPECT_TRUE(av.subspan(5, 0).size() == 0);
-        EXPECT_DEATH(av.subspan(6, 0).size(), expected);
+        EXPECT_DEATH(av.subspan(6, 0), expected);
     }
 
     {
@@ -698,13 +696,13 @@ TEST(span_test, subspan)
         EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
         EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
         EXPECT_TRUE(av.subspan(0, 0).size() == 0);
-        EXPECT_DEATH((av.subspan<1, 0>().size()), expected);
+        EXPECT_DEATH((av.subspan<1, 0>()), expected);
     }
 
     {
         span<int> av;
         EXPECT_TRUE(av.subspan(0).size() == 0);
-        EXPECT_DEATH(av.subspan(1).size(), expected);
+        EXPECT_DEATH(av.subspan(1), expected);
     }
 
     {
@@ -713,7 +711,7 @@ TEST(span_test, subspan)
         EXPECT_TRUE(av.subspan(1).size() == 4);
         EXPECT_TRUE(av.subspan(4).size() == 1);
         EXPECT_TRUE(av.subspan(5).size() == 0);
-        EXPECT_DEATH(av.subspan(6).size(), expected);
+        EXPECT_DEATH(av.subspan(6), expected);
         const auto av2 = av.subspan(1);
         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
     }
@@ -724,7 +722,7 @@ TEST(span_test, subspan)
         EXPECT_TRUE(av.subspan(1).size() == 4);
         EXPECT_TRUE(av.subspan(4).size() == 1);
         EXPECT_TRUE(av.subspan(5).size() == 0);
-        EXPECT_DEATH(av.subspan(6).size(), expected);
+        EXPECT_DEATH(av.subspan(6), expected);
         const auto av2 = av.subspan(1);
         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
     }

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -263,13 +263,6 @@ TEST(span_test, from_pointer_pointer_construction)
     //    EXPECT_DEATH(workaround_macro(), expected);
     //}
 
-    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{ // this test fails on gcc 13, clang 16, clang 17, xcode 15.4, vs 16
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
-
     {
         int* p = nullptr;
         span<int> s{p, p};
@@ -283,14 +276,6 @@ TEST(span_test, from_pointer_pointer_construction)
         EXPECT_TRUE(s.size() == 0);
         EXPECT_TRUE(s.data() == nullptr);
     }
-
-    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{ // this test fails on gcc 13/14, clang 16/17/18, xcode 15.4, vs 16
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    span<int> s{&arr[0], p};
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
 }
 
 template <typename U, typename V, typename = void>

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1143,12 +1143,11 @@ static_assert(!CtorCompilesFor<span<int, 5>, std::array<int, 4>&>,
               "!CtorCompilesFor<span<int, 5>, std::array<int, 4>&>");
 static_assert(CtorCompilesFor<span<int, 4>, std::array<int, 4>&>,
               "CtorCompilesFor<span<int, 4>, std::array<int, 4>&>");
-#ifdef FAIL_ON_SOME_PLATFORMS
-// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14".
-// Pass on all gcc, clang, xcode.
+#if !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
+// Fails on "Visual Studio 16 2019/Visual Studio 17 2022, windows-2019/2022, Debug/Release, 14".
 static_assert(!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>,
               "!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>");
-#endif
+#endif // !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
 static_assert(!CtorCompilesFor<span<const int, 2>, const std::array<int, 4>&>,
               "!CtorCompilesFor<span<const int, 2>, const std::array<int, 4>&>");
 static_assert(!CtorCompilesFor<span<const int, 0>, const std::array<int, 4>&>,
@@ -1172,13 +1171,11 @@ static_assert(CtorCompilesFor<span<int>, std::vector<int>&>,
               "CtorCompilesFor<span<int>, std::vector<int>&>");
 static_assert(CtorCompilesFor<span<const int>, std::vector<int>&&>,
               "CtorCompilesFor<span<const int>, std::vector<int>&&>");
-#ifdef FAIL_ON_SOME_PLATFORMS
-// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14" and
-// "Visual Studio 17 2022, windows-2022, Release, 14".
-// Pass on all gcc, clang, xcode.
+#if !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
+// Fails on "Visual Studio 16 2019/Visual Studio 17 2022, windows-2019/2022, Debug/Release, 14".
 static_assert(!CtorCompilesFor<span<int>, std::vector<int>&&>,
               "!CtorCompilesFor<span<int>, std::vector<int>&&>");
-#endif
+#endif // !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
 static_assert(!CtorCompilesFor<span<int>, const std::vector<int>&&>,
               "!CtorCompilesFor<span<int>, const std::vector<int>&&>");
 
@@ -1219,12 +1216,11 @@ static_assert(!ConversionCompilesFor<span<const int, 2>, std::array<int, 4>>,
               "!ConversionCompilesFor<span<const int, 2>, std::array<int, 4>>");
 static_assert(ConversionCompilesFor<span<const int>, std::vector<int>>,
               "ConversionCompilesFor<span<const int>, std::vector<int>>");
-#ifdef FAIL_ON_SOME_PLATFORMS
-// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14".
-// Pass on all gcc, clang, xcode.
+#if !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
+// Fails on "Visual Studio 16 2019/Visual Studio 17 2022, windows-2019/2022, Debug/Release, 14".
 static_assert(!ConversionCompilesFor<span<int>, std::vector<int>>,
               "!ConversionCompilesFor<span<int>, std::vector<int>>");
-#endif
+#endif // !defined(_MSC_VER) || (_MSC_VER > 1942) || (__cplusplus >= 201703L)
 #if __cplusplus < 201703L
 static_assert(!ConversionCompilesFor<span<char>, std::string>,
               "!ConversionCompilesFor<span<char>, std::string>");

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -447,7 +447,7 @@ TEST(span_test, from_container_constructor)
     const std::string cstr = "hello";
 
     {
-#ifdef FAIL_ON_SOME_PLATFORMS
+#if __cplusplus >= 201703L
         span<char> s{str};
         EXPECT_TRUE(s.size() == str.size());
         EXPECT_TRUE(s.data() == str.data());
@@ -1287,9 +1287,9 @@ static_assert(!CtorCompilesFor<span<int>, const std::vector<int>&&>,
               "!CtorCompilesFor<span<int>, const std::vector<int>&&>");
 #endif
 
-#ifdef FAIL_ON_SOME_PLATFORMS
-static_assert(CtorCompilesFor<span<char>, std::string&>,
-              "CtorCompilesFor<span<char>, std::string&>");
+#if __cplusplus < 201703L
+static_assert(!CtorCompilesFor<span<char>, std::string&>,
+              "!CtorCompilesFor<span<char>, std::string&>");
 #endif
 static_assert(CtorCompilesFor<span<const char>, std::string&&>,
               "CtorCompilesFor<span<const char>, std::string&&>");

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -258,17 +258,17 @@ TEST(span_test, from_pointer_pointer_construction)
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    { // this test succeeds on all platforms, but it relies on UB
-        auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
-        EXPECT_DEATH(workaround_macro(), expected);
-    }
+    //{ // this test succeeds on all platforms, but it relies on UB
+    //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
+    //    EXPECT_DEATH(workaround_macro(), expected);
+    //}
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    {
-        int* p = nullptr;
-        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-        EXPECT_DEATH(workaround_macro(), expected);
-    }
+    //{ // this test fails on gcc 13, clang 16, clang 17, xcode 15.4, vs 16
+    //    int* p = nullptr;
+    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+    //    EXPECT_DEATH(workaround_macro(), expected);
+    //}
 
     {
         int* p = nullptr;
@@ -285,11 +285,11 @@ TEST(span_test, from_pointer_pointer_construction)
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        int* p = nullptr;
+        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
 }
 
 template <typename U, typename V, typename = void>

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1144,6 +1144,8 @@ static_assert(!CtorCompilesFor<span<int, 5>, std::array<int, 4>&>,
 static_assert(CtorCompilesFor<span<int, 4>, std::array<int, 4>&>,
               "CtorCompilesFor<span<int, 4>, std::array<int, 4>&>");
 #ifdef FAIL_ON_SOME_PLATFORMS
+// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14".
+// Pass on all gcc, clang, xcode.
 static_assert(!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>,
               "!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>");
 #endif
@@ -1171,11 +1173,14 @@ static_assert(CtorCompilesFor<span<int>, std::vector<int>&>,
 static_assert(CtorCompilesFor<span<const int>, std::vector<int>&&>,
               "CtorCompilesFor<span<const int>, std::vector<int>&&>");
 #ifdef FAIL_ON_SOME_PLATFORMS
+// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14" and
+// "Visual Studio 17 2022, windows-2022, Release, 14".
+// Pass on all gcc, clang, xcode.
 static_assert(!CtorCompilesFor<span<int>, std::vector<int>&&>,
               "!CtorCompilesFor<span<int>, std::vector<int>&&>");
+#endif
 static_assert(!CtorCompilesFor<span<int>, const std::vector<int>&&>,
               "!CtorCompilesFor<span<int>, const std::vector<int>&&>");
-#endif
 
 #if __cplusplus < 201703L
 static_assert(!CtorCompilesFor<span<char>, std::string&>,
@@ -1215,7 +1220,8 @@ static_assert(!ConversionCompilesFor<span<const int, 2>, std::array<int, 4>>,
 static_assert(ConversionCompilesFor<span<const int>, std::vector<int>>,
               "ConversionCompilesFor<span<const int>, std::vector<int>>");
 #ifdef FAIL_ON_SOME_PLATFORMS
-// Fails for example on "Visual Studio 16 2019, windows-2019, Release, 14". Pass on all gcc, clang, xcode.
+// Fails for example on "Visual Studio 16 2019, windows-2019, Debug/Release, 14".
+// Pass on all gcc, clang, xcode.
 static_assert(!ConversionCompilesFor<span<int>, std::vector<int>>,
               "!ConversionCompilesFor<span<int>, std::vector<int>>");
 #endif

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -222,11 +222,11 @@ TEST(span_test, from_pointer_length_constructor)
 
 TEST(span_test, from_pointer_pointer_construction)
 {
-     const auto terminateHandler = std::set_terminate([] {
-         std::cerr << "Expected Death. from_pointer_pointer_construction";
-         std::abort();
-     });
-     const auto expected = GetExpectedDeathString(terminateHandler);
+    // const auto terminateHandler = std::set_terminate([] {
+    //     std::cerr << "Expected Death. from_pointer_pointer_construction";
+    //     std::abort();
+    // });
+    // const auto expected = GetExpectedDeathString(terminateHandler);
 
     int arr[4] = {1, 2, 3, 4};
 
@@ -285,11 +285,12 @@ TEST(span_test, from_pointer_pointer_construction)
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    {
-        int* p = nullptr;
-        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-        EXPECT_DEATH(workaround_macro(), expected);
-    }
+    //{ // this test fails on gcc 13/14, clang 16/17/18, xcode 15.4, vs 16
+    //    int* p = nullptr;
+    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+    //    span<int> s{&arr[0], p};
+    //    EXPECT_DEATH(workaround_macro(), expected);
+    //}
 }
 
 template <typename U, typename V, typename = void>

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -258,17 +258,17 @@ TEST(span_test, from_pointer_pointer_construction)
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    {
+    { // this test succeeds on all platforms, but it relies on UB
         auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
         EXPECT_DEATH(workaround_macro(), expected);
     }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        int* p = nullptr;
+        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
 
     {
         int* p = nullptr;

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -589,10 +589,7 @@ TEST(span_test, first)
 
     {
         span<int, 5> av = arr;
-#ifdef FAIL_ON_SOME_PLATFORMS
-        EXPECT_TRUE(av.first<6>().size() == 6);
-        EXPECT_TRUE(av.first<-1>().size() == -1);
-#endif
+        EXPECT_DEATH(av.first<6>().size(), expected);
         EXPECT_DEATH(av.first(6).size(), expected);
     }
 
@@ -1219,8 +1216,11 @@ static_assert(!ConversionCompilesFor<span<const int, 2>, std::array<int, 4>>,
               "!ConversionCompilesFor<span<const int, 2>, std::array<int, 4>>");
 static_assert(ConversionCompilesFor<span<const int>, std::vector<int>>,
               "ConversionCompilesFor<span<const int>, std::vector<int>>");
+#ifdef FAIL_ON_SOME_PLATFORMS
+// Fails for example on "Visual Studio 16 2019, windows-2019, Release, 14". Pass on all gcc, clang, xcode.
 static_assert(!ConversionCompilesFor<span<int>, std::vector<int>>,
               "!ConversionCompilesFor<span<int>, std::vector<int>>");
+#endif
 #if __cplusplus < 201703L
 static_assert(!ConversionCompilesFor<span<char>, std::string>,
               "!ConversionCompilesFor<span<char>, std::string>");

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -62,8 +62,7 @@ struct AddressOverloaded
 #if (__cplusplus > 201402L)
     [[maybe_unused]]
 #endif
-    AddressOverloaded
-    operator&() const
+    AddressOverloaded operator&() const
     {
         return {};
     }
@@ -298,70 +297,14 @@ TEST(span_test, from_array_constructor)
 
     int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
 
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        span<int, 6> s{arr};
-    }
-
-    {
-        span<int, 0> s{arr};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == &arr[0]);
-    }
-
-    {
-        span<int> s{arr2d};
-        EXPECT_TRUE(s.size() == 6);
-        EXPECT_TRUE(s.data() == &arr2d[0][0]);
-        EXPECT_TRUE(s[0] == 1);
-        EXPECT_TRUE(s[5] == 6);
-    }
-
-    {
-        span<int, 0> s{arr2d};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == &arr2d[0][0]);
-    }
-
-    {
-        span<int, 6> s{arr2d};
-    }
-#endif
     {
         const span<int[3]> s{std::addressof(arr2d[0]), 1};
         EXPECT_TRUE(s.size() == 1);
         EXPECT_TRUE(s.data() == std::addressof(arr2d[0]));
     }
 
-    int arr3d[2][3][2] = { { {1, 2}, {3, 4}, {5, 6} }, { {7, 8}, {9, 10}, {11, 12} } };
+    int arr3d[2][3][2] = {{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}};
 
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        span<int> s{arr3d};
-        EXPECT_TRUE(s.size() == 12);
-        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-        EXPECT_TRUE(s[0] == 1);
-        EXPECT_TRUE(s[11] == 12);
-    }
-
-    {
-        span<int, 0> s{arr3d};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-    }
-
-    {
-        span<int, 11> s{arr3d};
-    }
-
-    {
-        span<int, 12> s{arr3d};
-        EXPECT_TRUE(s.size() == 12);
-        EXPECT_TRUE(s.data() == &arr3d[0][0][0]);
-        EXPECT_TRUE(s[0] == 1);
-        EXPECT_TRUE(s[5] == 6);
-    }
-#endif
     {
         const span<int[3][2]> s{std::addressof(arr3d[0]), 1};
         EXPECT_TRUE(s.size() == 1);
@@ -428,42 +371,9 @@ TEST(span_test, from_std_array_constructor)
         EXPECT_TRUE(ao_arr.data() == fs.data());
     }
 
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        span<int, 2> s{arr};
-        EXPECT_TRUE(s.size() == 2);
-        EXPECT_TRUE(s.data() == arr.data());
-
-        span<const int, 2> cs{arr};
-        EXPECT_TRUE(cs.size() == 2);
-        EXPECT_TRUE(cs.data() == arr.data());
-    }
-
-    {
-        span<int, 0> s{arr};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == arr.data());
-
-        span<const int, 0> cs{arr};
-        EXPECT_TRUE(cs.size() == 0);
-        EXPECT_TRUE(cs.data() == arr.data());
-    }
-
-    {
-        span<int, 5> s{arr};
-    }
-
     {
         auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-        auto take_a_span = [](span<int> s) { static_cast<void>(s); };
-        // try to take a temporary std::array
-        take_a_span(get_an_array());
-    }
-#endif
-
-    {
-        auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-        auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
+        auto take_a_span = [](span<const int>) {};
         // try to take a temporary std::array
         take_a_span(get_an_array());
     }
@@ -493,24 +403,6 @@ TEST(span_test, from_const_std_array_constructor)
         EXPECT_TRUE(s.data() == ao_arr.data());
     }
 
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        span<const int, 2> s{arr};
-        EXPECT_TRUE(s.size() == 2);
-        EXPECT_TRUE(s.data() == arr.data());
-    }
-
-    {
-        span<const int, 0> s{arr};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == arr.data());
-    }
-
-    {
-        span<const int, 5> s{arr};
-    }
-#endif
-
     {
         auto get_an_array = []() -> const std::array<int, 4> { return {1, 2, 3, 4}; };
         auto take_a_span = [](span<const int> s) { static_cast<void>(s); };
@@ -534,28 +426,6 @@ TEST(span_test, from_std_array_const_constructor)
         EXPECT_TRUE(s.size() == arr.size());
         EXPECT_TRUE(s.data() == arr.data());
     }
-
-#ifdef CONFIRM_COMPILATION_ERRORS
-    {
-        span<const int, 2> s{arr};
-        EXPECT_TRUE(s.size() == 2);
-        EXPECT_TRUE(s.data() == arr.data());
-    }
-
-    {
-        span<const int, 0> s{arr};
-        EXPECT_TRUE(s.size() == 0);
-        EXPECT_TRUE(s.data() == arr.data());
-    }
-
-    {
-        span<const int, 5> s{arr};
-    }
-
-    {
-        span<int, 4> s{arr};
-    }
-#endif
 }
 
 TEST(span_test, from_container_constructor)
@@ -577,31 +447,21 @@ TEST(span_test, from_container_constructor)
     const std::string cstr = "hello";
 
     {
-#ifdef CONFIRM_COMPILATION_ERRORS
+#ifdef FAIL_ON_SOME_PLATFORMS
         span<char> s{str};
         EXPECT_TRUE(s.size() == str.size());
-         EXPECT_TRUE(s.data() == str.data()));
+        EXPECT_TRUE(s.data() == str.data());
 #endif
-         span<const char> cs{str};
-         EXPECT_TRUE(cs.size() == str.size());
-         EXPECT_TRUE(cs.data() == str.data());
+
+        span<const char> cs{str};
+        EXPECT_TRUE(cs.size() == str.size());
+        EXPECT_TRUE(cs.data() == str.data());
     }
 
     {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        span<char> s{cstr};
-#endif
         span<const char> cs{cstr};
         EXPECT_TRUE(cs.size() == cstr.size());
         EXPECT_TRUE(cs.data() == cstr.data());
-    }
-
-    {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        auto get_temp_vector = []() -> std::vector<int> { return {}; };
-        auto use_span = [](span<int> s) { static_cast<void>(s); };
-        use_span(get_temp_vector());
-#endif
     }
 
     {
@@ -611,38 +471,15 @@ TEST(span_test, from_container_constructor)
     }
 
     {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        auto get_temp_string = []() -> std::string { return {}; };
-        auto use_span = [](span<char> s) { static_cast<void>(s); };
-        use_span(get_temp_string());
-#endif
-    }
-
-    {
         auto get_temp_string = []() -> std::string { return {}; };
         auto use_span = [](span<const char> s) { static_cast<void>(s); };
         use_span(get_temp_string());
-    }
-
-    {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        auto get_temp_vector = []() -> const std::vector<int> { return {}; };
-        auto use_span = [](span<const char> s) { static_cast<void>(s); };
-        use_span(get_temp_vector());
-#endif
     }
 
     {
         auto get_temp_string = []() -> const std::string { return {}; };
         auto use_span = [](span<const char> s) { static_cast<void>(s); };
         use_span(get_temp_string());
-    }
-
-    {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        std::map<int, int> m;
-        span<int> s{m};
-#endif
     }
 }
 
@@ -799,7 +636,7 @@ TEST(span_test, first)
 
     {
         span<int, 5> av = arr;
-#ifdef CONFIRM_COMPILATION_ERRORS
+#ifdef FAIL_ON_SOME_PLATFORMS
         EXPECT_TRUE(av.first<6>().size() == 6);
         EXPECT_TRUE(av.first<-1>().size() == -1);
 #endif
@@ -843,7 +680,7 @@ TEST(span_test, last)
 
     {
         span<int, 5> av = arr;
-#ifdef CONFIRM_COMPILATION_ERRORS
+#ifdef FAIL_ON_SOME_PLATFORMS
         EXPECT_TRUE(av.last<6>().size() == 6);
 #endif
         EXPECT_DEATH(av.last(6).size(), expected);
@@ -1148,17 +985,6 @@ TEST(span_test, as_writable_bytes)
     int a[] = {1, 2, 3, 4};
 
     {
-#ifdef CONFIRM_COMPILATION_ERRORS
-        // you should not be able to get writeable bytes for const objects
-        span<const int> s = a;
-        EXPECT_TRUE(s.size() == 4);
-        span<const byte> bs = as_writable_bytes(s);
-        EXPECT_TRUE(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-        EXPECT_TRUE(bs.size() == s.size_bytes());
-#endif
-    }
-
-    {
         span<int> s;
         const auto bs = as_writable_bytes(s);
         EXPECT_TRUE(bs.size() == s.size());
@@ -1197,8 +1023,8 @@ TEST(span_test, fixed_size_conversions)
         static_cast<void>(s);
     }
 
-// initialization or assignment to static span that REDUCES size is NOT ok
 #ifdef CONFIRM_COMPILATION_ERRORS
+    // initialization or assignment to static span that REDUCES size is NOT ok
     {
         span<int, 2> s = arr;
     }
@@ -1206,11 +1032,9 @@ TEST(span_test, fixed_size_conversions)
         span<int, 2> s2 = s4;
         static_cast<void>(s2);
     }
-#endif
 
     // even when done dynamically
     {
-        /*
         // this now results in a compile-time error, rather than runtime.
         // There is no suitable conversion from dynamic span to fixed span.
         span<int> s = arr;
@@ -1219,8 +1043,8 @@ TEST(span_test, fixed_size_conversions)
             static_cast<void>(s2);
         };
         EXPECT_DEATH(f(), expected);
-        */
     }
+#endif
 
     // but doing so explicitly is ok
 
@@ -1234,19 +1058,19 @@ TEST(span_test, fixed_size_conversions)
         static_cast<void>(s1);
     }
 
-    /*
-     // this is not a legal operation in std::span, so we are no longer supporting it
-     // conversion from span<int, 4> to span<int, dynamic_extent> via call to `first`
-     // then convert from span<int, dynamic_extent> to span<int, 1>
-     // The dynamic to fixed extents are not supported in the standard
-     // to make this work, span<int, 1> would need to be span<int>.
-     {
+#ifdef CONFIRM_COMPILATION_ERRORS
+    // this is not a legal operation in std::span, so we are no longer supporting it
+    // conversion from span<int, 4> to span<int, dynamic_extent> via call to `first`
+    // then convert from span<int, dynamic_extent> to span<int, 1>
+    // The dynamic to fixed extents are not supported in the standard
+    // to make this work, span<int, 1> would need to be span<int>.
+    {
 
-         // NB: implicit conversion to span<int,1> from span<int>
-         span<int, 1> s1 = s4.first(1);
-         static_cast<void>(s1);
-     }
-     */
+        // NB: implicit conversion to span<int,1> from span<int>
+        span<int, 1> s1 = s4.first(1);
+        static_cast<void>(s1);
+    }
+#endif
 
     // initialization or assignment to static span that requires size INCREASE is not ok.
     int arr2[2] = {1, 2};
@@ -1268,16 +1092,17 @@ TEST(span_test, fixed_size_conversions)
         EXPECT_DEATH(f(), expected);
     }
 
-    /*
-     // This no longer compiles. There is no suitable conversion from dynamic span to a fixed size
-     span.
-     // this should fail - we are trying to assign a small dynamic span to a fixed_size larger one
-     span<int> av = arr2; auto f = [&]() {
-         const span<int, 4> _s4 = av;
-         static_cast<void>(_s4);
-     };
-     EXPECT_DEATH(f(), expected);
-     */
+#ifdef CONFIRM_COMPILATION_ERRORS
+    // This no longer compiles. There is no suitable conversion from dynamic span to a fixed size
+    // span. this should fail - we are trying to assign a small dynamic span to a fixed_size larger
+    // one
+    span<int> av = arr2;
+    auto f = [&]() {
+        const span<int, 4> _s4 = av;
+        static_cast<void>(_s4);
+    };
+    EXPECT_DEATH(f(), expected);
+#endif
 }
 
 TEST(span_test, interop_with_std_regex)
@@ -1376,8 +1201,119 @@ TEST(span_test, msvc_compile_error_PR1100)
     int arr[]{1, 7, 2, 9};
     gsl::span sp{arr, std::size(arr)};
     std::ranges::sort(sp);
-    for (const auto& e : sp) {
-        (void)e;
-    }
+    for (const auto& e : sp) { (void) e; }
 }
 #endif // defined(__cpp_lib_span) && defined(__cpp_lib_ranges)
+
+#if __cplusplus >= 201703l
+using std::void_t;
+#else  // __cplusplus >= 201703l
+template <class...>
+using void_t = void;
+#endif // __cplusplus < 201703l
+
+template <typename U, typename V, typename = void>
+static constexpr bool CtorCompilesFor = false;
+template <typename U, typename V>
+static constexpr bool CtorCompilesFor<U, V, void_t<decltype(U{std::declval<V>()})>> = true;
+static_assert(CtorCompilesFor<span<int>, std::array<int, 12>&>,
+              "CtorCompilesFor<span<int>, std::array<int, 12>&>");
+static_assert(CtorCompilesFor<span<int, 4>, std::array<int, 4>&>,
+              "CtorCompilesFor<span<int, 4>, std::array<int, 4>&>");
+static_assert(CtorCompilesFor<span<int*>, std::array<int*, 12>&>,
+              "CtorCompilesFor<span<int*>, std::array<int*, 12>&>");
+static_assert(!CtorCompilesFor<span<int*, 4>, std::array<int*, 12>&>,
+              "!CtorCompilesFor<span<int*, 4>, std::array<int*, 12>&>");
+static_assert(CtorCompilesFor<span<int, 6>, std::array<int, 6>&>,
+              "CtorCompilesFor<span<int, 6>, std::array<int, 6>&>");
+static_assert(!CtorCompilesFor<span<int, 6>, std::array<int, 5>&>,
+              "!CtorCompilesFor<span<int, 6>, std::array<int, 5>&>");
+static_assert(!CtorCompilesFor<span<int, 0>, std::array<int, 5>&>,
+              "!CtorCompilesFor<span<int, 0>, std::array<int, 5>&>");
+static_assert(!CtorCompilesFor<span<int>, int[2][3]>, "!CtorCompilesFor<span<int>, int[2][3]>");
+static_assert(!CtorCompilesFor<span<int, 0>, int[2][3]>,
+              "!CtorCompilesFor<span<int, 0>, int[2][3]>");
+static_assert(!CtorCompilesFor<span<int, 6>, int[2][3]>,
+              "!CtorCompilesFor<span<int, 6>, int[2][3]>");
+static_assert(!CtorCompilesFor<span<int>, int[2][3][2]>,
+              "!CtorCompilesFor<span<int>, int[2][3][2]>");
+static_assert(!CtorCompilesFor<span<int, 0>, int[2][3][2]>,
+              "!CtorCompilesFor<span<int, 0>, int[2][3][2]>");
+static_assert(!CtorCompilesFor<span<int, 11>, int[2][3][2]>,
+              "!CtorCompilesFor<span<int, 11>, int[2][3][2]>");
+static_assert(!CtorCompilesFor<span<int, 12>, int[2][3][2]>,
+              "!CtorCompilesFor<span<int, 12>, int[2][3][2]>");
+static_assert(!CtorCompilesFor<span<int, 2>, std::array<int, 4>&>,
+              "!CtorCompilesFor<span<int, 2>, std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 2>, std::array<int, 4>&>,
+              "!CtorCompilesFor<span<const int, 2>, std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<int, 0>, std::array<int, 4>&>,
+              "!CtorCompilesFor<span<int, 0>, std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 0>, std::array<int, 4>&>,
+              "!CtorCompilesFor<span<const int, 0>, std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<int, 5>, std::array<int, 4>&>,
+              "!CtorCompilesFor<span<int, 5>, std::array<int, 4>&>");
+static_assert(CtorCompilesFor<span<int, 4>, std::array<int, 4>&>,
+              "CtorCompilesFor<span<int, 4>, std::array<int, 4>&>");
+#ifdef FAIL_ON_SOME_PLATFORMS
+static_assert(!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>,
+              "!CtorCompilesFor<span<int, 4>, std::array<int, 4>&&>");
+#endif
+static_assert(!CtorCompilesFor<span<const int, 2>, const std::array<int, 4>&>,
+              "!CtorCompilesFor<span<const int, 2>, const std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 0>, const std::array<int, 4>&>,
+              "!CtorCompilesFor<span<const int, 0>, const std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 5>, const std::array<int, 4>&>,
+              "!CtorCompilesFor<span<const int, 5>, const std::array<int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 2>, std::array<const int, 4>&>,
+              "!CtorCompilesFor<span<const int, 2>, std::array<const int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 0>, std::array<const int, 4>&>,
+              "!CtorCompilesFor<span<const int, 0>, std::array<const int, 4>&>");
+static_assert(!CtorCompilesFor<span<const int, 5>, std::array<const int, 4>&>,
+              "!CtorCompilesFor<span<const int, 5>, std::array<const int, 4>&>");
+static_assert(!CtorCompilesFor<span<int, 4>, std::array<const int, 4>&>,
+              "!CtorCompilesFor<span<int, 4>, std::array<const int, 4>&>");
+static_assert(!CtorCompilesFor<span<char>, const std::string&>,
+              "!CtorCompilesFor<span<char>, const std::string&>");
+
+static_assert(CtorCompilesFor<span<int>, std::vector<int>&>,
+              "CtorCompilesFor<span<int>, std::vector<int>&>");
+static_assert(CtorCompilesFor<span<const int>, std::vector<int>&&>,
+              "CtorCompilesFor<span<const int>, std::vector<int>&&>");
+#ifdef FAIL_ON_SOME_PLATFORMS
+static_assert(!CtorCompilesFor<span<int>, std::vector<int>&&>,
+              "!CtorCompilesFor<span<int>, std::vector<int>&&>");
+static_assert(!CtorCompilesFor<span<int>, const std::vector<int>&&>,
+              "!CtorCompilesFor<span<int>, const std::vector<int>&&>");
+#endif
+
+#ifdef FAIL_ON_SOME_PLATFORMS
+static_assert(CtorCompilesFor<span<char>, std::string&>,
+              "CtorCompilesFor<span<char>, std::string&>");
+#endif
+static_assert(CtorCompilesFor<span<const char>, std::string&&>,
+              "CtorCompilesFor<span<const char>, std::string&&>");
+static_assert(!CtorCompilesFor<span<char>, std::string&&>,
+              "!CtorCompilesFor<span<char>, std::string&&>");
+static_assert(!CtorCompilesFor<span<char>, const std::string&&>,
+              "!CtorCompilesFor<span<char>, const std::string&&>");
+
+static_assert(!CtorCompilesFor<span<int>, std::map<int, int>&>,
+              "!CtorCompilesFor<span<int>, std::map<int, int>&>");
+
+static_assert(CtorCompilesFor<span<int>, span<int, 4>&>,
+              "CtorCompilesFor<span<int>, span<int, 4>&>");
+static_assert(CtorCompilesFor<span<int, 4>, span<int, 4>&>,
+              "CtorCompilesFor<span<int, 4>, span<int, 4>&>");
+static_assert(!CtorCompilesFor<span<int, 2>, span<int, 4>&>,
+              "!CtorCompilesFor<span<int, 2>, span<int, 4>&>");
+
+template <typename U, typename = void>
+static constexpr bool AsWritableBytesCompilesFor = false;
+template <typename U>
+static constexpr bool
+    AsWritableBytesCompilesFor<U, void_t<decltype(as_writable_bytes(std::declval<U>()))>> = true;
+static_assert(AsWritableBytesCompilesFor<span<int>>,
+              "AsWriteableBytesCompilesFor<span<int>>");
+static_assert(!AsWritableBytesCompilesFor<span<const int>>,
+              "!AsWriteableBytesCompilesFor<span<const int>>");

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -701,7 +701,9 @@ TEST(span_test, first)
 
     {
         span<int, 5> av = arr;
-        EXPECT_DEATH(av.first<6>(), expected);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        (void) av.first<6>();
+#endif
         EXPECT_DEATH(av.first(6), expected);
     }
 
@@ -742,7 +744,9 @@ TEST(span_test, last)
 
     {
         span<int, 5> av = arr;
-        EXPECT_DEATH(av.last<6>(), expected);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        (void) av.last<6>();
+#endif
         EXPECT_DEATH(av.last(6), expected);
     }
 
@@ -768,6 +772,9 @@ TEST(span_test, subspan)
         EXPECT_TRUE((av.subspan<2, 2>().size()) == 2);
         EXPECT_TRUE(decltype(av.subspan<2, 2>())::extent == 2);
         EXPECT_TRUE(av.subspan(2, 2).size() == 2);
+
+        EXPECT_TRUE((av.subspan<2, 3>().size()) == 3);
+        EXPECT_TRUE(decltype(av.subspan<2, 3>())::extent == 3);
         EXPECT_TRUE(av.subspan(2, 3).size() == 3);
     }
 
@@ -784,6 +791,10 @@ TEST(span_test, subspan)
         EXPECT_TRUE(decltype(av.subspan<0, 5>())::extent == 5);
         EXPECT_TRUE(av.subspan(0, 5).size() == 5);
 
+#ifdef CONFIRM_COMPILATION_ERRORS
+        (void) av.subspan<0, 6>();
+        (void) av.subspan<1, 5>();
+#endif
         EXPECT_DEATH(av.subspan(0, 6), expected);
         EXPECT_DEATH(av.subspan(1, 5), expected);
     }
@@ -793,7 +804,14 @@ TEST(span_test, subspan)
         EXPECT_TRUE((av.subspan<4, 0>().size()) == 0);
         EXPECT_TRUE(decltype(av.subspan<4, 0>())::extent == 0);
         EXPECT_TRUE(av.subspan(4, 0).size() == 0);
+
+        EXPECT_TRUE((av.subspan<5, 0>().size()) == 0);
+        EXPECT_TRUE(decltype(av.subspan<5, 0>())::extent == 0);
         EXPECT_TRUE(av.subspan(5, 0).size() == 0);
+
+#ifdef CONFIRM_COMPILATION_ERRORS
+        (void) av.subspan<6, 0>();
+#endif
         EXPECT_DEATH(av.subspan(6, 0), expected);
     }
 
@@ -801,6 +819,7 @@ TEST(span_test, subspan)
         span<int, 5> av = arr;
         EXPECT_TRUE(av.subspan<1>().size() == 4);
         EXPECT_TRUE(decltype(av.subspan<1>())::extent == 4);
+        EXPECT_TRUE(av.subspan(1).size() == 4);
     }
 
     {
@@ -808,35 +827,58 @@ TEST(span_test, subspan)
         EXPECT_TRUE((av.subspan<0, 0>().size()) == 0);
         EXPECT_TRUE(decltype(av.subspan<0, 0>())::extent == 0);
         EXPECT_TRUE(av.subspan(0, 0).size() == 0);
+
         EXPECT_DEATH((av.subspan<1, 0>()), expected);
+        EXPECT_DEATH((av.subspan(1, 0)), expected);
     }
 
     {
         span<int> av;
+        EXPECT_TRUE((av.subspan<0>().size()) == 0);
+        EXPECT_TRUE(decltype(av.subspan<0>())::extent == dynamic_extent);
         EXPECT_TRUE(av.subspan(0).size() == 0);
+
+        EXPECT_DEATH(av.subspan<1>(), expected);
+        EXPECT_TRUE(decltype(av.subspan<1>())::extent == dynamic_extent);
         EXPECT_DEATH(av.subspan(1), expected);
     }
 
     {
         span<int> av = arr;
         EXPECT_TRUE(av.subspan(0).size() == 5);
+        EXPECT_TRUE(av.subspan<0>().size() == 5);
         EXPECT_TRUE(av.subspan(1).size() == 4);
+        EXPECT_TRUE(av.subspan<1>().size() == 4);
         EXPECT_TRUE(av.subspan(4).size() == 1);
+        EXPECT_TRUE(av.subspan<4>().size() == 1);
         EXPECT_TRUE(av.subspan(5).size() == 0);
+        EXPECT_TRUE(av.subspan<5>().size() == 0);
         EXPECT_DEATH(av.subspan(6), expected);
+        EXPECT_DEATH(av.subspan<6>(), expected);
         const auto av2 = av.subspan(1);
         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
+        const auto av3 = av.subspan<1>();
+        for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av3[i] == static_cast<int>(i) + 2);
     }
 
     {
         span<int, 5> av = arr;
         EXPECT_TRUE(av.subspan(0).size() == 5);
+        EXPECT_TRUE(av.subspan<0>().size() == 5);
         EXPECT_TRUE(av.subspan(1).size() == 4);
+        EXPECT_TRUE(av.subspan<1>().size() == 4);
         EXPECT_TRUE(av.subspan(4).size() == 1);
+        EXPECT_TRUE(av.subspan<4>().size() == 1);
         EXPECT_TRUE(av.subspan(5).size() == 0);
+        EXPECT_TRUE(av.subspan<5>().size() == 0);
         EXPECT_DEATH(av.subspan(6), expected);
+#ifdef CONFIRM_COMPILATION_ERRORS
+        EXPECT_DEATH(av.subspan<6>(), expected);
+#endif
         const auto av2 = av.subspan(1);
         for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av2[i] == static_cast<int>(i) + 2);
+        const auto av3 = av.subspan<1>();
+        for (std::size_t i = 0; i < 4; ++i) EXPECT_TRUE(av3[i] == static_cast<int>(i) + 2);
     }
 }
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -257,8 +257,7 @@ TEST(span_test, from_pointer_pointer_construction)
         EXPECT_TRUE(s.data() == &arr[0]);
     }
 
-    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{ // this test succeeds on all platforms, but it relies on UB
+    //{ // this test succeeds on all platforms, gsl::span is more relaxed than std::span where this would be UB
     //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
     //    EXPECT_DEATH(workaround_macro(), expected);
     //}

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -215,6 +215,14 @@ TEST(span_test, from_pointer_length_constructor)
 
 TEST(span_test, from_pointer_pointer_construction)
 {
+#if !(defined _MSVC_STL_VERSION) || defined(NDEBUG)
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. from_pointer_pointer_construction";
+        std::abort();
+    });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+#endif
+
     int arr[4] = {1, 2, 3, 4};
 
     {
@@ -244,18 +252,20 @@ TEST(span_test, from_pointer_pointer_construction)
         EXPECT_TRUE(s.data() == &arr[0]);
     }
 
+#if !(defined _MSVC_STL_VERSION) || defined(NDEBUG)
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
 
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        int* p = nullptr;
+        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
+#endif
 
     {
         int* p = nullptr;
@@ -271,12 +281,14 @@ TEST(span_test, from_pointer_pointer_construction)
         EXPECT_TRUE(s.data() == nullptr);
     }
 
+#if !(defined _MSVC_STL_VERSION) || defined(NDEBUG)
     // this will fail the std::distance() precondition, which asserts on MSVC debug builds
-    //{
-    //    int* p = nullptr;
-    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-    //    EXPECT_DEATH(workaround_macro(), expected);
-    //}
+    {
+        int* p = nullptr;
+        auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+        EXPECT_DEATH(workaround_macro(), expected);
+    }
+#endif
 }
 
 TEST(span_test, from_array_constructor)


### PR DESCRIPTION
- Bugfix: templated versions of span::first(), span::last() and span::subspan() now fail to compile if more elements than available are being extracted from a static sized span; previously it compiled and `Expects` failed during runtime
- Remove some of the checks in `#ifdef CONFIRM_COMPILATION_ERRORS` and add compile time checks for these tests.
- Acitvate some commented out checks.
- Activate some deactivated checks depending on the platform
- Make some death checks simpler to only check the function call that is needed to trigger the death.
- clang-format