### PR TITLE
Fix version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14...3.16)
 
-project(GSL VERSION 4.1.0 LANGUAGES CXX)
+project(GSL VERSION 4.2.0 LANGUAGES CXX)
 
 add_library(GSL INTERFACE)
 add_library(Microsoft.GSL::GSL ALIAS GSL)

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ include(FetchContent)
 
 FetchContent_Declare(GSL
     GIT_REPOSITORY "https://github.com/microsoft/GSL"
-    GIT_TAG "v4.1.0"
+    GIT_TAG "v4.2.0"
     GIT_SHALLOW ON
 )
 


### PR DESCRIPTION
Just tagging as 4.2.0 is not enough, the version number must be incremented for cmake and in the readme. Compare https://github.com/microsoft/GSL/pull/1163.
