### PR TITLE
replace BYTE_TYPE with a solution based on namespaces

### DIFF
--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -75,18 +75,18 @@
 #endif // defined __clang__ || defined __GNUC__
 
 #if GSL_USE_STD_BYTE
-#define BYTE_TYPE std::byte
-#else // !GSL_USE_STD_BYTE
-#define BYTE_TYPE byte
-#endif // GSL_USE_STD_BYTE
-
-#if GSL_USE_STD_BYTE
 #include <cstddef>
 #endif
 
 namespace gsl
 {
 #if GSL_USE_STD_BYTE
+
+namespace impl {
+// impl::byte is used by gsl::as_bytes so our own code does not trigger a deprecation warning as would be the case when we used gsl::byte.
+// Users of GSL should only use gsl::byte, not gsl::impl::byte.
+using byte = std::byte;
+}
 
 using byte GSL_DEPRECATED("Use std::byte instead.") = std::byte;
 
@@ -99,6 +99,12 @@ using std::to_integer;
 enum class byte_may_alias byte : unsigned char
 {
 };
+
+namespace impl {
+// impl::byte is used by gsl::as_bytes so our own code does not trigger a deprecation warning as would be the case when we used gsl::byte.
+// Users of GSL should only use gsl::byte, not gsl::impl::byte.
+using byte = gsl::byte;
+}
 
 template <class IntegerType, std::enable_if_t<std::is_integral<IntegerType>::value, bool> = true>
 constexpr byte& operator<<=(byte& b, IntegerType shift) noexcept
@@ -168,20 +174,20 @@ constexpr IntegerType to_integer(byte b) noexcept
 template <typename T>
 // NOTE: need suppression since c++14 does not allow "return {t}"
 // GSL_SUPPRESS(type.4) // NO-FORMAT: attribute // TODO: suppression does not work
-constexpr BYTE_TYPE to_byte(T t) noexcept
+constexpr gsl::impl::byte to_byte(T t) noexcept
 {
     static_assert(std::is_same<T, unsigned char>::value,
                   "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
                   "If you are calling to_byte with an integer constant use: gsl::to_byte<t>() version.");
-    return BYTE_TYPE(t);
+    return gsl::impl::byte(t);
 }
 
 template <int I>
-constexpr BYTE_TYPE to_byte() noexcept
+constexpr gsl::impl::byte to_byte() noexcept
 {
     static_assert(I >= 0 && I <= 255,
                   "gsl::byte only has 8 bits of storage, values must be in range 0-255");
-    return static_cast<BYTE_TYPE>(I);
+    return static_cast<gsl::impl::byte>(I);
 }
 
 } // namespace gsl

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -18,7 +18,7 @@
 #define GSL_SPAN_H
 
 #include "./assert"   // for Expects
-#include "./byte"     // for BYTE_TYPE
+#include "./byte"     // for gsl::impl::byte
 #include "./span_ext" // for span specialization of gsl::at and other span-related extensions
 #include "./util"     // for narrow_cast
 
@@ -824,28 +824,28 @@ namespace details
 
 // [span.objectrep], views of object representation
 template <class ElementType, std::size_t Extent>
-span<const BYTE_TYPE, details::calculate_byte_size<ElementType, Extent>::value>
+span<const gsl::impl::byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_bytes(span<ElementType, Extent> s) noexcept
 {
-    using type = span<const BYTE_TYPE, details::calculate_byte_size<ElementType, Extent>::value>;
+    using type = span<const gsl::impl::byte, details::calculate_byte_size<ElementType, Extent>::value>;
 
     // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
     // clang-format on
-    return type{reinterpret_cast<const BYTE_TYPE*>(s.data()), s.size_bytes()};
+    return type{reinterpret_cast<const gsl::impl::byte*>(s.data()), s.size_bytes()};
 }
 
 template <class ElementType, std::size_t Extent,
           std::enable_if_t<!std::is_const<ElementType>::value, int> = 0>
-span<BYTE_TYPE, details::calculate_byte_size<ElementType, Extent>::value>
+span<gsl::impl::byte, details::calculate_byte_size<ElementType, Extent>::value>
 as_writable_bytes(span<ElementType, Extent> s) noexcept
 {
-    using type = span<BYTE_TYPE, details::calculate_byte_size<ElementType, Extent>::value>;
+    using type = span<gsl::impl::byte, details::calculate_byte_size<ElementType, Extent>::value>;
 
     // clang-format off
     GSL_SUPPRESS(type.1) // NO-FORMAT: attribute
     // clang-format on
-    return type{reinterpret_cast<BYTE_TYPE*>(s.data()), s.size_bytes()};
+    return type{reinterpret_cast<gsl::impl::byte*>(s.data()), s.size_bytes()};
 }
 
 } // namespace gsl


### PR DESCRIPTION
- A macro with the very generic name `BYTE_TYPE` is likely to collide with existing code, so get rid of the macro.
- The new solution is to provide a non-deprecated `byte` in the namespace `gsl::impl`.
  - Users of GSL should use `gsl::byte`, which is still deprecated when mapped to a `std::std::byte`.
  - GSL types and functions need to use `gsl::impl::byte` so they do not trigger the deprecation warning.
- The `gsl::impl::byte` return type in an exported function is not nice, it might mislead users to use that type in their own declarations. But the `BYTE_TYPE` solution is not better in this respect.
