### PR TITLE
use relative path in # include

### DIFF
--- a/include/gsl/algorithm
+++ b/include/gsl/algorithm
@@ -17,8 +17,8 @@
 #ifndef GSL_ALGORITHM_H
 #define GSL_ALGORITHM_H
 
-#include "gsl/assert" // for Expects
-#include "gsl/span"   // for dynamic_extent, span
+#include "./assert" // for Expects
+#include "./span"   // for dynamic_extent, span
 
 #include <algorithm>   // for copy_n
 #include <cstddef>     // for ptrdiff_t

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -18,16 +18,16 @@
 #define GSL_GSL_H
 
 // IWYU pragma: begin_exports
-#include "gsl/algorithm"   // copy
-#include "gsl/assert"      // Ensures/Expects
-#include "gsl/byte"        // byte
-#include "gsl/pointers"    // owner, not_null
-#include "gsl/span"        // span
-#include "gsl/zstring"     // zstring
-#include "gsl/util"        // finally()/narrow_cast()...
+#include "./algorithm"   // copy
+#include "./assert"      // Ensures/Expects
+#include "./byte"        // byte
+#include "./pointers"    // owner, not_null
+#include "./span"        // span
+#include "./zstring"     // zstring
+#include "./util"        // finally()/narrow_cast()...
 
 #ifdef __cpp_exceptions
-#include "gsl/narrow" // narrow()
+#include "./narrow" // narrow()
 #endif
 // IWYU pragma: end_exports
 

--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -16,8 +16,8 @@
 
 #ifndef GSL_NARROW_H
 #define GSL_NARROW_H
-#include "gsl/assert"    // for GSL_SUPPRESS
-#include "gsl/util"      // for narrow_cast
+#include "./assert"    // for GSL_SUPPRESS
+#include "./util"      // for narrow_cast
 #include <exception> // for std::exception
 namespace gsl
 {

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -17,7 +17,7 @@
 #ifndef GSL_POINTERS_H
 #define GSL_POINTERS_H
 
-#include "gsl/assert" // for Ensures, Expects
+#include "./assert" // for Ensures, Expects
 
 #include <cstddef>      // for ptrdiff_t, nullptr_t, size_t
 #include <functional>   // for less, greater

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -17,10 +17,10 @@
 #ifndef GSL_SPAN_H
 #define GSL_SPAN_H
 
-#include "gsl/assert"   // for Expects
-#include "gsl/byte"     // for byte
-#include "gsl/span_ext" // for span specialization of gsl::at and other span-related extensions
-#include "gsl/util"     // for narrow_cast
+#include "./assert"   // for Expects
+#include "./byte"     // for byte
+#include "./span_ext" // for span specialization of gsl::at and other span-related extensions
+#include "./util"     // for narrow_cast
 
 #include <array>       // for array
 #include <cstddef>     // for ptrdiff_t, size_t, nullptr_t

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -27,8 +27,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "gsl/assert" // GSL_KERNEL_MODE
-#include "gsl/util"   // for narrow_cast, narrow
+#include "./assert" // GSL_KERNEL_MODE
+#include "./util"   // for narrow_cast, narrow
 
 #include <cstddef> // for ptrdiff_t, size_t
 #include <utility>

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -17,7 +17,7 @@
 #ifndef GSL_UTIL_H
 #define GSL_UTIL_H
 
-#include "gsl/assert" // for Expects
+#include "./assert" // for Expects
 
 #include <array>
 #include <cstddef>          // for ptrdiff_t, size_t

--- a/include/gsl/zstring
+++ b/include/gsl/zstring
@@ -17,7 +17,7 @@
 #ifndef GSL_ZSTRING_H
 #define GSL_ZSTRING_H
 
-#include "gsl/span_ext" // for dynamic_extent
+#include "./span_ext" // for dynamic_extent
 
 #include <cstddef>   // for size_t, nullptr_t
 


### PR DESCRIPTION
Reverts commit that changes #include "assert" -> #include "gsl/assert". This change is necessary in order to comply with CppCoreGuideline's SF.12. Now we do #include "./assert".

fixes https://github.com/microsoft/GSL/issues/1188