### PR TITLE
Update return by value threshold in gsl::not_null

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -54,7 +54,7 @@ namespace details
     // Copied from cppfront's implementation of the CppCoreGuidelines F.16 (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in)
     template<typename T>
     using value_or_reference_return_t = std::conditional_t<
-                                            sizeof(T) < 2*sizeof(void*) && std::is_trivially_copy_constructible<T>::value,
+                                            sizeof(T) <= 2*sizeof(void*) && std::is_trivially_copy_constructible<T>::value,
                                             const T,
                                             const T&>;
 


### PR DESCRIPTION
Fixes: #1204 
- Allow returning by value for types that are not greater than two pointers in size