### PR TITLE
allow final action to invoke throwing actions

### DIFF
--- a/include/gsl/util
+++ b/include/gsl/util
@@ -77,7 +77,7 @@ public:
     explicit final_action(const F& ff) noexcept : f{ff} { }
     explicit final_action(F&& ff) noexcept : f{std::move(ff)} { }
 
-    ~final_action() noexcept { if (invoke) f(); }
+	~final_action() noexcept(std::is_nothrow_invocable_v<F>)
 
     final_action(final_action&& other) noexcept
         : f(std::move(other.f)), invoke(std::exchange(other.invoke, false))


### PR DESCRIPTION
where an action is provided to final action to execute at end of scope and that action throws, because final action's destructor is marked noexcept, the program will terminate. Instead, allow final action's destructor to be noexcept dependent upon whether the action throws.