### PR TITLE
React to ubuntu-latest changing to 24.04

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -17,12 +17,10 @@ jobs:
   gcc:
     strategy:
       matrix:
-        gcc_version: [ 10, 11, 12 ]
+        gcc_version: [ 12, 13, 14 ]
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
         exclude:
-          - gcc_version: 10
-            cxx_version: 23
           # https://github.com/google/googletest/issues/4232
           # Looks like GoogleTest is not interested in making version 1.14
           # work with gcc-12.
@@ -44,7 +42,7 @@ jobs:
   clang:
     strategy:
       matrix:
-        clang_version: [ 13, 14, 15 ]
+        clang_version: [ 16, 17, 18 ]
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -46,7 +46,9 @@ jobs:
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
         exclude:
-          # TODO (@carsonradtke): revert this
+          # https://github.com/llvm/llvm-project/issues/93734
+          # Looks like clang fixed this issue in clang-18, but won't backport
+          # the fix.
           - clang_version: 17
             cxx_version: 23
     runs-on: ubuntu-latest

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -45,6 +45,10 @@ jobs:
         clang_version: [ 16, 17, 18 ]
         build_type: [ Debug, Release ]
         cxx_version: [ 14, 17, 20, 23 ]
+        exclude:
+          # TODO (@carsonradtke): revert this
+          - clang_version: 17
+            cxx_version: 23
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Below is a table showing the versions currently being tested (also see [.github/
 
 Compiler |Toolset Versions Currently Tested
 :------- |--:
- GCC | 10, 11, 12
+ GCC | 12, 13, 14
  XCode | 14.3.1, 15.4
- Clang | 13, 14, 15
+ Clang | 16, 17, 18
  Visual Studio with MSVC | VS2019, VS2022 
  Visual Studio with LLVM | VS2019, VS2022
 


### PR DESCRIPTION
Reacting to https://github.com/actions/runner-images/issues/10636
* update clang to 16,17,18
* update gcc to 12,13,14