### PR TITLE
Guard includes of standard library headers so users can use import std

### DIFF
--- a/include/gsl/algorithm
+++ b/include/gsl/algorithm
@@ -20,9 +20,13 @@
 #include "./assert" // for Expects
 #include "./span"   // for dynamic_extent, span
 
-#include <algorithm>   // for copy_n
-#include <cstddef>     // for ptrdiff_t
-#include <type_traits> // for is_assignable
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <algorithm>   // for copy_n
+    #include <cstddef>     // for ptrdiff_t
+    #include <type_traits> // for is_assignable
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -36,7 +36,11 @@
 #else // defined(_MSC_VER) && (defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) &&
       // !_HAS_EXCEPTIONS))
 
-#include <exception>
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <exception>
+#endif
 
 #endif // defined(_MSC_VER) && (defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) &&
        // !_HAS_EXCEPTIONS))

--- a/include/gsl/byte
+++ b/include/gsl/byte
@@ -19,7 +19,11 @@
 
 #include "./util" // for GSL_DEPRECATED
 
-#include <type_traits>
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <type_traits>
+#endif
 
 #ifdef _MSC_VER
 
@@ -45,7 +49,9 @@
 #else // _MSC_VER
 
 #ifndef GSL_USE_STD_BYTE
-#include <cstddef> /* __cpp_lib_byte */
+#if !defined(GSL_BUILD_USING_STD_MODULE)
+    #include <cstddef> /* __cpp_lib_byte */
+#endif
 // this tests if we are under GCC or Clang with enough -std=c++1z power to get us std::byte
 // also check if libc++ version is sufficient (> 5.0) or libstdc++ actually contains std::byte
 #if defined(__cplusplus) && (__cplusplus >= 201703L) &&                                            \
@@ -75,7 +81,9 @@
 #endif // defined __clang__ || defined __GNUC__
 
 #if GSL_USE_STD_BYTE
-#include <cstddef>
+#if !defined(GSL_BUILD_USING_STD_MODULE)
+    #include <cstddef>
+#endif
 #endif
 
 namespace gsl

--- a/include/gsl/narrow
+++ b/include/gsl/narrow
@@ -18,7 +18,13 @@
 #define GSL_NARROW_H
 #include "./assert"    // for GSL_SUPPRESS
 #include "./util"      // for narrow_cast
-#include <exception> // for std::exception
+
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <exception> // for std::exception
+#endif
+
 namespace gsl
 {
 struct narrowing_error : public std::exception

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -20,15 +20,19 @@
 #include "./assert" // for Ensures, Expects
 #include "./util" // for GSL_DEPRECATED
 
-#include <cstddef>      // for ptrdiff_t, nullptr_t, size_t
-#include <functional>   // for less, greater
-#include <memory>       // for shared_ptr, unique_ptr, hash
-#include <type_traits>  // for enable_if_t, is_convertible, is_assignable
-#include <utility>      // for declval, forward
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <cstddef>      // for ptrdiff_t, nullptr_t, size_t
+    #include <functional>   // for less, greater
+    #include <memory>       // for shared_ptr, unique_ptr, hash
+    #include <type_traits>  // for enable_if_t, is_convertible, is_assignable
+    #include <utility>      // for declval, forward
 
-#if !defined(GSL_NO_IOSTREAMS)
-#include <iosfwd> // for ostream
-#endif            // !defined(GSL_NO_IOSTREAMS)
+    #if !defined(GSL_NO_IOSTREAMS)
+    #include <iosfwd> // for ostream
+    #endif            // !defined(GSL_NO_IOSTREAMS)
+#endif
 
 namespace gsl
 {

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -22,11 +22,15 @@
 #include "./span_ext" // for span specialization of gsl::at and other span-related extensions
 #include "./util"     // for narrow_cast
 
-#include <array>       // for array
-#include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
-#include <iterator>    // for reverse_iterator, distance, random_access_...
-#include <memory>      // for pointer_traits
-#include <type_traits> // for enable_if_t, declval, is_convertible, inte...
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <array>       // for array
+    #include <cstddef>     // for ptrdiff_t, size_t, nullptr_t
+    #include <iterator>    // for reverse_iterator, distance, random_access_...
+    #include <memory>      // for pointer_traits
+    #include <type_traits> // for enable_if_t, declval, is_convertible, inte...
+#endif
 
 #if defined(__has_include) && __has_include(<version>)
 #include <version>

--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -30,12 +30,16 @@
 #include "./assert" // GSL_KERNEL_MODE
 #include "./util"   // for narrow_cast, narrow
 
-#include <cstddef> // for ptrdiff_t, size_t
-#include <utility>
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <cstddef> // for ptrdiff_t, size_t
+    #include <utility>
 
-#ifndef GSL_KERNEL_MODE
-#include <algorithm> // for lexicographical_compare
-#endif               // GSL_KERNEL_MODE
+    #ifndef GSL_KERNEL_MODE
+    #include <algorithm> // for lexicographical_compare
+    #endif               // GSL_KERNEL_MODE
+#endif
 
 namespace gsl
 {

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -19,17 +19,23 @@
 
 #include "./assert" // for Expects
 
-#include <array>
-#include <cstddef>          // for ptrdiff_t, size_t
-#include <limits>           // for numeric_limits
-#include <initializer_list> // for initializer_list
-#include <type_traits>      // for is_signed, integral_constant
-#include <utility>          // for exchange, forward
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <array>
+    #include <cstddef>          // for ptrdiff_t, size_t
+    #include <limits>           // for numeric_limits
+    #include <initializer_list> // for initializer_list
+    #include <type_traits>      // for is_signed, integral_constant
+    #include <utility>          // for exchange, forward
+#endif
 
 #if defined(__has_include) && __has_include(<version>)
-#include <version>
+    #include <version>
 #if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
-#include <span>
+#if !defined(GSL_BUILD_USING_STD_MODULE)
+    #include <span>
+#endif
 #endif // __cpp_lib_span >= 202002L
 #endif //__has_include(<version>)
 

--- a/include/gsl/zstring
+++ b/include/gsl/zstring
@@ -19,7 +19,11 @@
 
 #include "./span_ext" // for dynamic_extent
 
-#include <cstddef>   // for size_t, nullptr_t
+#if defined(GSL_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <cstddef>   // for size_t, nullptr_t
+#endif
 
 namespace gsl
 {


### PR DESCRIPTION
fixes #1217 

This is an example of how issue #1217 could be fixed
