### PR TITLE
feat: implementation of gsl::dyn_array

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -88,8 +88,6 @@ jobs:
           # Regular MSVC builds use Ninja (from preset)
           - toolset: ''
             generator_override: ''
-            build_config_args: ''
-            test_config_args: ''
           # ClangCL builds require Visual Studio generator
           - toolset: 'ClangCL'
             generator_override: '-G "Visual Studio 17 2022" -T ClangCL'

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -95,6 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: microsoft/setup-msbuild@v3
+      - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Run CMake (configure, build, test)
         uses: ./.github/workflows/cmake

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -84,6 +84,15 @@ jobs:
         build_type: [ Debug, Release ]
         toolset: [ '', 'ClangCL' ]
         cxx_version: [ 14, 17, 20, 23 ]
+        include:
+          # Regular MSVC builds use Ninja (from preset)
+          - toolset: ''
+            generator_override: ''
+            build_config_args: ''
+            test_config_args: ''
+          # ClangCL builds require Visual Studio generator
+          - toolset: 'ClangCL'
+            generator_override: '-G "Visual Studio 17 2022" -T ClangCL'
     runs-on: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v6
@@ -93,7 +102,7 @@ jobs:
         uses: ./.github/workflows/cmake
         with:
           cmake_preset: msvc-${{ matrix.cxx_version }}-${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
-          extra_cmake_configure_args: ${{ matrix.toolset != '' && format('-G "Visual Studio 17 2022" -T {0}', matrix.toolset) || '' }}
-          extra_cmake_build_args: ${{ matrix.toolset != '' && format('--config {0}', matrix.build_type) || '' }}
-          extra_ctest_args: ${{ matrix.toolset != '' && format('-C {0}', matrix.build_type) || '' }}
+          extra_cmake_configure_args: ${{ matrix.generator_override }}
+          extra_cmake_build_args: ${{ matrix.toolset == 'ClangCL' && format('--config {0}', matrix.build_type) || '' }}
+          extra_ctest_args: ${{ matrix.toolset == 'ClangCL' && format('-C {0}', matrix.build_type) || '' }}
 

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -83,7 +83,7 @@ jobs:
         generator: [ 'Visual Studio 17 2022' ]
         image: [ windows-2022, windows-2025 ]
         build_type: [ Debug, Release ]
-        extra_args: [ '', '-T ClangCL' ]
+        extra_args: [ '', '-DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl' ]
         cxx_version: [ 14, 17, 20, 23 ]
     runs-on: ${{ matrix.image }}
     steps:

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -77,16 +77,16 @@ jobs:
           cmake_preset: clang-${{ matrix.cxx_version }}-${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
           extra_cmake_configure_args: '-DCMAKE_CXX_FLAGS="-isysroot \"$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk\""'
 
-  VisualStudio:
+  msvc:
     strategy:
       matrix:
         image: [ windows-2022, windows-2025 ]
         build_type: [ Debug, Release ]
-        toolset: [ '', 'ClangCL' ]
+        toolset: [ 'msvc', 'ClangCL' ]
         cxx_version: [ 14, 17, 20, 23 ]
         include:
           # Regular MSVC builds use Ninja (from preset)
-          - toolset: ''
+          - toolset: 'msvc'
             generator_override: ''
           # ClangCL builds require Visual Studio generator
           - toolset: 'ClangCL'
@@ -104,4 +104,3 @@ jobs:
           extra_cmake_configure_args: ${{ matrix.generator_override }}
           extra_cmake_build_args: ${{ matrix.toolset == 'ClangCL' && format('--config {0}', matrix.build_type) || '' }}
           extra_ctest_args: ${{ matrix.toolset == 'ClangCL' && format('-C {0}', matrix.build_type) || '' }}
-

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -80,10 +80,9 @@ jobs:
   VisualStudio:
     strategy:
       matrix:
-        generator: [ 'Visual Studio 17 2022' ]
         image: [ windows-2022, windows-2025 ]
         build_type: [ Debug, Release ]
-        extra_args: [ '', '-DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl' ]
+        toolset: [ '', 'ClangCL' ]
         cxx_version: [ 14, 17, 20, 23 ]
     runs-on: ${{ matrix.image }}
     steps:
@@ -94,6 +93,7 @@ jobs:
         uses: ./.github/workflows/cmake
         with:
           cmake_preset: msvc-${{ matrix.cxx_version }}-${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
-          extra_cmake_configure_args: ${{ matrix.extra_args }}
-          extra_cmake_build_args: --config ${{ matrix.build_type }}
-          extra_ctest_args: -C ${{ matrix.build_type }}
+          extra_cmake_configure_args: ${{ matrix.toolset != '' && format('-G "Visual Studio 17 2022" -T {0}', matrix.toolset) || '' }}
+          extra_cmake_build_args: ${{ matrix.toolset != '' && format('--config {0}', matrix.build_type) || '' }}
+          extra_ctest_args: ${{ matrix.toolset != '' && format('-C {0}', matrix.build_type) || '' }}
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,6 +6,7 @@
             "hidden": true,
             "binaryDir": "${sourceDir}/build/${presetName}",
             "installDir": "${sourceDir}/install/${presetName}",
+            "generator": "Ninja",
             "cacheVariables": {
                 "GSL_CXX_STANDARD": "14",
                 "GSL_TEST": "ON"
@@ -15,14 +16,11 @@
             "name": "msvc-base",
             "inherits": "base",
             "hidden": true,
-            "generator": "Visual Studio 17 2022",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
             },
-            "toolset": "host=x64",
-            "architecture": "x64",
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "cl"
             }
@@ -31,7 +29,6 @@
             "name": "gcc-base",
             "inherits": "base",
             "hidden": true,
-            "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "g++",
                 "CMAKE_C_COMPILER": "gcc"
@@ -41,7 +38,6 @@
             "name": "clang-base",
             "inherits": "base",
             "hidden": true,
-            "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_C_COMPILER": "clang"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ span_p                                                                   | &#x26
 [cu32zstring](docs/headers.md#user-content-H-zstring)                    | &#x2611;   | An alias to `basic_zstring` with dynamic extent and a char type of `const char32_t`
 [**2. Owners**][cg-owners]                                               |            |
 stack_array                                                              | &#x2610;   | A stack-allocated array
-dyn_array                                                                | &#x2610;   | A heap-allocated array
+dyn_array                                                                | &#x2611;   | A heap-allocated array
 [**3. Assertions**][cg-assertions]                                       |            |
 [Expects](docs/headers.md#user-content-H-assert-expects)                 | &#x2611;   | A precondition assertion; on failure it terminates
 [Ensures](docs/headers.md#user-content-H-assert-ensures)                 | &#x2611;   | A postcondition assertion; on failure it terminates

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -9,6 +9,7 @@ See [GSL: Guidelines support library](https://isocpp.github.io/CppCoreGuidelines
 - [`<algorithms>`](#user-content-H-algorithms)
 - [`<assert>`](#user-content-H-assert)
 - [`<byte>`](#user-content-H-byte)
+- [`<dyn_array>`](#user-content-H-dyn_array)
 - [`<gsl>`](#user-content-H-gsl)
 - [`<narrow>`](#user-content-H-narrow)
 - [`<pointers>`](#user-content-H-pointers)
@@ -154,6 +155,10 @@ constexpr byte to_byte() noexcept;
 ```
 
 Convert the given value `I` to a `byte`. The template requires `I` to be in the valid range 0..255 for a `gsl::byte`.
+
+## <a name="H-dyn_array" />`<dyn_array>`
+
+# TODO (@carsonradtke)
 
 ## <a name="H-gsl" />`<gsl>`
 

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -158,7 +158,175 @@ Convert the given value `I` to a `byte`. The template requires `I` to be in the 
 
 ## <a name="H-dyn_array" />`<dyn_array>`
 
-# TODO (@carsonradtke)
+This header contains an owning dynamically allocated array type whose size is fixed between assignments.
+
+- [`gsl::dyn_array`](#user-content-H-dyn_array-dyn_array)
+
+### <a name="H-dyn_array-dyn_array" />`gsl::dyn_array`
+
+```cpp
+template <typename T, typename Allocator = std::allocator<T>>
+class dyn_array;
+```
+
+`gsl::dyn_array` owns a contiguous sequence of `T` objects allocated with `Allocator`.
+The number of elements is established when the object is constructed and remains unchanged until the object is copy-assigned.
+It provides bounds-checked element access and checked random-access iterators.
+
+`gsl::dyn_array` is useful when the number of elements is known only at runtime, but the array should not grow or shrink through container operations.
+
+#### Member Types
+
+```cpp
+using value_type = T;
+using reference = T&;
+using const_reference = const T&;
+using iterator = details::dyn_array_iterator<T>;
+using const_iterator = details::dyn_array_iterator<const T>;
+using reverse_iterator = std::reverse_iterator<iterator>;
+using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+using difference_type = std::ptrdiff_t;
+using size_type = std::size_t;
+
+using allocator_type = Allocator;
+```
+
+#### Member functions
+
+##### Construct/Copy
+
+```cpp
+explicit constexpr dyn_array(const Allocator& alloc = {});
+```
+
+Constructs an empty `dyn_array`.
+No elements are allocated and `data()` returns `nullptr`.
+
+```cpp
+constexpr explicit dyn_array(size_type count, const Allocator& alloc = {});
+
+constexpr dyn_array(size_type count, const T& value, const Allocator& alloc = {});
+```
+
+Constructs a `dyn_array` with `count` elements using `alloc`.
+The first overload default-constructs each element.
+The second overload constructs each element as a copy of `value`.
+
+```cpp
+template <typename InputIt>
+constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {});
+```
+
+Constructs a `dyn_array` by copying the elements in the range `[first, last)`.
+
+```cpp
+template <std::ranges::input_range InputRg>
+constexpr dyn_array(std::from_range_t, InputRg&& rg, const Allocator& alloc = {});
+```
+
+Constructs a `dyn_array` by copying the elements in `rg`.
+This overload is available when container ranges are supported.
+
+```cpp
+constexpr dyn_array(const dyn_array& other, const Allocator& alloc = {});
+
+constexpr dyn_array(std::initializer_list<T> init, const Allocator& alloc = {});
+```
+
+Constructs a `dyn_array` by copying the elements from another `dyn_array` or from an initializer list.
+
+```cpp
+constexpr auto operator=(const dyn_array& other) -> dyn_array&;
+
+constexpr dyn_array(dyn_array&&) = delete;
+dyn_array& operator=(dyn_array&&) = delete;
+```
+
+Copy assignment replaces the contents with copies of the elements in `other`.
+Move construction and move assignment are explicitly deleted.
+
+##### Observers
+
+```cpp
+constexpr auto size() const;
+constexpr auto empty() const;
+constexpr auto max_size() const;
+constexpr auto get_allocator() -> Allocator&;
+```
+
+Returns the number of elements, whether the array is empty, the maximum representable size, or the allocator used by the `dyn_array`.
+
+##### Element access
+
+```cpp
+constexpr auto operator[](size_type pos) -> reference;
+constexpr auto operator[](size_type pos) const -> const_reference;
+```
+
+Returns a reference to the element at the given index.
+[`Expects`](#user-content-H-assert-expects) that `pos` is less than the `dyn_array`'s size.
+
+```cpp
+constexpr auto data();
+constexpr auto data() const -> const T*;
+```
+
+Returns a pointer to the beginning of the contained data.
+If the `dyn_array` is empty, this returns `nullptr`.
+
+##### Iterators
+
+```cpp
+constexpr auto begin();
+constexpr auto begin() const;
+constexpr auto cbegin() const;
+
+constexpr auto end();
+constexpr auto end() const;
+constexpr auto cend() const;
+```
+
+Returns an iterator to the first element or to one past the last element.
+
+```cpp
+constexpr auto rbegin();
+constexpr auto rbegin() const;
+constexpr auto crbegin() const;
+
+constexpr auto rend();
+constexpr auto rend() const;
+constexpr auto crend() const;
+```
+
+Returns a reverse iterator to the first element of the reversed range or to one past the last element of the reversed range.
+
+The iterators are random-access iterators and perform bounds checking.
+Dereferencing `end()`, moving before `begin()` or past `end()`, or comparing iterators from different arrays violates preconditions.
+
+##### Comparisons
+
+```cpp
+constexpr auto operator==(const dyn_array& other) const;
+constexpr auto operator!=(const dyn_array& other) const;
+```
+
+Compares two `dyn_array`s by size and element value.
+
+#### Deduction guides
+
+```cpp
+template <class InputIt,
+          class Alloc = std::allocator<typename std::iterator_traits<InputIt>::value_type>>
+dyn_array(InputIt, InputIt,
+          Alloc = {}) -> dyn_array<typename std::iterator_traits<InputIt>::value_type, Alloc>;
+
+template <std::ranges::input_range InputRg,
+          class Alloc = std::allocator<std::ranges::range_value_t<InputRg>>>
+dyn_array(std::from_range_t, InputRg&&,
+          Alloc = {}) -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
+```
+
+The range deduction guide is available when container ranges are supported.
 
 ## <a name="H-gsl" />`<gsl>`
 

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -42,7 +42,7 @@ namespace details
         using reference = T&;
         using const_reference = const T&;
         using difference_type = std::ptrdiff_t;
-        using size_type = decltype(sizeof(0));
+        using size_type = std::size_t;
     };
 
     template <typename T, typename Allocator = std::allocator<T>>
@@ -51,6 +51,7 @@ namespace details
         using pointer = typename dyn_array_traits<T>::pointer;
         using size_type = typename dyn_array_traits<T>::size_type;
 
+        protected:
         const class dyn_array_impl
         {
         public:
@@ -76,10 +77,8 @@ namespace details
 
         GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
         {
-            if (impl().data()) Allocator::deallocate(impl().data(), impl().count());
+            if (_impl.data()) Allocator::deallocate(_impl.data(), _impl.count());
         }
-
-        constexpr auto impl() const -> const dyn_array_impl& { return _impl; }
     };
 
     template <typename T>
@@ -96,7 +95,7 @@ namespace details
         using iterator_category = std::random_access_iterator_tag;
 
 #ifdef GSL_HAS_RANGES
-        constexpr dyn_array_iterator() : dyn_array_iterator(nullptr, 0, 0) {}
+        constexpr dyn_array_iterator() = default;
 #endif /* GSL_HAS_RANGES */
 
         constexpr dyn_array_iterator(pointer ptr, size_type pos, size_type end_pos)
@@ -134,7 +133,7 @@ namespace details
         constexpr auto operator++() -> dyn_array_iterator&
         {
             Expects(_pos < _end_pos);
-            _pos++;
+            ++_pos;
             return *this;
         }
 
@@ -148,7 +147,7 @@ namespace details
         constexpr auto operator--() -> dyn_array_iterator&
         {
             Expects(_pos > 0);
-            _pos--;
+            --_pos;
             return *this;
         }
 
@@ -161,17 +160,19 @@ namespace details
 
         constexpr auto operator+=(difference_type diff) -> dyn_array_iterator&
         {
-            auto pos = gsl::narrow<difference_type>(_pos);
-            Expects(pos + diff <= gsl::narrow<difference_type>(_end_pos));
-            _pos = gsl::narrow<size_type>(pos + diff);
+            auto new_pos = gsl::narrow<difference_type>(_pos) + diff;
+            Expects(new_pos >= 0);
+            Expects(new_pos <= gsl::narrow<difference_type>(_end_pos));
+            _pos = gsl::narrow<size_type>(new_pos);
             return *this;
         }
 
         constexpr auto operator-=(difference_type diff) -> dyn_array_iterator&
         {
-            auto pos = gsl::narrow<difference_type>(_pos);
-            Expects(pos >= diff);
-            _pos = gsl::narrow<size_type>(pos - diff);
+            auto new_pos = gsl::narrow<difference_type>(_pos) - diff;
+            Expects(new_pos >= 0);
+            Expects(new_pos <= gsl::narrow<difference_type>(_end_pos));
+            _pos = gsl::narrow<size_type>(new_pos);
             return *this;
         }
 
@@ -204,14 +205,14 @@ namespace details
         }
 
     private:
-        pointer _ptr;
-        size_type _pos;
-        size_type _end_pos;
+        pointer _ptr{};
+        size_type _pos{};
+        size_type _end_pos{};
     };
 } // namespace details
 
 template <typename T, typename Allocator = std::allocator<T>>
-class dyn_array : public details::dyn_array_base<T, Allocator>
+class dyn_array : private details::dyn_array_base<T, Allocator>
 {
     using base = details::dyn_array_base<T, Allocator>;
     using pointer = typename details::dyn_array_traits<T>::pointer;
@@ -231,7 +232,7 @@ public:
 
     explicit constexpr dyn_array(const Allocator& alloc = {}) : base{alloc} {}
 
-    explicit constexpr dyn_array(size_type count, const T& value, const Allocator& alloc = {})
+    constexpr dyn_array(size_type count, const T& value, const Allocator& alloc = {})
         : base{count, alloc}
     {
         std::fill(begin(), end(), value);
@@ -278,7 +279,7 @@ public:
 
     constexpr auto operator!=(const dyn_array& other) const { return !(*this == other); }
 
-    constexpr auto size() const { return impl().count(); }
+    constexpr auto size() const { return base::_impl.count(); }
 
     constexpr auto empty() const { return size() == 0; }
 
@@ -297,14 +298,16 @@ public:
         return const_cast<dyn_array&>(*this)[pos];
     }
 
-    constexpr auto data() { return impl().data(); }
+    constexpr auto data() { return base::_impl.data(); }
     constexpr auto data() const -> const T* { return const_cast<dyn_array&>(*this).data(); }
 
     constexpr auto begin() { return iterator{data(), 0, size()}; }
     constexpr auto begin() const { return const_iterator{data(), 0, size()}; }
+    constexpr auto cbegin() const { return begin(); }
 
     constexpr auto rbegin() { return reverse_iterator{end()}; }
     constexpr auto rbegin() const { return const_reverse_iterator{end()}; }
+    constexpr auto crbegin() const { return rbegin(); }
 
 #ifdef _MSC_VER
     constexpr auto _Unchecked_begin() { return data(); }
@@ -316,9 +319,11 @@ public:
 
     constexpr auto end() { return iterator{data(), size(), size()}; }
     constexpr auto end() const { return const_iterator{data(), size(), size()}; }
+    constexpr auto cend() const { return end(); }
 
     constexpr auto rend() { return reverse_iterator{begin()}; }
     constexpr auto rend() const { return const_reverse_iterator{begin()}; }
+    constexpr auto crend() const { return rend(); }
 
 #ifdef _MSC_VER
     constexpr auto _Unchecked_end() { return data() + size(); }
@@ -327,9 +332,6 @@ public:
         return const_cast<dyn_array&>(*this)._Unchecked_end();
     }
 #endif /* MSC_VER */
-
-private:
-    constexpr auto impl() const { return base::impl(); }
 };
 
 #ifdef GSL_HAS_DEDUCTION_GUIDES

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -1,0 +1,352 @@
+// -*- C++ -*-
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef GSL_DYN_ARRAY_H
+#define GSL_DYN_ARRAY_H
+
+#include "./assert"
+#include "./narrow"
+#include "./util"
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+
+#ifdef GSL_HAS_RANGES
+#include <ranges>
+#endif /* GSL_HAS_RANGES */
+
+namespace gsl
+{
+namespace details
+{
+    template <typename T>
+    struct dyn_array_traits
+    {
+        using value_type = T;
+        using pointer = T*;
+        using reference = T&;
+        using const_reference = const T&;
+        using difference_type = std::ptrdiff_t;
+        using size_type = decltype(sizeof(0));
+    };
+
+    template <typename T, typename Allocator = std::allocator<T>>
+    class dyn_array_base : public Allocator
+    {
+        using pointer = typename dyn_array_traits<T>::pointer;
+        using size_type = typename dyn_array_traits<T>::size_type;
+
+        const class dyn_array_impl
+        {
+        public:
+            constexpr dyn_array_impl(pointer data, size_type count) : _data{data}, _count{count}
+            {
+                Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
+            }
+
+            constexpr auto data() const { return _data; }
+
+            constexpr auto count() const { return _count; }
+
+        private:
+            pointer _data;
+            size_type _count;
+        } _impl;
+
+    public:
+        constexpr dyn_array_base(const Allocator& alloc) : Allocator{alloc}, _impl{nullptr, 0} {}
+        constexpr dyn_array_base(size_type count, const Allocator& alloc)
+            : Allocator{alloc}, _impl{count == 0 ? nullptr : Allocator::allocate(count), count}
+        {}
+
+        GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
+        {
+            if (impl().data()) Allocator::deallocate(impl().data(), impl().count());
+        }
+
+        constexpr auto impl() const -> const dyn_array_impl& { return _impl; }
+    };
+
+    template <typename T>
+    class dyn_array_iterator
+    {
+        using size_type = typename dyn_array_traits<T>::size_type;
+
+    public:
+        using difference_type = typename dyn_array_traits<T>::difference_type;
+        using value_type = typename dyn_array_traits<T>::value_type;
+        using pointer = typename dyn_array_traits<T>::pointer;
+        using reference = typename dyn_array_traits<T>::reference;
+        using const_reference = typename dyn_array_traits<T>::const_reference;
+        using iterator_category = std::random_access_iterator_tag;
+
+#ifdef GSL_HAS_RANGES
+        constexpr dyn_array_iterator() : dyn_array_iterator(nullptr, 0, 0) {}
+#endif /* GSL_HAS_RANGES */
+
+        constexpr dyn_array_iterator(pointer ptr, size_type pos, size_type end_pos)
+            : _ptr{ptr}, _pos{pos}, _end_pos{end_pos}
+        {
+            Ensures((_ptr != nullptr && _end_pos > 0) || (_ptr == nullptr && _end_pos == 0));
+            Ensures(_pos <= _end_pos);
+        }
+
+#if defined(_MSC_VER) && defined(GSL_HAS_RANGES)
+        // TODO (@carsonradtke): Investigate why this is necessary for MSVC.
+        // Is it a a bug in GSL? STL? MSVC?
+        constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }
+#endif /* defined(_MSC_VER) && defined(GSL_HAS_RANGES) */
+
+        constexpr auto operator==(const dyn_array_iterator& other) const
+        {
+            Expects(_ptr == other._ptr);
+            Expects(_end_pos == other._end_pos);
+            return _pos == other._pos;
+        }
+
+        constexpr auto operator!=(const dyn_array_iterator& other) const
+        {
+            return !(*this == other);
+        }
+
+        constexpr auto operator*() const -> reference
+        {
+            Expects(_ptr != nullptr);
+            Expects(_pos < _end_pos);
+            return _ptr[_pos];
+        }
+
+        constexpr auto operator++() -> dyn_array_iterator&
+        {
+            Expects(_pos < _end_pos);
+            _pos++;
+            return *this;
+        }
+
+        constexpr auto operator++(int)
+        {
+            auto rv = *this;
+            ++(*this);
+            return rv;
+        }
+
+        constexpr auto operator--() -> dyn_array_iterator&
+        {
+            Expects(_pos > 0);
+            _pos--;
+            return *this;
+        }
+
+        constexpr auto operator--(int)
+        {
+            auto rv = *this;
+            --(*this);
+            return rv;
+        }
+
+        constexpr auto operator+=(difference_type diff) -> dyn_array_iterator&
+        {
+            auto pos = gsl::narrow<difference_type>(_pos);
+            Expects(pos + diff <= gsl::narrow<difference_type>(_end_pos));
+            _pos = gsl::narrow<size_type>(pos + diff);
+            return *this;
+        }
+
+        constexpr auto operator-=(difference_type diff) -> dyn_array_iterator&
+        {
+            auto pos = gsl::narrow<difference_type>(_pos);
+            Expects(pos >= diff);
+            _pos = gsl::narrow<size_type>(pos - diff);
+            return *this;
+        }
+
+        constexpr auto operator+(difference_type diff) const
+        {
+            return dyn_array_iterator{_ptr, _pos + gsl::narrow<size_type>(diff), _end_pos};
+        }
+
+        constexpr auto operator-(difference_type diff) const
+        {
+            return dyn_array_iterator{_ptr, _pos + gsl::narrow<size_type>(diff), _end_pos};
+        }
+
+        constexpr auto operator-(const dyn_array_iterator& other) const
+        {
+            Expects(_ptr == other._ptr);
+            Expects(_end_pos == other._end_pos);
+            return gsl::narrow<difference_type>(_pos) - gsl::narrow<difference_type>(other._pos);
+        }
+
+        constexpr auto operator[](size_type pos) -> reference
+        {
+            Expects(_pos + pos < _end_pos);
+            return _ptr[_pos + pos];
+        }
+
+        constexpr auto operator[](size_type pos) const -> const_reference
+        {
+            return const_cast<dyn_array_iterator&>(*this).operator[](pos);
+        }
+
+    private:
+        pointer _ptr;
+        size_type _pos;
+        size_type _end_pos;
+    };
+} // namespace details
+
+template <typename T, typename Allocator = std::allocator<T>>
+class dyn_array : public details::dyn_array_base<T, Allocator>
+{
+    using base = details::dyn_array_base<T, Allocator>;
+    using pointer = typename details::dyn_array_traits<T>::pointer;
+
+public:
+    using value_type = typename details::dyn_array_traits<T>::value_type;
+    using reference = typename details::dyn_array_traits<T>::reference;
+    using const_reference = typename details::dyn_array_traits<T>::const_reference;
+    using iterator = details::dyn_array_iterator<T>;
+    using const_iterator = details::dyn_array_iterator<const T>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using difference_type = typename details::dyn_array_traits<T>::difference_type;
+    using size_type = typename details::dyn_array_traits<T>::size_type;
+
+    using allocator_type = Allocator;
+
+    explicit constexpr dyn_array(const Allocator& alloc = {}) : base{alloc} {}
+
+    explicit constexpr dyn_array(size_type count, const T& value, const Allocator& alloc = {})
+        : base{count, alloc}
+    {
+        std::fill(begin(), end(), value);
+    }
+
+    GSL_TYPE_IS_ITERATOR(InputIt)
+    constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {})
+        : base{gsl::narrow<size_type>(std::distance(first, last)), alloc}
+    {
+        std::copy(first, last, begin());
+    }
+
+#ifdef GSL_HAS_CONTAINER_RANGES
+    template <typename InputRg>
+        requires(std::ranges::input_range<InputRg>)
+    constexpr dyn_array(std::from_range_t, InputRg&& rg, const Allocator& alloc = {})
+        : base{gsl::narrow<size_type>(std::size(rg)), alloc}
+    {
+        std::ranges::copy(rg, std::ranges::begin(*this));
+    }
+#endif /* GSL_HAS_RANGES */
+
+    constexpr explicit dyn_array(size_type count, const Allocator& alloc = {})
+        : dyn_array{count, T{}, alloc}
+    {}
+
+    constexpr dyn_array(const dyn_array& other, const Allocator& alloc = {})
+        : dyn_array(other.begin(), other.end(), alloc)
+    {}
+
+    constexpr dyn_array(std::initializer_list<T> init, const Allocator& alloc = {})
+        : dyn_array(init.begin(), init.end(), alloc)
+    {}
+
+    constexpr auto operator=(const dyn_array& other) -> dyn_array& { return dyn_array{other}; }
+
+    constexpr dyn_array(dyn_array&&) = delete;
+    dyn_array& operator=(dyn_array&&) = delete;
+
+    constexpr auto operator==(const dyn_array& other) const
+    {
+        return size() == other.size() && std::equal(begin(), end(), other.begin(), other.end());
+    }
+
+    constexpr auto operator!=(const dyn_array& other) const { return !(*this == other); }
+
+    constexpr auto size() const { return impl().count(); }
+
+    constexpr auto empty() const { return size() == 0; }
+
+    constexpr auto max_size() const { return static_cast<size_type>(-1); }
+
+    constexpr auto get_allocator() -> Allocator& { return *this; }
+
+    constexpr auto operator[](size_type pos) -> reference
+    {
+        Expects(pos < size());
+        return data()[pos];
+    }
+
+    constexpr auto operator[](size_type pos) const -> const_reference
+    {
+        return const_cast<dyn_array&>(*this)[pos];
+    }
+
+    constexpr auto data() { return impl().data(); }
+    constexpr auto data() const -> const T* { return const_cast<dyn_array&>(*this).data(); }
+
+    constexpr auto begin() { return iterator{data(), 0, size()}; }
+    constexpr auto begin() const { return const_iterator{data(), 0, size()}; }
+
+    constexpr auto rbegin() { return reverse_iterator{end()}; }
+    constexpr auto rbegin() const { return const_reverse_iterator{end()}; }
+
+#ifdef _MSC_VER
+    constexpr auto _Unchecked_begin() { return data(); }
+    constexpr auto _Unchecked_begin() const -> const pointer
+    {
+        return const_cast<dyn_array&>(*this)._Unchecked_begin();
+    }
+#endif /* _MSC_VER */
+
+    constexpr auto end() { return iterator{data(), size(), size()}; }
+    constexpr auto end() const { return const_iterator{data(), size(), size()}; }
+
+    constexpr auto rend() { return reverse_iterator{begin()}; }
+    constexpr auto rend() const { return const_reverse_iterator{begin()}; }
+
+#ifdef _MSC_VER
+    constexpr auto _Unchecked_end() { return data() + size(); }
+    constexpr auto _Unchecked_end() const -> const pointer
+    {
+        return const_cast<dyn_array&>(*this)._Unchecked_end();
+    }
+#endif /* MSC_VER */
+
+private:
+    constexpr auto impl() const { return base::impl(); }
+};
+
+#ifdef GSL_HAS_DEDUCTION_GUIDES
+
+template <class InputIt,
+          class Alloc = std::allocator<typename std::iterator_traits<InputIt>::value_type>>
+dyn_array(InputIt, InputIt,
+          Alloc = {}) -> dyn_array<typename std::iterator_traits<InputIt>::value_type, Alloc>;
+
+#ifdef GSL_HAS_CONTAINER_RANGES
+template <std::ranges::input_range InputRg,
+          class Alloc = std::allocator<std::ranges::range_value_t<InputRg>>>
+dyn_array(std::from_range_t, InputRg&&,
+          Alloc = {}) -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
+#endif /* GSL_HAS_RANGES */
+
+#endif /* GSL_HAS_DEDUCTION_GUIDES */
+} // namespace gsl
+
+#endif /* defined(GSL_DYN_ARRAY_H) */

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -125,16 +125,7 @@ namespace details
             }
         }
 
-        constexpr void swap(dyn_array_base& other) {
-            auto old_count = _count;
-            auto old_data = _data;
-            _count = other._count;
-            _data = other._data;
-            other._count = old_count;
-            other._data = old_data;
-        }
-
-    private:
+        private:
         pointer _data;
         size_type _count;
 
@@ -299,10 +290,6 @@ class dyn_array : private details::dyn_array_base<T, Allocator>
     using base = details::dyn_array_base<T, Allocator>;
     using pointer = T*;
 
-    constexpr void swap(dyn_array& other) {
-        base::swap(other);
-    }
-
 public:
     using value_type = T;
     using reference = T&;
@@ -361,12 +348,6 @@ public:
     constexpr dyn_array(std::initializer_list<T> init, const Allocator& alloc = {})
         : dyn_array(init.begin(), init.end(), alloc)
     {}
-
-    constexpr auto operator=(const dyn_array& other) -> dyn_array& {
-        dyn_array tmp{other, get_allocator()};
-        swap(tmp);
-        return *this;
-    }
 
     constexpr dyn_array(dyn_array&&) = delete;
     dyn_array& operator=(dyn_array&&) = delete;

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -34,22 +34,11 @@ namespace gsl
 {
 namespace details
 {
-    template <typename T>
-    struct dyn_array_traits
-    {
-        using value_type = T;
-        using pointer = T*;
-        using reference = T&;
-        using const_reference = const T&;
-        using difference_type = std::ptrdiff_t;
-        using size_type = std::size_t;
-    };
-
     template <typename T, typename Allocator = std::allocator<T>>
     class dyn_array_base : public Allocator
     {
-        using pointer = typename dyn_array_traits<T>::pointer;
-        using size_type = typename dyn_array_traits<T>::size_type;
+        using pointer = T*;
+        using size_type = std::size_t;
 
     protected:
         constexpr auto data() const { return _data; }
@@ -82,14 +71,14 @@ namespace details
     template <typename T>
     class dyn_array_iterator
     {
-        using size_type = typename dyn_array_traits<T>::size_type;
+        using size_type = std::size_t;
 
     public:
-        using difference_type = typename dyn_array_traits<T>::difference_type;
-        using value_type = typename dyn_array_traits<T>::value_type;
-        using pointer = typename dyn_array_traits<T>::pointer;
-        using reference = typename dyn_array_traits<T>::reference;
-        using const_reference = typename dyn_array_traits<T>::const_reference;
+        using difference_type = std::ptrdiff_t;
+        using value_type = T;
+        using pointer = T*;
+        using reference = T&;
+        using const_reference = const T&;
         using iterator_category = std::random_access_iterator_tag;
 
 #ifdef GSL_HAS_RANGES
@@ -213,18 +202,18 @@ template <typename T, typename Allocator = std::allocator<T>>
 class dyn_array : private details::dyn_array_base<T, Allocator>
 {
     using base = details::dyn_array_base<T, Allocator>;
-    using pointer = typename details::dyn_array_traits<T>::pointer;
+    using pointer = T*;
 
 public:
-    using value_type = typename details::dyn_array_traits<T>::value_type;
-    using reference = typename details::dyn_array_traits<T>::reference;
-    using const_reference = typename details::dyn_array_traits<T>::const_reference;
+    using value_type = T;
+    using reference = T&;
+    using const_reference = const T&;
     using iterator = details::dyn_array_iterator<T>;
     using const_iterator = details::dyn_array_iterator<const T>;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    using difference_type = typename details::dyn_array_traits<T>::difference_type;
-    using size_type = typename details::dyn_array_traits<T>::size_type;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
 
     using allocator_type = Allocator;
 

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -189,8 +189,6 @@ namespace details
         }
 
 #if defined(_MSC_VER) && defined(GSL_HAS_RANGES)
-        // TODO (@carsonradtke): Investigate why this is necessary for MSVC.
-        // Is it a bug in GSL? STL? MSVC?
         constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }
 #endif /* defined(_MSC_VER) && defined(GSL_HAS_RANGES) */
 
@@ -302,7 +300,6 @@ class dyn_array : private details::dyn_array_base<T, Allocator>
     using pointer = T*;
 
     constexpr void swap(dyn_array& other) {
-        // TODO (@carsonradtke): This was not in the spec, should it have been?
         base::swap(other);
     }
 
@@ -336,7 +333,6 @@ public:
 
     template <typename InputIt, std::enable_if_t<!details::is_fwd_iterator<InputIt>::value && details::is_iterator<InputIt>::value, bool> = true>
     constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc={}) : dyn_array{alloc} {
-        // TODO (@carsonradtke): Can this be done better?
         std::vector<T> tmp(first, last);
         base::resize(tmp.size());
         base::copy(std::begin(tmp), std::end(tmp), data());

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -73,7 +73,7 @@ namespace details
 
         constexpr auto count() const { return _count; }
 
-        void resize(size_type count) {
+        GSL_CONSTEXPR_SINCE_CPP20 void resize(size_type count) {
             // This should only be called when constructing a non-forward iteartor.
             // It neither frees nor copies `_data`.
             Expects(_data == nullptr && _count == 0);
@@ -112,7 +112,7 @@ namespace details
             }
         }
 
-        void default_construct(pointer first, size_type count) {
+        GSL_CONSTEXPR_SINCE_CPP20 void default_construct(pointer first, size_type count) {
             pointer current = first;
             try {
                 for (size_type i = 0; i < count; ++i, ++current) {
@@ -125,7 +125,7 @@ namespace details
             }
         }
 
-        void swap(dyn_array_base& other) {
+        constexpr void swap(dyn_array_base& other) {
             auto old_count = _count;
             auto old_data = _data;
             _count = other._count;

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <type_traits>
 
 #ifdef GSL_HAS_RANGES
 #include <ranges>
@@ -40,10 +41,66 @@ namespace details
         using pointer = T*;
         using size_type = std::size_t;
 
+        template <typename... Args>
+        GSL_CONSTEXPR_SINCE_CPP20 void construct(pointer ptr, Args&&... args)
+        {
+            std::allocator_traits<Allocator>::construct(static_cast<Allocator&>(*this), ptr,
+                                                        std::forward<Args>(args)...);
+        }
+
+        GSL_CONSTEXPR_SINCE_CPP20 void destroy(pointer ptr)
+        {
+            std::allocator_traits<Allocator>::destroy(static_cast<Allocator&>(*this), ptr);
+        }
+
+        GSL_CONSTEXPR_SINCE_CPP20 void destroy_range(pointer first, pointer last)
+        {
+            for (; first != last; ++first) {
+                destroy(first);
+            }
+        }
+
+        GSL_CONSTEXPR_SINCE_CPP20 void rollback_construction(pointer first, pointer last)
+        {
+            destroy_range(first, last);
+            std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data, _count);
+            _data = nullptr;
+            _count = 0;
+        }
+
     protected:
         constexpr auto data() const { return _data; }
 
         constexpr auto count() const { return _count; }
+
+        GSL_CONSTEXPR_SINCE_CPP20 void fill(pointer first, size_type count, const T& value)
+        {
+            pointer current = first;
+            try {
+                for (size_type i = 0; i < count; ++i, ++current) {
+                    construct(current, value);
+                }
+            }
+            catch (...) {
+                rollback_construction(first, current);
+                throw;
+            }
+        }
+
+        template <typename InputIt>
+        GSL_CONSTEXPR_SINCE_CPP20 void copy(InputIt first, InputIt last, pointer output)
+        {
+            pointer current = output;
+            try {
+                for (; first != last; ++first, ++current) {
+                    construct(current, *first);
+                }
+            }
+            catch (...) {
+                rollback_construction(output, current);
+                throw;
+            }
+        }
 
     private:
         pointer _data;
@@ -67,6 +124,9 @@ namespace details
         GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
         {
             if (_data) {
+                if (!std::is_trivially_destructible<T>::value) {
+                    destroy_range(_data, _data + _count);
+                }
                 std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data, _count);
             }
         }
@@ -226,14 +286,14 @@ public:
     constexpr dyn_array(size_type count, const T& value, const Allocator& alloc = {})
         : base{count, alloc}
     {
-        std::fill(begin(), end(), value);
+        base::fill(data(), size(), value);
     }
 
     GSL_TYPE_IS_ITERATOR(InputIt)
     constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {})
         : base{gsl::narrow<size_type>(std::distance(first, last)), alloc}
     {
-        std::copy(first, last, begin());
+        base::copy(first, last, data());
     }
 
 #ifdef GSL_HAS_CONTAINER_RANGES
@@ -242,7 +302,7 @@ public:
     constexpr dyn_array(std::from_range_t, InputRg&& rg, const Allocator& alloc = {})
         : base{gsl::narrow<size_type>(std::size(rg)), alloc}
     {
-        std::ranges::copy(rg, std::ranges::begin(*this));
+        base::copy(std::ranges::begin(rg), std::ranges::end(rg), data());
     }
 #endif /* GSL_HAS_RANGES */
 

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -112,6 +112,19 @@ namespace details
             }
         }
 
+        void default_construct(pointer first, size_type count) {
+            pointer current = first;
+            try {
+                for (size_type i = 0; i < count; ++i, ++current) {
+                    construct(current);
+                }
+            }
+            catch (...) {
+                rollback_construction(first, current);
+                throw;
+            }
+        }
+
         void swap(dyn_array_base& other) {
             auto old_count = _count;
             auto old_data = _data;
@@ -248,12 +261,13 @@ namespace details
 
         constexpr auto operator+(difference_type diff) const
         {
-            return dyn_array_iterator{_ptr, _pos + gsl::narrow<size_type>(diff), _end_pos};
+            auto new_pos = gsl::narrow<difference_type>(_pos) + diff;
+            return dyn_array_iterator{_ptr, gsl::narrow<size_type>(new_pos), _end_pos};
         }
 
         constexpr auto operator-(difference_type diff) const
         {
-            return dyn_array_iterator{_ptr, _pos - gsl::narrow<size_type>(diff), _end_pos};
+            return *this + (-diff);
         }
 
         constexpr auto operator-(const dyn_array_iterator& other) const
@@ -339,8 +353,10 @@ public:
 #endif /* GSL_HAS_RANGES */
 
     constexpr explicit dyn_array(size_type count, const Allocator& alloc = {})
-        : dyn_array{count, T{}, alloc}
-    {}
+        : base{count, alloc}
+    {
+        base::default_construct(data(), size());
+    }
 
     constexpr dyn_array(const dyn_array& other, const Allocator& alloc = {})
         : dyn_array(other.begin(), other.end(), alloc)
@@ -351,7 +367,7 @@ public:
     {}
 
     constexpr auto operator=(const dyn_array& other) -> dyn_array& {
-        dyn_array tmp{other};
+        dyn_array tmp{other, get_allocator()};
         swap(tmp);
         return *this;
     }

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -68,10 +68,20 @@ namespace details
             _count = 0;
         }
 
-    protected:
+        protected:
         constexpr auto data() const { return _data; }
 
         constexpr auto count() const { return _count; }
+
+        void resize(size_type count) {
+            // This should only be called when constructing a non-forward iteartor.
+            // It neither frees nor copies `_data`.
+            Expects(_data == nullptr && _count == 0);
+            if (count != 0) {
+                _data = std::allocator_traits<Allocator>::allocate(static_cast<Allocator&>(*this), count);
+                _count = count;
+            }
+        }
 
         GSL_CONSTEXPR_SINCE_CPP20 void fill(pointer first, size_type count, const T& value)
         {
@@ -100,6 +110,15 @@ namespace details
                 rollback_construction(output, current);
                 throw;
             }
+        }
+
+        void swap(dyn_array_base& other) {
+            auto old_count = _count;
+            auto old_data = _data;
+            _count = other._count;
+            _data = other._data;
+            other._count = old_count;
+            other._data = old_data;
         }
 
     private:
@@ -234,7 +253,7 @@ namespace details
 
         constexpr auto operator-(difference_type diff) const
         {
-            return dyn_array_iterator{_ptr, _pos + gsl::narrow<size_type>(diff), _end_pos};
+            return dyn_array_iterator{_ptr, _pos - gsl::narrow<size_type>(diff), _end_pos};
         }
 
         constexpr auto operator-(const dyn_array_iterator& other) const
@@ -268,6 +287,11 @@ class dyn_array : private details::dyn_array_base<T, Allocator>
     using base = details::dyn_array_base<T, Allocator>;
     using pointer = T*;
 
+    constexpr void swap(dyn_array& other) {
+        // TODO (@carsonradtke): This was not in the spec, should it have been?
+        base::swap(other);
+    }
+
 public:
     using value_type = T;
     using reference = T&;
@@ -289,11 +313,19 @@ public:
         base::fill(data(), size(), value);
     }
 
-    GSL_TYPE_IS_ITERATOR(InputIt)
+    template <typename InputIt, std::enable_if_t<details::is_fwd_iterator<InputIt>::value, bool> = true>
     constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {})
         : base{gsl::narrow<size_type>(std::distance(first, last)), alloc}
     {
         base::copy(first, last, data());
+    }
+
+    template <typename InputIt, std::enable_if_t<!details::is_fwd_iterator<InputIt>::value && details::is_iterator<InputIt>::value, bool> = true>
+    constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc={}) : dyn_array{alloc} {
+        // TODO (@carsonradtke): Can this be done better?
+        std::vector<T> tmp(first, last);
+        base::resize(tmp.size());
+        base::copy(std::begin(tmp), std::end(tmp), data());
     }
 
 #ifdef GSL_HAS_CONTAINER_RANGES
@@ -318,7 +350,11 @@ public:
         : dyn_array(init.begin(), init.end(), alloc)
     {}
 
-    constexpr auto operator=(const dyn_array& other) -> dyn_array& { return dyn_array{other}; }
+    constexpr auto operator=(const dyn_array& other) -> dyn_array& {
+        auto tmp = dyn_array{other};
+        swap(tmp);
+        return *this;
+    }
 
     constexpr dyn_array(dyn_array&&) = delete;
     dyn_array& operator=(dyn_array&&) = delete;
@@ -362,7 +398,7 @@ public:
 
 #ifdef _MSC_VER
     constexpr auto _Unchecked_begin() { return data(); }
-    constexpr auto _Unchecked_begin() const -> const pointer
+    constexpr auto _Unchecked_begin() const -> const T*
     {
         return const_cast<dyn_array&>(*this)._Unchecked_begin();
     }
@@ -378,7 +414,7 @@ public:
 
 #ifdef _MSC_VER
     constexpr auto _Unchecked_end() { return data() + size(); }
-    constexpr auto _Unchecked_end() const -> const pointer
+    constexpr auto _Unchecked_end() const -> const T*
     {
         return const_cast<dyn_array&>(*this)._Unchecked_end();
     }

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -27,9 +27,9 @@
 #include <memory>
 #include <type_traits>
 
-#ifdef GSL_HAS_RANGES
+#if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
 #include <ranges>
-#endif /* GSL_HAS_RANGES */
+#endif /* __cpp_lib_ranges >= 201911L */
 
 namespace gsl
 {
@@ -177,9 +177,9 @@ namespace details
         using const_reference = const T&;
         using iterator_category = std::random_access_iterator_tag;
 
-#ifdef GSL_HAS_RANGES
+#if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
         constexpr dyn_array_iterator() = default;
-#endif /* GSL_HAS_RANGES */
+#endif /* __cpp_lib_ranges >= 201911L */
 
         constexpr dyn_array_iterator(pointer ptr, size_type pos, size_type end_pos)
             : _ptr{ptr}, _pos{pos}, _end_pos{end_pos}
@@ -188,9 +188,9 @@ namespace details
             Ensures(_pos <= _end_pos);
         }
 
-#if defined(_MSC_VER) && defined(GSL_HAS_RANGES)
+#if defined(_MSC_VER) && defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
         constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }
-#endif /* defined(_MSC_VER) && defined(GSL_HAS_RANGES) */
+#endif /* defined(_MSC_VER) && __cpp_lib_ranges >= 201911L */
 
         constexpr auto operator==(const dyn_array_iterator& other) const
         {
@@ -338,7 +338,7 @@ public:
         base::copy(std::begin(tmp), std::end(tmp), data());
     }
 
-#ifdef GSL_HAS_CONTAINER_RANGES
+#if defined(__cpp_lib_containers_ranges) && (__cpp_lib_containers_ranges >= 202202L)
     template <typename InputRg>
         requires(std::ranges::input_range<InputRg>)
     constexpr dyn_array(std::from_range_t, InputRg&& rg, const Allocator& alloc = {})
@@ -346,7 +346,7 @@ public:
     {
         base::copy(std::ranges::begin(rg), std::ranges::end(rg), data());
     }
-#endif /* GSL_HAS_CONTAINER_RANGES */
+#endif /* __cpp_lib_containers_ranges >= 202202L */
 
     constexpr explicit dyn_array(size_type count, const Allocator& alloc = {})
         : base{count, alloc}
@@ -433,21 +433,21 @@ public:
 #endif /* _MSC_VER */
 };
 
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
 template <class InputIt,
           class Alloc = std::allocator<typename std::iterator_traits<InputIt>::value_type>>
 dyn_array(InputIt, InputIt,
           Alloc = {}) -> dyn_array<typename std::iterator_traits<InputIt>::value_type, Alloc>;
 
-#ifdef GSL_HAS_CONTAINER_RANGES
+#if defined(__cpp_lib_containers_ranges) && (__cpp_lib_containers_ranges >= 202202L)
 template <std::ranges::input_range InputRg,
           class Alloc = std::allocator<std::ranges::range_value_t<InputRg>>>
 dyn_array(std::from_range_t, InputRg&&,
           Alloc = {}) -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
-#endif /* GSL_HAS_CONTAINER_RANGES */
+#endif /* __cpp_lib_containers_ranges >= 202202L */
 
-#endif /* GSL_HAS_DEDUCTION_GUIDES */
+#endif /* __cpp_deduction_guides >= 201703L */
 } // namespace gsl
 
 #endif /* defined(GSL_DYN_ARRAY_H) */

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -55,30 +55,32 @@ namespace details
 
         GSL_CONSTEXPR_SINCE_CPP20 void destroy_range(pointer first, pointer last)
         {
-            for (; first != last; ++first) {
-                destroy(first);
-            }
+            for (; first != last; ++first) { destroy(first); }
         }
 
         GSL_CONSTEXPR_SINCE_CPP20 void rollback_construction(pointer first, pointer last)
         {
             destroy_range(first, last);
-            std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data, _count);
+            std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data,
+                                                         _count);
             _data = nullptr;
             _count = 0;
         }
 
-        protected:
+    protected:
         constexpr auto data() const { return _data; }
 
         constexpr auto count() const { return _count; }
 
-        GSL_CONSTEXPR_SINCE_CPP20 void resize(size_type count) {
+        GSL_CONSTEXPR_SINCE_CPP20 void resize(size_type count)
+        {
             // This should only be called when constructing a non-forward iterator.
             // It neither frees nor copies `_data`.
             Expects(_data == nullptr && _count == 0);
-            if (count != 0) {
-                _data = std::allocator_traits<Allocator>::allocate(static_cast<Allocator&>(*this), count);
+            if (count != 0)
+            {
+                _data = std::allocator_traits<Allocator>::allocate(static_cast<Allocator&>(*this),
+                                                                   count);
                 _count = count;
             }
         }
@@ -86,12 +88,11 @@ namespace details
         GSL_CONSTEXPR_SINCE_CPP20 void fill(pointer first, size_type count, const T& value)
         {
             pointer current = first;
-            try {
-                for (size_type i = 0; i < count; ++i, ++current) {
-                    construct(current, value);
-                }
-            }
-            catch (...) {
+            try
+            {
+                for (size_type i = 0; i < count; ++i, ++current) { construct(current, value); }
+            } catch (...)
+            {
                 rollback_construction(first, current);
                 throw;
             }
@@ -101,31 +102,30 @@ namespace details
         GSL_CONSTEXPR_SINCE_CPP20 void copy(InputIt first, InputIt last, pointer output)
         {
             pointer current = output;
-            try {
-                for (; first != last; ++first, ++current) {
-                    construct(current, *first);
-                }
-            }
-            catch (...) {
+            try
+            {
+                for (; first != last; ++first, ++current) { construct(current, *first); }
+            } catch (...)
+            {
                 rollback_construction(output, current);
                 throw;
             }
         }
 
-        GSL_CONSTEXPR_SINCE_CPP20 void default_construct(pointer first, size_type count) {
+        GSL_CONSTEXPR_SINCE_CPP20 void default_construct(pointer first, size_type count)
+        {
             pointer current = first;
-            try {
-                for (size_type i = 0; i < count; ++i, ++current) {
-                    construct(current);
-                }
-            }
-            catch (...) {
+            try
+            {
+                for (size_type i = 0; i < count; ++i, ++current) { construct(current); }
+            } catch (...)
+            {
                 rollback_construction(first, current);
                 throw;
             }
         }
 
-        private:
+    private:
         pointer _data;
         size_type _count;
 
@@ -137,20 +137,25 @@ namespace details
         }
 
         constexpr dyn_array_base(size_type count, const Allocator& alloc)
-            : Allocator{alloc},
-            _data{count == 0 ? nullptr : std::allocator_traits<Allocator>::allocate(static_cast<Allocator&>(*this), count)},
-            _count{count}
+            : Allocator{alloc}
+            , _data{count == 0 ? nullptr
+                               : std::allocator_traits<Allocator>::allocate(
+                                     static_cast<Allocator&>(*this), count)}
+            , _count{count}
         {
             Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
         }
 
         GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
         {
-            if (_data) {
-                if (!std::is_trivially_destructible<T>::value) {
+            if (_data)
+            {
+                if (!std::is_trivially_destructible<T>::value)
+                {
                     destroy_range(_data, _data + _count);
                 }
-                std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data, _count);
+                std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data,
+                                                             _count);
             }
         }
     };
@@ -254,10 +259,7 @@ namespace details
             return dyn_array_iterator{_ptr, gsl::narrow<size_type>(new_pos), _end_pos};
         }
 
-        constexpr auto operator-(difference_type diff) const
-        {
-            return *this + (-diff);
-        }
+        constexpr auto operator-(difference_type diff) const { return *this + (-diff); }
 
         constexpr auto operator-(const dyn_array_iterator& other) const
         {
@@ -311,15 +313,19 @@ public:
         base::fill(data(), size(), value);
     }
 
-    template <typename InputIt, std::enable_if_t<details::is_fwd_iterator<InputIt>::value, bool> = true>
+    template <typename InputIt,
+              std::enable_if_t<details::is_fwd_iterator<InputIt>::value, bool> = true>
     constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {})
         : base{gsl::narrow<size_type>(std::distance(first, last)), alloc}
     {
         base::copy(first, last, data());
     }
 
-    template <typename InputIt, std::enable_if_t<!details::is_fwd_iterator<InputIt>::value && details::is_iterator<InputIt>::value, bool> = true>
-    constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc={}) : dyn_array{alloc} {
+    template <typename InputIt, std::enable_if_t<!details::is_fwd_iterator<InputIt>::value &&
+                                                     details::is_iterator<InputIt>::value,
+                                                 bool> = true>
+    constexpr dyn_array(InputIt first, InputIt last, const Allocator& alloc = {}) : dyn_array{alloc}
+    {
         std::vector<T> tmp(first, last);
         base::resize(tmp.size());
         base::copy(std::begin(tmp), std::end(tmp), data());
@@ -335,8 +341,7 @@ public:
     }
 #endif /* __cpp_lib_containers_ranges >= 202202L */
 
-    constexpr explicit dyn_array(size_type count, const Allocator& alloc = {})
-        : base{count, alloc}
+    constexpr explicit dyn_array(size_type count, const Allocator& alloc = {}) : base{count, alloc}
     {
         base::default_construct(data(), size());
     }
@@ -418,14 +423,14 @@ public:
 
 template <class InputIt,
           class Alloc = std::allocator<typename std::iterator_traits<InputIt>::value_type>>
-dyn_array(InputIt, InputIt,
-          Alloc = {}) -> dyn_array<typename std::iterator_traits<InputIt>::value_type, Alloc>;
+dyn_array(InputIt, InputIt, Alloc = {})
+    -> dyn_array<typename std::iterator_traits<InputIt>::value_type, Alloc>;
 
 #if defined(__cpp_lib_containers_ranges) && (__cpp_lib_containers_ranges >= 202202L)
 template <std::ranges::input_range InputRg,
           class Alloc = std::allocator<std::ranges::range_value_t<InputRg>>>
-dyn_array(std::from_range_t, InputRg&&,
-          Alloc = {}) -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
+dyn_array(std::from_range_t, InputRg&&, Alloc = {})
+    -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
 #endif /* __cpp_lib_containers_ranges >= 202202L */
 
 #endif /* __cpp_deduction_guides >= 201703L */

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -351,7 +351,7 @@ public:
     {}
 
     constexpr auto operator=(const dyn_array& other) -> dyn_array& {
-        auto tmp = dyn_array{other};
+        dyn_array tmp{other};
         swap(tmp);
         return *this;
     }

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -51,33 +51,31 @@ namespace details
         using pointer = typename dyn_array_traits<T>::pointer;
         using size_type = typename dyn_array_traits<T>::size_type;
 
-        protected:
-        const class dyn_array_impl
-        {
-        public:
-            constexpr dyn_array_impl(pointer data, size_type count) : _data{data}, _count{count}
-            {
-                Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
-            }
+    protected:
+        constexpr auto data() const { return _data; }
 
-            constexpr auto data() const { return _data; }
+        constexpr auto count() const { return _count; }
 
-            constexpr auto count() const { return _count; }
-
-        private:
-            pointer _data;
-            size_type _count;
-        } _impl;
+    private:
+        pointer _data;
+        size_type _count;
 
     public:
-        constexpr dyn_array_base(const Allocator& alloc) : Allocator{alloc}, _impl{nullptr, 0} {}
+        constexpr dyn_array_base(const Allocator& alloc)
+            : Allocator{alloc}, _data{nullptr}, _count{0}
+        {
+            Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
+        }
+
         constexpr dyn_array_base(size_type count, const Allocator& alloc)
-            : Allocator{alloc}, _impl{count == 0 ? nullptr : Allocator::allocate(count), count}
-        {}
+            : Allocator{alloc}, _data{count == 0 ? nullptr : Allocator::allocate(count)}, _count{count}
+        {
+            Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
+        }
 
         GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
         {
-            if (_impl.data()) Allocator::deallocate(_impl.data(), _impl.count());
+            if (_data) Allocator::deallocate(_data, _count);
         }
     };
 
@@ -279,7 +277,7 @@ public:
 
     constexpr auto operator!=(const dyn_array& other) const { return !(*this == other); }
 
-    constexpr auto size() const { return base::_impl.count(); }
+    constexpr auto size() const { return base::count(); }
 
     constexpr auto empty() const { return size() == 0; }
 
@@ -298,7 +296,7 @@ public:
         return const_cast<dyn_array&>(*this)[pos];
     }
 
-    constexpr auto data() { return base::_impl.data(); }
+    constexpr auto data() { return base::data(); }
     constexpr auto data() const -> const T* { return const_cast<dyn_array&>(*this).data(); }
 
     constexpr auto begin() { return iterator{data(), 0, size()}; }

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -74,7 +74,7 @@ namespace details
         constexpr auto count() const { return _count; }
 
         GSL_CONSTEXPR_SINCE_CPP20 void resize(size_type count) {
-            // This should only be called when constructing a non-forward iteartor.
+            // This should only be called when constructing a non-forward iterator.
             // It neither frees nor copies `_data`.
             Expects(_data == nullptr && _count == 0);
             if (count != 0) {
@@ -190,7 +190,7 @@ namespace details
 
 #if defined(_MSC_VER) && defined(GSL_HAS_RANGES)
         // TODO (@carsonradtke): Investigate why this is necessary for MSVC.
-        // Is it a a bug in GSL? STL? MSVC?
+        // Is it a bug in GSL? STL? MSVC?
         constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }
 #endif /* defined(_MSC_VER) && defined(GSL_HAS_RANGES) */
 
@@ -350,7 +350,7 @@ public:
     {
         base::copy(std::ranges::begin(rg), std::ranges::end(rg), data());
     }
-#endif /* GSL_HAS_RANGES */
+#endif /* GSL_HAS_CONTAINER_RANGES */
 
     constexpr explicit dyn_array(size_type count, const Allocator& alloc = {})
         : base{count, alloc}
@@ -434,7 +434,7 @@ public:
     {
         return const_cast<dyn_array&>(*this)._Unchecked_end();
     }
-#endif /* MSC_VER */
+#endif /* _MSC_VER */
 };
 
 #ifdef GSL_HAS_DEDUCTION_GUIDES
@@ -449,7 +449,7 @@ template <std::ranges::input_range InputRg,
           class Alloc = std::allocator<std::ranges::range_value_t<InputRg>>>
 dyn_array(std::from_range_t, InputRg&&,
           Alloc = {}) -> dyn_array<std::ranges::range_value_t<InputRg>, Alloc>;
-#endif /* GSL_HAS_RANGES */
+#endif /* GSL_HAS_CONTAINER_RANGES */
 
 #endif /* GSL_HAS_DEDUCTION_GUIDES */
 } // namespace gsl

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -57,14 +57,18 @@ namespace details
         }
 
         constexpr dyn_array_base(size_type count, const Allocator& alloc)
-            : Allocator{alloc}, _data{count == 0 ? nullptr : Allocator::allocate(count)}, _count{count}
+            : Allocator{alloc},
+            _data{count == 0 ? nullptr : std::allocator_traits<Allocator>::allocate(static_cast<Allocator&>(*this), count)},
+            _count{count}
         {
             Ensures((_count == 0 && _data == nullptr) || (_count > 0 && _data != nullptr));
         }
 
         GSL_CONSTEXPR_SINCE_CPP20 ~dyn_array_base()
         {
-            if (_data) Allocator::deallocate(_data, _count);
+            if (_data) {
+                std::allocator_traits<Allocator>::deallocate(static_cast<Allocator&>(*this), _data, _count);
+            }
         }
     };
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -358,7 +358,7 @@ auto make_strict_not_null(T&& t) noexcept
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
 // deduction guides to prevent the ctad-maybe-unsupported warning
 template <class T>
@@ -366,7 +366,7 @@ not_null(T) -> not_null<T>;
 template <class T>
 strict_not_null(T) -> strict_not_null<T>;
 
-#endif // GSL_HAS_DEDUCTION_GUIDES
+#endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
 } // namespace gsl
 

--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Copyright (c) 2015 Microsoft Corporation. All rights reserved.
@@ -357,7 +358,7 @@ auto make_strict_not_null(T&& t) noexcept
     return strict_not_null<std::remove_cv_t<std::remove_reference_t<T>>>{std::forward<T>(t)};
 }
 
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#ifdef GSL_HAS_DEDUCTION_GUIDES
 
 // deduction guides to prevent the ctad-maybe-unsupported warning
 template <class T>
@@ -365,7 +366,7 @@ not_null(T) -> not_null<T>;
 template <class T>
 strict_not_null(T) -> strict_not_null<T>;
 
-#endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
+#endif // GSL_HAS_DEDUCTION_GUIDES
 
 } // namespace gsl
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Copyright (c) 2015 Microsoft Corporation. All rights reserved.
@@ -747,7 +748,7 @@ private:
     }
 };
 
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#ifdef GSL_HAS_DEDUCTION_GUIDES
 
 // Deduction Guides
 template <class Type, std::size_t Extent>
@@ -767,7 +768,7 @@ template <class Container,
           class Element = std::remove_pointer_t<decltype(std::declval<const Container&>().data())>>
 span(const Container&) -> span<Element>;
 
-#endif // ( defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L) )
+#endif // GSL_HAS_DEDUCTION_GUIDES
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
 #if defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -748,7 +748,7 @@ private:
     }
 };
 
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
 // Deduction Guides
 template <class Type, std::size_t Extent>
@@ -768,7 +768,7 @@ template <class Container,
           class Element = std::remove_pointer_t<decltype(std::declval<const Container&>().data())>>
 span(const Container&) -> span<Element>;
 
-#endif // GSL_HAS_DEDUCTION_GUIDES
+#endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
 #if defined(GSL_USE_STATIC_CONSTEXPR_WORKAROUND)
 #if defined(__clang__) && defined(_MSC_VER) && defined(__cplusplus) && (__cplusplus < 201703L)

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -113,7 +113,7 @@
     template <typename Ty>                                                                         \
         requires(std::input_iterator<Ty>)
 #else // ^^^ since C++20 /// before C++20 vvv
-#define GSL_UNTIL_CPP20
+#define GSL_BEFORE_CPP20
 #define GSL_CONSTEXPR_SINCE_CPP20
 #define GSL_TYPE_IS_ITERATOR(Ty)                                                                   \
     template <typename Ty, std::enable_if_t<details::is_iterator<Ty>::value, bool> = true>
@@ -128,7 +128,7 @@ namespace gsl
 // index type for all container indexes/subscripts/sizes
 using index = std::ptrdiff_t;
 
-#ifdef GSL_UNTIL_CPP20
+#ifdef GSL_BEFORE_CPP20
 namespace details
 {
     template <typename ...>
@@ -142,7 +142,7 @@ namespace details
     struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>>
         : std::true_type {};
 } // namespace details
-#endif /* GSL_UNTIL_CPP20 */
+#endif /* GSL_BEFORE_CPP20 */
 
 // final_action allows you to ensure something gets run at the end of a scope
 template <class F>

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -109,14 +109,9 @@
 
 #if __cplusplus >= 202002L
 #define GSL_CONSTEXPR_SINCE_CPP20 constexpr
-#define GSL_TYPE_IS_ITERATOR(Ty)                                                                   \
-    template <typename Ty>                                                                         \
-        requires(std::input_iterator<Ty>)
 #else // ^^^ since C++20 /// before C++20 vvv
 #define GSL_BEFORE_CPP20
 #define GSL_CONSTEXPR_SINCE_CPP20
-#define GSL_TYPE_IS_ITERATOR(Ty)                                                                   \
-    template <typename Ty, std::enable_if_t<details::is_iterator<Ty>::value, bool> = true>
 #endif // __cplusplus >= 202002L
 
 namespace gsl
@@ -128,21 +123,26 @@ namespace gsl
 // index type for all container indexes/subscripts/sizes
 using index = std::ptrdiff_t;
 
-#ifdef GSL_BEFORE_CPP20
 namespace details
 {
     template <typename ...>
     using void_t = void;
 
     template <typename T, typename = void>
-    struct is_iterator : std::false_type
+    struct is_iterator : std::false_type {};
+
+    template <typename T>
+    struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>>
+        : std::true_type {};
+
+    template <typename T, typename = void>
+    struct is_fwd_iterator : std::false_type
     {};
 
    template <typename T>
-    struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>>
-        : std::true_type {};
+    struct is_fwd_iterator<T, void_t<typename std::iterator_traits<T>::iterator_category>>
+        : std::integral_constant<bool, std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<T>::iterator_category>::value> {};
 } // namespace details
-#endif /* GSL_BEFORE_CPP20 */
 
 // final_action allows you to ensure something gets run at the end of a scope
 template <class F>

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -87,26 +87,6 @@
 #define GSL_DEPRECATED(msg)
 #endif // !defined(GSL_DEPRECATED)
 
-#if (defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703L)
-#define GSL_HAS_DEDUCTION_GUIDES
-#endif // (defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703L)
-
-#if (defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L)
-#define GSL_HAS_RANGES
-#endif // (defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L)
-
-#if (defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L)
-#define GSL_HAS_CONTAINER_RANGES
-#endif // (defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L)
-
-#if (defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L)
-#define GSL_HAS_CONCEPTS
-#endif // (defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L)
-
-#if (defined(__cpp_lib_constexpr_dynamic_alloc) && __cpp_lib_constexpr_dynamic_alloc >= 201907L)
-#define GSL_HAS_CONSTEXPR_ALLOCATOR
-#endif // (defined(__cpp_lib_constexpr_dynamic_alloc) && __cpp_lib_constexpr_dynamic_alloc >= 201907L)
-
 #if __cplusplus >= 202002L
 #define GSL_CONSTEXPR_SINCE_CPP20 constexpr
 #else // ^^^ since C++20 /// before C++20 vvv

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -116,10 +116,9 @@ namespace details
         : std::true_type {};
 
     template <typename T, typename = void>
-    struct is_fwd_iterator : std::false_type
-    {};
-
-   template <typename T>
+    struct is_fwd_iterator : std::false_type {};
+    
+    template <typename T>
     struct is_fwd_iterator<T, void_t<typename std::iterator_traits<T>::iterator_category>>
         : std::integral_constant<bool, std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<T>::iterator_category>::value> {};
 } // namespace details

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Copyright (c) 2015 Microsoft Corporation. All rights reserved.
@@ -19,10 +20,10 @@
 
 #include "./assert" // for Expects
 
-#include <array>
 #include <cstddef>          // for ptrdiff_t, size_t
-#include <initializer_list> // for initializer_list
 #include <limits>           // for numeric_limits
+#include <initializer_list> // for initializer_list
+#include <iterator>         // for is_iterator, iterator_traits
 #include <type_traits>      // for is_signed, integral_constant
 #include <utility>          // for exchange, forward
 
@@ -86,6 +87,38 @@
 #define GSL_DEPRECATED(msg)
 #endif // !defined(GSL_DEPRECATED)
 
+#if (defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703L)
+#define GSL_HAS_DEDUCTION_GUIDES
+#endif // (defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703L)
+
+#if (defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L)
+#define GSL_HAS_RANGES
+#endif // (defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L)
+
+#if (defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L)
+#define GSL_HAS_CONTAINER_RANGES
+#endif // (defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L)
+
+#if (defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L)
+#define GSL_HAS_CONCEPTS
+#endif // (defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L)
+
+#if (defined(__cpp_lib_constexpr_dynamic_alloc) && __cpp_lib_constexpr_dynamic_alloc >= 201907L)
+#define GSL_HAS_CONSTEXPR_ALLOCATOR
+#endif // (defined(__cpp_lib_constexpr_dynamic_alloc) && __cpp_lib_constexpr_dynamic_alloc >= 201907L)
+
+#if __cplusplus >= 202002L
+#define GSL_CONSTEXPR_SINCE_CPP20 constexpr
+#define GSL_TYPE_IS_ITERATOR(Ty)                                                                   \
+    template <typename Ty>                                                                         \
+        requires(std::input_iterator<Ty>)
+#else // ^^^ since C++20 /// before C++20 vvv
+#define GSL_UNTIL_CPP20
+#define GSL_CONSTEXPR_SINCE_CPP20
+#define GSL_TYPE_IS_ITERATOR(Ty)                                                                   \
+    template <typename Ty, std::enable_if_t<details::is_iterator<Ty>::value, bool> = true>
+#endif // __cplusplus >= 202002L
+
 namespace gsl
 {
 //
@@ -94,6 +127,22 @@ namespace gsl
 
 // index type for all container indexes/subscripts/sizes
 using index = std::ptrdiff_t;
+
+#ifdef GSL_UNTIL_CPP20
+namespace details
+{
+    template <typename ...>
+    using void_t = void;
+
+    template <typename T, typename = void>
+    struct is_iterator : std::false_type
+    {};
+
+   template <typename T>
+    struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>>
+        : std::true_type {};
+} // namespace details
+#endif /* GSL_UNTIL_CPP20 */
 
 // final_action allows you to ensure something gets run at the end of a scope
 template <class F>

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -23,7 +23,7 @@
 #include <cstddef>          // for ptrdiff_t, size_t
 #include <limits>           // for numeric_limits
 #include <initializer_list> // for initializer_list
-#include <iterator>         // for is_iterator, iterator_traits
+#include <iterator>         // for iterator_traits
 #include <type_traits>      // for is_signed, integral_constant
 #include <utility>          // for exchange, forward
 

--- a/include/gsl/util
+++ b/include/gsl/util
@@ -21,9 +21,9 @@
 #include "./assert" // for Expects
 
 #include <cstddef>          // for ptrdiff_t, size_t
-#include <limits>           // for numeric_limits
 #include <initializer_list> // for initializer_list
 #include <iterator>         // for iterator_traits
+#include <limits>           // for numeric_limits
 #include <type_traits>      // for is_signed, integral_constant
 #include <utility>          // for exchange, forward
 
@@ -105,22 +105,31 @@ using index = std::ptrdiff_t;
 
 namespace details
 {
-    template <typename ...>
+    template <typename...>
     using void_t = void;
 
     template <typename T, typename = void>
-    struct is_iterator : std::false_type {};
+    struct is_iterator : std::false_type
+    {
+    };
 
     template <typename T>
-    struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>>
-        : std::true_type {};
+    struct is_iterator<T, void_t<typename std::iterator_traits<T>::value_type>> : std::true_type
+    {
+    };
 
     template <typename T, typename = void>
-    struct is_fwd_iterator : std::false_type {};
-    
+    struct is_fwd_iterator : std::false_type
+    {
+    };
+
     template <typename T>
     struct is_fwd_iterator<T, void_t<typename std::iterator_traits<T>::iterator_category>>
-        : std::integral_constant<bool, std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<T>::iterator_category>::value> {};
+        : std::integral_constant<
+              bool, std::is_base_of<std::forward_iterator_tag,
+                                    typename std::iterator_traits<T>::iterator_category>::value>
+    {
+    };
 } // namespace details
 
 // final_action allows you to ensure something gets run at the end of a scope

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,10 @@ include(CheckCXXCompilerFlag)
 # please try to keep entries ordered =)
 add_library(gsl_tests_config INTERFACE)
 if(MSVC) # MSVC or simulating MSVC
+    set(CMAKE_VS_GLOBALS
+        "EnableMicrosoftCodeAnalysis=true"
+        "CodeAnalysisRuleSet=AllRules.ruleset"
+    )
     target_compile_options(gsl_tests_config INTERFACE
         ${GSL_CPLUSPLUS_OPT}
         /EHsc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,7 @@ else()
           -Wno-unknown-attributes
           -Wno-used-but-marked-unused # GTest EXPECT_DEATH
           -Wno-weak-vtables
+          -Wno-poison-system-directories
           $<$<EQUAL:${GSL_CXX_STANDARD},14>: # no support for [[maybe_unused]]
             -Wno-unused-member-function
             -Wno-unused-variable
@@ -280,6 +281,7 @@ else()
           -Wno-missing-prototypes
           -Wno-unknown-attributes
           -Wno-weak-vtables
+          -Wno-poison-system-directories
         >
         $<$<CXX_COMPILER_ID:GNU>:
           -Wdouble-promotion # float implicit to double

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,10 +76,6 @@ include(CheckCXXCompilerFlag)
 # please try to keep entries ordered =)
 add_library(gsl_tests_config INTERFACE)
 if(MSVC) # MSVC or simulating MSVC
-    set(CMAKE_VS_GLOBALS
-        "EnableMicrosoftCodeAnalysis=true"
-        "CodeAnalysisRuleSet=AllRules.ruleset"
-    )
     target_compile_options(gsl_tests_config INTERFACE
         ${GSL_CPLUSPLUS_OPT}
         /EHsc

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -1,0 +1,290 @@
+#include <gtest/gtest.h>
+
+#include <gsl/dyn_array>
+#include <gsl/util>
+
+// Despite using <algorithm> and <ranges> utilities in this test, they
+// are not being included directly by this file as a test to ensure
+// transitive inclusion via <gsl/dyn_array>.
+
+static_assert(sizeof(gsl::dyn_array<int>) == 2 * sizeof(void*),
+              "gsl::dyn_array (with the default allocator) should be 16 bytes");
+
+#ifdef GSL_HAS_CONCEPTS
+static_assert(std::input_iterator<gsl::dyn_array<int>::iterator>,
+              "gsl_dyn_array should expose a valid input_iterator");
+#endif /* GSL_HAS_CONCEPTS */
+
+#ifdef GSL_HAS_RANGES
+static_assert(std::ranges::input_range<gsl::dyn_array<int>>,
+              "gsl::dyn_array should be a valid input range");
+#endif /* GSL_HAS_RANGES */
+
+TEST(dyn_array_tests, default_ctor)
+{
+    gsl::dyn_array<char> diamondbacks;
+    EXPECT_TRUE(diamondbacks.empty());
+    EXPECT_EQ(diamondbacks.size(), 0);
+    EXPECT_EQ(diamondbacks.data(), nullptr);
+}
+
+TEST(dyn_array_tests, count_ctor)
+{
+    gsl::dyn_array<char> athletics(10);
+    EXPECT_FALSE(athletics.empty());
+    EXPECT_EQ(athletics.size(), 10);
+    EXPECT_NE(athletics.data(), nullptr);
+
+    gsl::dyn_array<char> braves(0);
+    EXPECT_TRUE(braves.empty());
+    EXPECT_EQ(braves.size(), 0);
+    EXPECT_EQ(braves.data(), nullptr);
+    EXPECT_TRUE(std::all_of(braves.begin(), braves.end(), [](char c) { return c == char{}; }));
+}
+
+TEST(dyn_array_tests, count_value_ctor)
+{
+    gsl::dyn_array<char> orioles(10, 'c');
+    EXPECT_FALSE(orioles.empty());
+    EXPECT_EQ(orioles.size(), 10);
+    EXPECT_NE(orioles.data(), nullptr);
+    EXPECT_TRUE(std::all_of(orioles.begin(), orioles.end(), [](char c) { return c == 'c'; }));
+
+    gsl::dyn_array<int> redsox(10, 42);
+    EXPECT_FALSE(redsox.empty());
+    EXPECT_EQ(redsox.size(), 10);
+    EXPECT_NE(redsox.data(), nullptr);
+    EXPECT_TRUE(std::all_of(redsox.begin(), redsox.end(), [](int i) { return i == 42; }));
+}
+
+TEST(dyn_array_tests, inputit_ctor)
+{
+    std::vector<char> cubs(10, 'c');
+    gsl::dyn_array<char> whitesox(cubs.begin(), cubs.end());
+    EXPECT_FALSE(whitesox.empty());
+    EXPECT_EQ(whitesox.size(), cubs.size());
+    EXPECT_NE(whitesox.data(), nullptr);
+    EXPECT_TRUE(std::all_of(whitesox.begin(), whitesox.end(), [](char c) { return c == 'c'; }));
+}
+
+TEST(dyn_array_tests, copy_ctor)
+{
+    gsl::dyn_array<char> reds(10, 'c');
+    gsl::dyn_array<char> guardians(reds);
+    EXPECT_FALSE(guardians.empty());
+    EXPECT_EQ(guardians.size(), reds.size());
+    EXPECT_NE(guardians.data(), nullptr);
+    EXPECT_TRUE(std::all_of(guardians.begin(), guardians.end(), [](char c) { return c == 'c'; }));
+}
+
+TEST(dyn_array_tests, access_operator)
+{
+    gsl::dyn_array<char> rockies(10, 'c');
+    using ST = typename decltype(rockies)::size_type;
+    for (int i = 0; i < gsl::narrow<int>(rockies.size()); i++)
+        EXPECT_EQ(rockies[gsl::narrow<ST>(i)], 'c');
+    for (int i = 0; i < gsl::narrow<int>(rockies.size()); i++) rockies[gsl::narrow<ST>(i)] = 'r';
+    for (int i = 0; i < gsl::narrow<int>(rockies.size()); i++)
+        EXPECT_EQ(rockies[gsl::narrow<ST>(i)], 'r');
+    gsl::dyn_array<int> tigers(10);
+    for (int i = 0; i < gsl::narrow<int>(tigers.size()); i++) tigers[gsl::narrow<ST>(i)] = i;
+    for (int i = 0; i < gsl::narrow<int>(tigers.size()); i++)
+        EXPECT_EQ(tigers[gsl::narrow<ST>(i)], i);
+}
+
+TEST(dyn_array_tests, iterators)
+{
+    gsl::dyn_array<char> astros(10, 'c');
+    for (auto it = astros.begin(); it != astros.end(); it++) EXPECT_EQ(*it, 'c');
+    for (auto it = astros.begin(); it != astros.end(); it++) *it = 'r';
+    for (auto it = astros.begin(); it != astros.end(); it++) EXPECT_EQ(*it, 'r');
+    EXPECT_TRUE(std::all_of(astros.begin(), astros.end(), [](char c) { return c == 'r'; }));
+
+    gsl::dyn_array<char> royals(10, 'c');
+    for (auto it = royals.begin(); it != royals.end(); ++it) EXPECT_EQ(*it, 'c');
+    for (auto it = royals.begin(); it != royals.end(); ++it) *it = 'r';
+    for (auto it = royals.begin(); it != royals.end(); ++it) EXPECT_EQ(*it, 'r');
+    EXPECT_TRUE(std::all_of(royals.begin(), royals.end(), [](char c) { return c == 'r'; }));
+}
+
+TEST(dyn_array_tests, range_for)
+{
+    gsl::dyn_array<char> angels(10, 'c');
+    for (auto x : angels) EXPECT_EQ(x, 'c');
+    for (auto& x : angels) x = 'r';
+    for (auto x : angels) EXPECT_EQ(x, 'r');
+    EXPECT_TRUE(std::all_of(angels.begin(), angels.end(), [](char c) { return c == 'r'; }));
+}
+
+TEST(dyn_array_tests, use_std_algorithms)
+{
+    gsl::dyn_array<char> dodgers(26);
+    std::generate(dodgers.begin(), dodgers.end(), [i = 0]() mutable { return 'a' + i++; });
+    char ch = 'a';
+    for (auto x : dodgers) EXPECT_EQ(x, ch++);
+    EXPECT_EQ(std::find(dodgers.begin(), dodgers.end(), 'a'), dodgers.begin());
+    {
+        auto it = std::find(dodgers.begin(), dodgers.end(), 'c');
+        EXPECT_EQ(std::distance(dodgers.begin(), it), 'c' - 'a');
+        EXPECT_EQ(std::distance(it, dodgers.begin()), 'a' - 'c');
+    }
+    {
+        auto it = std::lower_bound(dodgers.begin(), dodgers.end(), 'j');
+        EXPECT_EQ(*it, 'j');
+        EXPECT_EQ(std::distance(dodgers.begin(), it), 'j' - 'a');
+        EXPECT_EQ(std::distance(it, dodgers.begin()), 'a' - 'j');
+    }
+    EXPECT_EQ(dodgers.begin(), std::begin(dodgers));
+    EXPECT_EQ(dodgers.end(), std::end(dodgers));
+}
+
+#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+TEST(dyn_array_tests, constexprness)
+{
+    constexpr gsl::dyn_array<char> marlins;
+    static_assert(marlins == marlins);
+    static_assert(marlins.empty());
+    static_assert(marlins.size() == 0);
+    static_assert(marlins.data() == nullptr);
+    static_assert(marlins.begin() == marlins.end());
+    static_assert(std::distance(marlins.begin(), marlins.end()) == 0);
+}
+#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+
+#ifdef GSL_HAS_RANGES
+TEST(dyn_array_tests, ranges)
+{
+    gsl::dyn_array<char> brewers(26);
+    std::ranges::generate(brewers, [c = 'a']() mutable { return c++; });
+    char ch = 'a';
+    for (auto x : brewers) EXPECT_EQ(x, ch++);
+    EXPECT_EQ(std::ranges::find(brewers, 'a'), std::ranges::begin(brewers));
+    {
+        auto it = std::ranges::find(brewers, 'c');
+        EXPECT_EQ(std::ranges::distance(std::ranges::begin(brewers), it), 'c' - 'a');
+        EXPECT_EQ(std::ranges::distance(it, std::ranges::begin(brewers)), 'a' - 'c');
+    }
+
+#ifdef GSL_HAS_CONTAINER_RANGES
+    std::vector<char> twins(10, 'c');
+    gsl::dyn_array<char> mets(std::from_range_t{}, twins);
+    EXPECT_EQ(twins.size(), mets.size());
+    EXPECT_TRUE(std::ranges::all_of(mets, [](char c) { return c == 'c'; }));
+#endif /* GSL_HAS_CONTAINER_RANGES */
+}
+#endif /* GSL_HAS_RANGES */
+
+#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+template <typename T, unsigned N>
+struct ConstexprAllocator
+{
+    T buf[N];
+    std::size_t sz;
+
+    constexpr ConstexprAllocator() : buf{}, sz{} {}
+
+    constexpr auto allocate(std::size_t n)
+    {
+        auto addr = &buf[sz];
+        sz += n;
+        return addr;
+    }
+
+    constexpr void deallocate(T*, size_t) {}
+};
+#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+
+template <typename T>
+static int AllocCounter = 0;
+
+template <typename T>
+static int DeallocCounter = 0;
+
+template <typename T>
+class Newocator
+{
+    static int allocations;
+    static int deallocations;
+
+public:
+    static void init()
+    {
+        AllocCounter<Newocator<T>> = 0;
+        DeallocCounter<Newocator<T>> = 0;
+    }
+
+    static void check() { EXPECT_EQ(AllocCounter<Newocator<T>>, DeallocCounter<Newocator<T>>); }
+
+    T* allocate(std::size_t n)
+    {
+        AllocCounter<Newocator<T>> ++;
+        return static_cast<T*>(new T[n]);
+    }
+
+    void deallocate(T* p, size_t)
+    {
+        DeallocCounter<Newocator<T>> ++;
+        delete[] p;
+    }
+};
+
+TEST(dyn_array_tests, custom_allocator)
+{
+#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+    static constexpr gsl::dyn_array<char, ConstexprAllocator<char, 10>> mets(10, 'c');
+    static_assert(mets.size() == 10);
+    static_assert(mets[0] == 'c');
+    static_assert(std::all_of(std::begin(mets), std::end(mets), [](char c) { return c == 'c'; }));
+#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+
+    Newocator<char>::init();
+    {
+        gsl::dyn_array<char, Newocator<char>> yankees(10, 'c');
+        EXPECT_EQ(yankees.size(), 10);
+        EXPECT_TRUE(
+            std::all_of(std::begin(yankees), std::end(yankees), [](char c) { return c == 'c'; }));
+        yankees[0] = 'a';
+        yankees[1] = 'b';
+        EXPECT_EQ(yankees[0], 'a');
+        EXPECT_EQ(yankees[1], 'b');
+        EXPECT_EQ(yankees[2], 'c');
+        yankees.get_allocator().deallocate(yankees.get_allocator().allocate(1), 1);
+    }
+    Newocator<char>::check();
+}
+
+TEST(dyn_array_tests, init_list)
+{
+    gsl::dyn_array<char> phillies = {'a', 'b', 'c'};
+    EXPECT_EQ(phillies.size(), 3);
+    EXPECT_EQ(phillies[0], 'a');
+    EXPECT_EQ(phillies[1], 'b');
+    EXPECT_EQ(phillies[2], 'c');
+}
+
+TEST(dyn_array_tests, const_operations)
+{
+    const gsl::dyn_array<char> pirates{'a', 'b', 'c', 'd'};
+    EXPECT_EQ(pirates.size(), 4);
+    EXPECT_EQ(pirates[0], 'a');
+}
+
+TEST(dyn_array_tests, reverse_iterator)
+{
+    const gsl::dyn_array<char> padres{'a', 'b', 'c'};
+    auto it = std::rbegin(padres);
+    EXPECT_EQ(*it++, 'c');
+    EXPECT_EQ(*it++, 'b');
+    EXPECT_EQ(*it++, 'a');
+}
+
+#ifdef GSL_HAS_DEDUCTION_GUIDES
+TEST(dyn_array_tests, deduction_guides)
+{
+    std::vector<char> giants{10};
+#ifdef GSL_HAS_CONTAINER_RANGES
+    gsl::dyn_array mariners(std::from_range_t{}, giants);
+#endif /* GSL_HAS_CONTAINER_RANGES */
+    gsl::dyn_array cardinals(std::begin(giants), std::end(giants));
+}
+#endif /* GSL_HAS_DEDUCTION_GUIDES */

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -167,7 +167,7 @@ TEST(dyn_array_tests, ranges)
 
 #ifdef GSL_HAS_CONTAINER_RANGES
     std::vector<char> twins(10, 'c');
-    gsl::dyn_array<char> mets(std::from_range_t{}, twins);
+    gsl::dyn_array<char> mets(std::from_range, twins);
     EXPECT_EQ(twins.size(), mets.size());
     EXPECT_TRUE(std::ranges::all_of(mets, [](char c) { return c == 'c'; }));
 #endif /* GSL_HAS_CONTAINER_RANGES */
@@ -178,10 +178,8 @@ TEST(dyn_array_tests, ranges)
 template <typename T, unsigned N>
 struct ConstexprAllocator
 {
-    T buf[N];
-    std::size_t sz;
-
-    constexpr ConstexprAllocator() : buf{}, sz{} {}
+    T buf[N]{};
+    std::size_t sz{};
 
     constexpr auto allocate(std::size_t n)
     {
@@ -283,7 +281,7 @@ TEST(dyn_array_tests, deduction_guides)
 {
     std::vector<char> giants{10};
 #ifdef GSL_HAS_CONTAINER_RANGES
-    gsl::dyn_array mariners(std::from_range_t{}, giants);
+    gsl::dyn_array mariners(std::from_range, giants);
 #endif /* GSL_HAS_CONTAINER_RANGES */
     gsl::dyn_array cardinals(std::begin(giants), std::end(giants));
 }

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -229,6 +229,48 @@ static int AllocCounter = 0;
 template <typename T>
 static int DeallocCounter = 0;
 
+struct LifetimeCounter
+{
+    static int alive_count;
+
+    int value{};
+
+    explicit LifetimeCounter(int v = 0) : value(v) { ++alive_count; }
+
+    LifetimeCounter(const LifetimeCounter& other) : value(other.value) { ++alive_count; }
+
+    ~LifetimeCounter() { --alive_count; }
+};
+
+int LifetimeCounter::alive_count = 0;
+
+struct ThrowOnCopy
+{
+    static int alive_count;
+    static int copy_count;
+    static int throw_on_copy_index;
+
+    int value{};
+
+    explicit ThrowOnCopy(int v = 0) : value(v) { ++alive_count; }
+
+    ThrowOnCopy(const ThrowOnCopy& other) : value(other.value)
+    {
+        if (copy_count == throw_on_copy_index) {
+            ++copy_count;
+            throw 42;
+        }
+        ++copy_count;
+        ++alive_count;
+    }
+
+    ~ThrowOnCopy() { --alive_count; }
+};
+
+int ThrowOnCopy::alive_count = 0;
+int ThrowOnCopy::copy_count = 0;
+int ThrowOnCopy::throw_on_copy_index = -1;
+
 template <typename T>
 class Newocator
 {
@@ -321,6 +363,31 @@ TEST(dyn_array_tests, custom_allocator)
         yankees.get_allocator().deallocate(yankees.get_allocator().allocate(1), 1);
     }
     Newocator<char>::check();
+}
+
+TEST(dyn_array_tests, non_trivial_elements_are_destroyed)
+{
+    LifetimeCounter::alive_count = 0;
+
+    {
+        gsl::dyn_array<LifetimeCounter> values(5, LifetimeCounter{7});
+        EXPECT_EQ(values.size(), 5);
+        EXPECT_EQ(LifetimeCounter::alive_count, 5);
+    }
+
+    EXPECT_EQ(LifetimeCounter::alive_count, 0);
+}
+
+TEST(dyn_array_tests, failed_element_construction_rolls_back)
+{
+    ThrowOnCopy::alive_count = 0;
+    ThrowOnCopy::copy_count = 0;
+    ThrowOnCopy::throw_on_copy_index = 2;
+
+    EXPECT_THROW((gsl::dyn_array<ThrowOnCopy>(5, ThrowOnCopy{1})), int);
+    EXPECT_EQ(ThrowOnCopy::alive_count, 0);
+
+    ThrowOnCopy::throw_on_copy_index = -1;
 }
 
 TEST(dyn_array_tests, init_list)

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -180,18 +180,47 @@ TEST(dyn_array_tests, ranges)
 template <typename T, unsigned N>
 struct ConstexprAllocator
 {
+    using value_type = T;
+
     T buf[N]{};
     std::size_t sz{};
 
-    constexpr auto allocate(std::size_t n)
+    constexpr ConstexprAllocator() = default;
+
+    template <typename U>
+    constexpr ConstexprAllocator(const ConstexprAllocator<U, N>&) noexcept
+        : buf{}, sz{}
+    {}
+
+    template <typename U>
+    struct rebind
+    {
+        using other = ConstexprAllocator<U, N>;
+    };
+
+    constexpr auto allocate(std::size_t n) -> value_type*
     {
         auto addr = &buf[sz];
         sz += n;
         return addr;
     }
 
-    constexpr void deallocate(T*, size_t) {}
+    constexpr void deallocate(value_type*, std::size_t) noexcept {}
 };
+
+template <typename T1, unsigned N1, typename T2, unsigned N2>
+constexpr auto operator==(const ConstexprAllocator<T1, N1>& lhs,
+                          const ConstexprAllocator<T2, N2>& rhs) noexcept
+{
+    return std::addressof(lhs) == std::addressof(rhs);
+}
+
+template <typename T1, unsigned N1, typename T2, unsigned N2>
+constexpr auto operator!=(const ConstexprAllocator<T1, N1>& lhs,
+                          const ConstexprAllocator<T2, N2>& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
 #endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
 
 template <typename T>
@@ -203,10 +232,15 @@ static int DeallocCounter = 0;
 template <typename T>
 class Newocator
 {
-    static int allocations;
-    static int deallocations;
-
 public:
+    using value_type = T;
+
+    Newocator() = default;
+
+    template <typename U>
+    Newocator(const Newocator<U>&) noexcept
+    {}
+
     static void init()
     {
         AllocCounter<Newocator<T>> = 0;
@@ -215,18 +249,54 @@ public:
 
     static void check() { EXPECT_EQ(AllocCounter<Newocator<T>>, DeallocCounter<Newocator<T>>); }
 
-    T* allocate(std::size_t n)
+    auto allocate(std::size_t n) -> value_type*
     {
-        AllocCounter<Newocator<T>> ++;
-        return static_cast<T*>(new T[n]);
+        AllocCounter<Newocator<T>>++;
+        return static_cast<value_type*>(::operator new(n * sizeof(value_type)));
     }
 
-    void deallocate(T* p, size_t)
+    void deallocate(value_type* p, std::size_t) noexcept
     {
-        DeallocCounter<Newocator<T>> ++;
-        delete[] p;
+        DeallocCounter<Newocator<T>>++;
+        ::operator delete(p);
     }
+
+    template <typename U>
+    struct rebind
+    {
+        using other = Newocator<U>;
+    };
 };
+
+template <typename T, typename U>
+constexpr auto operator==(const Newocator<T>&, const Newocator<U>&) noexcept
+{
+    return true;
+}
+
+template <typename T, typename U>
+constexpr auto operator!=(const Newocator<T>& lhs, const Newocator<U>& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
+TEST(dyn_array_tests, custom_allocator_models_allocator)
+{
+    using traits = std::allocator_traits<Newocator<char>>;
+    using ptr = traits::pointer;
+
+    static_assert(std::is_same_v<traits::value_type, char>);
+    static_assert(std::is_same_v<ptr, char*>);
+
+    Newocator<char> alloc;
+    auto p = traits::allocate(alloc, 1);
+    traits::deallocate(alloc, p, 1);
+
+#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+    using constexpr_traits = std::allocator_traits<ConstexprAllocator<char, 10>>;
+    static_assert(std::is_same_v<constexpr_traits::value_type, char>);
+#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+}
 
 TEST(dyn_array_tests, custom_allocator)
 {

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -332,8 +332,8 @@ TEST(dyn_array_tests, custom_allocator_models_allocator)
     using traits = std::allocator_traits<Newocator<char>>;
     using ptr = traits::pointer;
 
-    static_assert(std::is_same_v<traits::value_type, char>);
-    static_assert(std::is_same_v<ptr, char*>);
+    static_assert(std::is_same<traits::value_type, char>::value, "allocator trait type mismatch");
+    static_assert(std::is_same<ptr, char*>::value, "allocator trait type mismatch");
 
     Newocator<char> alloc;
     auto p = traits::allocate(alloc, 1);

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -341,7 +341,7 @@ TEST(dyn_array_tests, custom_allocator_models_allocator)
 
 #ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
     using constexpr_traits = std::allocator_traits<ConstexprAllocator<char, 10>>;
-    static_assert(std::is_same_v<constexpr_traits::value_type, char>);
+    static_assert(std::is_same<constexpr_traits::value_type, char>::value, "allocator trait type mismatch");
 #endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
 }
 
@@ -503,14 +503,14 @@ TEST(dyn_array_tests, unchecked_iterators)
 
 TEST(DynArrayTests, TypeConsistency)
 {
-    static_assert(std::is_same_v<gsl::dyn_array<int>::value_type, int>, "Value type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::reference, int&>, "Reference type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::const_reference, const int&>, "Const reference type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::value_type, int>, "Iterator value type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::reference, int&>, "Iterator reference type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::const_reference, const int&>, "Iterator const reference type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::size_type, std::size_t>, "Size type mismatch");
-    static_assert(std::is_same_v<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>, "Difference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::value_type, int>::value, "Value type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::reference, int&>::value, "Reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::const_reference, const int&>::value, "Const reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::value_type, int>::value, "Iterator value type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::reference, int&>::value, "Iterator reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::const_reference, const int&>::value, "Iterator const reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::size_type, std::size_t>::value, "Size type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>::value, "Difference type mismatch");
 }
 
 #ifdef GSL_HAS_DEDUCTION_GUIDES

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -249,6 +249,39 @@ struct LifetimeCounter
 
 int LifetimeCounter::alive_count = 0;
 
+struct DefaultConstructionCounter
+{
+    static int default_constructor_count;
+    static int copy_constructor_count;
+
+    int value{};
+
+    DefaultConstructionCounter() { ++default_constructor_count; }
+
+    DefaultConstructionCounter(const DefaultConstructionCounter& other) : value(other.value)
+    {
+        ++copy_constructor_count;
+    }
+
+    static void reset()
+    {
+        default_constructor_count = 0;
+        copy_constructor_count = 0;
+    }
+};
+
+int DefaultConstructionCounter::default_constructor_count = 0;
+int DefaultConstructionCounter::copy_constructor_count = 0;
+
+struct DefaultOnlyElement
+{
+    DefaultOnlyElement() = default;
+    DefaultOnlyElement(const DefaultOnlyElement&) = delete;
+    DefaultOnlyElement& operator=(const DefaultOnlyElement&) = delete;
+    DefaultOnlyElement(DefaultOnlyElement&&) = delete;
+    DefaultOnlyElement& operator=(DefaultOnlyElement&&) = delete;
+};
+
 struct ThrowOnCopy
 {
     static int alive_count;
@@ -327,6 +360,95 @@ constexpr auto operator!=(const Newocator<T>& lhs, const Newocator<U>& rhs) noex
     return !(lhs == rhs);
 }
 
+template <typename T>
+class OwnershipTrackingAllocator
+{
+public:
+    using value_type = T;
+
+    OwnershipTrackingAllocator() noexcept : owner_id(next_owner_id()) { ++next_owner_id(); }
+
+    explicit OwnershipTrackingAllocator(int owner) noexcept : owner_id(owner) {}
+
+    template <typename U>
+    OwnershipTrackingAllocator(const OwnershipTrackingAllocator<U>& other) noexcept
+        : owner_id(other.owner())
+    {}
+
+    auto allocate(std::size_t count) -> value_type*
+    {
+        static_assert(alignof(value_type) <= alignof(int),
+                      "test allocator only supports types with int-or-smaller alignment");
+        auto raw = static_cast<unsigned char*>(::operator new(sizeof(int) + count * sizeof(value_type)));
+        *reinterpret_cast<int*>(raw) = owner_id;
+        ++allocation_count();
+        return reinterpret_cast<value_type*>(raw + sizeof(int));
+    }
+
+    void deallocate(value_type* pointer, std::size_t) noexcept
+    {
+        auto raw = reinterpret_cast<unsigned char*>(pointer) - sizeof(int);
+        if (*reinterpret_cast<int*>(raw) != owner_id) {
+            ++mismatched_deallocation_count();
+        }
+        ++deallocation_count();
+        ::operator delete(raw);
+    }
+
+    auto owner() const noexcept { return owner_id; }
+
+    static void reset()
+    {
+        next_owner_id() = 1;
+        allocation_count() = 0;
+        deallocation_count() = 0;
+        mismatched_deallocation_count() = 0;
+    }
+
+    static auto mismatched_deallocations() { return mismatched_deallocation_count(); }
+
+private:
+    int owner_id;
+
+    static auto next_owner_id() -> int&
+    {
+        static int value = 1;
+        return value;
+    }
+
+    static auto allocation_count() -> int&
+    {
+        static int value = 0;
+        return value;
+    }
+
+    static auto deallocation_count() -> int&
+    {
+        static int value = 0;
+        return value;
+    }
+
+    static auto mismatched_deallocation_count() -> int&
+    {
+        static int value = 0;
+        return value;
+    }
+};
+
+template <typename T, typename U>
+constexpr auto operator==(const OwnershipTrackingAllocator<T>& lhs,
+                          const OwnershipTrackingAllocator<U>& rhs) noexcept
+{
+    return lhs.owner() == rhs.owner();
+}
+
+template <typename T, typename U>
+constexpr auto operator!=(const OwnershipTrackingAllocator<T>& lhs,
+                          const OwnershipTrackingAllocator<U>& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
 TEST(dyn_array_tests, custom_allocator_models_allocator)
 {
     using traits = std::allocator_traits<Newocator<char>>;
@@ -370,6 +492,23 @@ TEST(dyn_array_tests, custom_allocator)
     Newocator<char>::check();
 }
 
+TEST(dyn_array_tests, copy_assignment_deallocates_with_the_allocator_that_owns_the_storage)
+{
+    using allocator_type = OwnershipTrackingAllocator<char>;
+    using array_type = gsl::dyn_array<char, allocator_type>;
+
+    allocator_type::reset();
+
+    {
+        array_type source(3, 's', allocator_type{1});
+        array_type target(2, 't', allocator_type{2});
+
+        target = source;
+    }
+
+    EXPECT_EQ(allocator_type::mismatched_deallocations(), 0);
+}
+
 TEST(dyn_array_tests, non_trivial_elements_are_destroyed)
 {
     LifetimeCounter::alive_count = 0;
@@ -382,6 +521,27 @@ TEST(dyn_array_tests, non_trivial_elements_are_destroyed)
 
     EXPECT_EQ(LifetimeCounter::alive_count, 0);
 }
+
+TEST(dyn_array_tests, count_constructor_default_constructs_each_element)
+{
+    DefaultConstructionCounter::reset();
+
+    {
+        gsl::dyn_array<DefaultConstructionCounter> values(4);
+        EXPECT_EQ(values.size(), 4);
+    }
+
+    EXPECT_EQ(DefaultConstructionCounter::default_constructor_count, 4);
+    EXPECT_EQ(DefaultConstructionCounter::copy_constructor_count, 0);
+}
+
+#ifdef GSL_DYN_ARRAY_COMPILE_FAILURE_TESTS
+TEST(dyn_array_compile_failure_tests, count_constructor_accepts_default_constructible_only_elements)
+{
+    gsl::dyn_array<DefaultOnlyElement> values(4);
+    EXPECT_EQ(values.size(), 4);
+}
+#endif /* GSL_DYN_ARRAY_COMPILE_FAILURE_TESTS */
 
 TEST(dyn_array_tests, failed_element_construction_rolls_back)
 {
@@ -445,6 +605,21 @@ TEST(dyn_array_tests, random_access_iterator_arithmetic)
     EXPECT_EQ(third - first, 2);
     EXPECT_EQ(*(third - 1), 'b');
     EXPECT_EQ(*std::prev(third), 'b');
+}
+
+TEST(dyn_array_tests, random_access_iterator_arithmetic_accepts_negative_offsets)
+{
+    gsl::dyn_array<char> bluejays{'a', 'b', 'c', 'd'};
+
+    auto third = bluejays.begin() + 2;
+    char previous{};
+    char next{};
+
+    EXPECT_NO_THROW(previous = *(third + -1));
+    EXPECT_EQ(previous, 'b');
+
+    EXPECT_NO_THROW(next = *(third - -1));
+    EXPECT_EQ(next, 'd');
 }
 
 TEST(dyn_array_tests, input_iterator_constructor)

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -17,15 +17,15 @@
 static_assert(sizeof(gsl::dyn_array<int>) == 2 * sizeof(void*),
               "gsl::dyn_array (with the default allocator) should be 16 bytes");
 
-#ifdef GSL_HAS_CONCEPTS
+#if defined(__cpp_lib_concepts) && (__cpp_lib_concepts >= 202002L)
 static_assert(std::input_iterator<gsl::dyn_array<int>::iterator>,
               "gsl::dyn_array should expose a valid input_iterator");
-#endif /* GSL_HAS_CONCEPTS */
+#endif /* __cpp_lib_concepts >= 202002L */
 
-#ifdef GSL_HAS_RANGES
+#if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
 static_assert(std::ranges::input_range<gsl::dyn_array<int>>,
               "gsl::dyn_array should be a valid input range");
-#endif /* GSL_HAS_RANGES */
+#endif /* __cpp_lib_ranges >= 201911L */
 
 TEST(dyn_array_tests, default_ctor)
 {
@@ -145,7 +145,7 @@ TEST(dyn_array_tests, use_std_algorithms)
     EXPECT_EQ(dodgers.end(), std::end(dodgers));
 }
 
-#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+#if defined(__cpp_lib_constexpr_dynamic_alloc) && (__cpp_lib_constexpr_dynamic_alloc >= 201907L)
 constexpr auto default_constructed_count_dyn_array_is_constexpr()
 {
     gsl::dyn_array<int> values(3);
@@ -174,9 +174,9 @@ TEST(dyn_array_tests, constexprness)
     static_assert(default_constructed_count_dyn_array_is_constexpr());
     static_assert(copy_assigned_dyn_array_is_constexpr());
 }
-#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+#endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 
-#ifdef GSL_HAS_RANGES
+#if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
 TEST(dyn_array_tests, ranges)
 {
     gsl::dyn_array<char> brewers(26);
@@ -190,16 +190,16 @@ TEST(dyn_array_tests, ranges)
         EXPECT_EQ(std::ranges::distance(it, std::ranges::begin(brewers)), 'a' - 'c');
     }
 
-#ifdef GSL_HAS_CONTAINER_RANGES
+#if defined(__cpp_lib_containers_ranges) && (__cpp_lib_containers_ranges >= 202202L)
     std::vector<char> twins(10, 'c');
     gsl::dyn_array<char> mets(std::from_range, twins);
     EXPECT_EQ(twins.size(), mets.size());
     EXPECT_TRUE(std::ranges::all_of(mets, [](char c) { return c == 'c'; }));
-#endif /* GSL_HAS_CONTAINER_RANGES */
+#endif /* __cpp_lib_containers_ranges >= 202202L */
 }
-#endif /* GSL_HAS_RANGES */
+#endif /* __cpp_lib_ranges >= 201911L */
 
-#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+#if defined(__cpp_lib_constexpr_dynamic_alloc) && (__cpp_lib_constexpr_dynamic_alloc >= 201907L)
 template <typename T, unsigned N>
 struct ConstexprAllocator
 {
@@ -244,7 +244,7 @@ constexpr auto operator!=(const ConstexprAllocator<T1, N1>& lhs,
 {
     return !(lhs == rhs);
 }
-#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+#endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 
 template <typename T>
 static int AllocCounter = 0;
@@ -479,20 +479,20 @@ TEST(dyn_array_tests, custom_allocator_models_allocator)
     auto p = traits::allocate(alloc, 1);
     traits::deallocate(alloc, p, 1);
 
-#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+#if defined(__cpp_lib_constexpr_dynamic_alloc) && (__cpp_lib_constexpr_dynamic_alloc >= 201907L)
     using constexpr_traits = std::allocator_traits<ConstexprAllocator<char, 10>>;
     static_assert(std::is_same<constexpr_traits::value_type, char>::value, "allocator trait type mismatch");
-#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+#endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 }
 
 TEST(dyn_array_tests, custom_allocator)
 {
-#ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+#if defined(__cpp_lib_constexpr_dynamic_alloc) && (__cpp_lib_constexpr_dynamic_alloc >= 201907L)
     static constexpr gsl::dyn_array<char, ConstexprAllocator<char, 10>> mets(10, 'c');
     static_assert(mets.size() == 10);
     static_assert(mets[0] == 'c');
     static_assert(std::all_of(std::begin(mets), std::end(mets), [](char c) { return c == 'c'; }));
-#endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
+#endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 
     Newocator<char>::init();
     {
@@ -706,13 +706,13 @@ TEST(DynArrayTests, TypeConsistency)
     static_assert(std::is_same<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>::value, "Difference type mismatch");
 }
 
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 TEST(dyn_array_tests, deduction_guides)
 {
     std::vector<char> giants{10};
-#ifdef GSL_HAS_CONTAINER_RANGES
+#if defined(__cpp_lib_containers_ranges) && (__cpp_lib_containers_ranges >= 202202L)
     gsl::dyn_array mariners(std::from_range, giants);
-#endif /* GSL_HAS_CONTAINER_RANGES */
+#endif /* __cpp_lib_containers_ranges >= 202202L */
     gsl::dyn_array cardinals(std::begin(giants), std::end(giants));
 }
-#endif /* GSL_HAS_DEDUCTION_GUIDES */
+#endif /* __cpp_deduction_guides >= 201703L */

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -152,16 +152,6 @@ constexpr auto default_constructed_count_dyn_array_is_constexpr()
     return values.size() == 3 && values[0] == 0 && values[1] == 0 && values[2] == 0;
 }
 
-constexpr auto copy_assigned_dyn_array_is_constexpr()
-{
-    gsl::dyn_array<int> source(3, 7);
-    gsl::dyn_array<int> target(2, 4);
-
-    target = source;
-
-    return target.size() == 3 && target[0] == 7 && target[1] == 7 && target[2] == 7;
-}
-
 TEST(dyn_array_tests, constexprness)
 {
     constexpr gsl::dyn_array<char> marlins;
@@ -172,7 +162,6 @@ TEST(dyn_array_tests, constexprness)
     static_assert(marlins.begin() == marlins.end());
     static_assert(std::distance(marlins.begin(), marlins.end()) == 0);
     static_assert(default_constructed_count_dyn_array_is_constexpr());
-    static_assert(copy_assigned_dyn_array_is_constexpr());
 }
 #endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 
@@ -510,23 +499,6 @@ TEST(dyn_array_tests, custom_allocator)
     Newocator<char>::check();
 }
 
-TEST(dyn_array_tests, copy_assignment_deallocates_with_the_allocator_that_owns_the_storage)
-{
-    using allocator_type = OwnershipTrackingAllocator<char>;
-    using array_type = gsl::dyn_array<char, allocator_type>;
-
-    allocator_type::reset();
-
-    {
-        array_type source(3, 's', allocator_type{1});
-        array_type target(2, 't', allocator_type{2});
-
-        target = source;
-    }
-
-    EXPECT_EQ(allocator_type::mismatched_deallocations(), 0);
-}
-
 TEST(dyn_array_tests, non_trivial_elements_are_destroyed)
 {
     LifetimeCounter::alive_count = 0;
@@ -596,20 +568,6 @@ TEST(dyn_array_tests, reverse_iterator)
     EXPECT_EQ(*it++, 'c');
     EXPECT_EQ(*it++, 'b');
     EXPECT_EQ(*it++, 'a');
-}
-
-TEST(dyn_array_tests, copy_assignment)
-{
-    gsl::dyn_array<char> rays(3, 'r');
-    const gsl::dyn_array<char> rangers{'a', 'b', 'c'};
-
-    auto& assigned = (rays = rangers);
-
-    EXPECT_EQ(&assigned, &rays);
-    EXPECT_EQ(rays.size(), rangers.size());
-    EXPECT_EQ(rays[0], 'a');
-    EXPECT_EQ(rays[1], 'b');
-    EXPECT_EQ(rays[2], 'c');
 }
 
 TEST(dyn_array_tests, random_access_iterator_arithmetic)

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -2,6 +2,8 @@
 
 #include <gsl/dyn_array>
 #include <gsl/util>
+#include "gsl/dyn_array"
+#include <type_traits>
 
 // Despite using <algorithm> and <ranges> utilities in this test, they
 // are not being included directly by this file as a test to ensure
@@ -274,6 +276,18 @@ TEST(dyn_array_tests, reverse_iterator)
     EXPECT_EQ(*it++, 'c');
     EXPECT_EQ(*it++, 'b');
     EXPECT_EQ(*it++, 'a');
+}
+
+TEST(DynArrayTests, TypeConsistency)
+{
+    static_assert(std::is_same_v<gsl::dyn_array<int>::value_type, int>, "Value type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::reference, int&>, "Reference type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::const_reference, const int&>, "Const reference type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::value_type, int>, "Iterator value type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::reference, int&>, "Iterator reference type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::iterator::const_reference, const int&>, "Iterator const reference type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::size_type, std::size_t>, "Size type mismatch");
+    static_assert(std::is_same_v<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>, "Difference type mismatch");
 }
 
 #ifdef GSL_HAS_DEDUCTION_GUIDES

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "deathTestCommon.h"
-#include <gsl/dyn_array>
-#include <gsl/util>
 #include "gsl/dyn_array"
 #include <cstdlib>
 #include <exception>
+#include <gsl/dyn_array>
+#include <gsl/util>
 #include <iostream>
 #include <sstream>
 #include <type_traits>
@@ -200,8 +200,7 @@ struct ConstexprAllocator
     constexpr ConstexprAllocator() = default;
 
     template <typename U>
-    constexpr ConstexprAllocator(const ConstexprAllocator<U, N>&) noexcept
-        : buf{}, sz{}
+    constexpr ConstexprAllocator(const ConstexprAllocator<U, N>&) noexcept : buf{}, sz{}
     {}
 
     template <typename U>
@@ -301,7 +300,8 @@ struct ThrowOnCopy
 
     ThrowOnCopy(const ThrowOnCopy& other) : value(other.value)
     {
-        if (copy_count == throw_on_copy_index) {
+        if (copy_count == throw_on_copy_index)
+        {
             ++copy_count;
             throw 42;
         }
@@ -338,13 +338,13 @@ public:
 
     auto allocate(std::size_t n) -> value_type*
     {
-        AllocCounter<Newocator<T>>++;
+        AllocCounter<Newocator<T>> ++;
         return static_cast<value_type*>(::operator new(n * sizeof(value_type)));
     }
 
     void deallocate(value_type* p, std::size_t) noexcept
     {
-        DeallocCounter<Newocator<T>>++;
+        DeallocCounter<Newocator<T>> ++;
         ::operator delete(p);
     }
 
@@ -386,7 +386,8 @@ public:
     {
         static_assert(alignof(value_type) <= alignof(int),
                       "test allocator only supports types with int-or-smaller alignment");
-        auto raw = static_cast<unsigned char*>(::operator new(sizeof(int) + count * sizeof(value_type)));
+        auto raw =
+            static_cast<unsigned char*>(::operator new(sizeof(int) + count * sizeof(value_type)));
         *reinterpret_cast<int*>(raw) = owner_id;
         ++allocation_count();
         return reinterpret_cast<value_type*>(raw + sizeof(int));
@@ -395,9 +396,7 @@ public:
     void deallocate(value_type* pointer, std::size_t) noexcept
     {
         auto raw = reinterpret_cast<unsigned char*>(pointer) - sizeof(int);
-        if (*reinterpret_cast<int*>(raw) != owner_id) {
-            ++mismatched_deallocation_count();
-        }
+        if (*reinterpret_cast<int*>(raw) != owner_id) { ++mismatched_deallocation_count(); }
         ++deallocation_count();
         ::operator delete(raw);
     }
@@ -470,7 +469,8 @@ TEST(dyn_array_tests, custom_allocator_models_allocator)
 
 #if defined(__cpp_lib_constexpr_dynamic_alloc) && (__cpp_lib_constexpr_dynamic_alloc >= 201907L)
     using constexpr_traits = std::allocator_traits<ConstexprAllocator<char, 10>>;
-    static_assert(std::is_same<constexpr_traits::value_type, char>::value, "allocator trait type mismatch");
+    static_assert(std::is_same<constexpr_traits::value_type, char>::value,
+                  "allocator trait type mismatch");
 #endif /* __cpp_lib_constexpr_dynamic_alloc >= 201907L */
 }
 
@@ -641,7 +641,8 @@ TEST(dyn_array_tests, unchecked_iterators)
     EXPECT_TRUE((std::is_same<decltype(const_values._Unchecked_end()), const char*>::value));
 
     std::size_t count = 0;
-    for (const auto value : const_values) {
+    for (const auto value : const_values)
+    {
         EXPECT_EQ(value, 'v');
         ++count;
     }
@@ -655,13 +656,20 @@ TEST(dyn_array_tests, unchecked_iterators)
 TEST(DynArrayTests, TypeConsistency)
 {
     static_assert(std::is_same<gsl::dyn_array<int>::value_type, int>::value, "Value type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::reference, int&>::value, "Reference type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::const_reference, const int&>::value, "Const reference type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::iterator::value_type, int>::value, "Iterator value type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::iterator::reference, int&>::value, "Iterator reference type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::iterator::const_reference, const int&>::value, "Iterator const reference type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::size_type, std::size_t>::value, "Size type mismatch");
-    static_assert(std::is_same<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>::value, "Difference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::reference, int&>::value,
+                  "Reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::const_reference, const int&>::value,
+                  "Const reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::value_type, int>::value,
+                  "Iterator value type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::reference, int&>::value,
+                  "Iterator reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::iterator::const_reference, const int&>::value,
+                  "Iterator const reference type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::size_type, std::size_t>::value,
+                  "Size type mismatch");
+    static_assert(std::is_same<gsl::dyn_array<int>::difference_type, std::ptrdiff_t>::value,
+                  "Difference type mismatch");
 }
 
 #if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -146,6 +146,22 @@ TEST(dyn_array_tests, use_std_algorithms)
 }
 
 #ifdef GSL_HAS_CONSTEXPR_ALLOCATOR
+constexpr auto default_constructed_count_dyn_array_is_constexpr()
+{
+    gsl::dyn_array<int> values(3);
+    return values.size() == 3 && values[0] == 0 && values[1] == 0 && values[2] == 0;
+}
+
+constexpr auto copy_assigned_dyn_array_is_constexpr()
+{
+    gsl::dyn_array<int> source(3, 7);
+    gsl::dyn_array<int> target(2, 4);
+
+    target = source;
+
+    return target.size() == 3 && target[0] == 7 && target[1] == 7 && target[2] == 7;
+}
+
 TEST(dyn_array_tests, constexprness)
 {
     constexpr gsl::dyn_array<char> marlins;
@@ -155,6 +171,8 @@ TEST(dyn_array_tests, constexprness)
     static_assert(marlins.data() == nullptr);
     static_assert(marlins.begin() == marlins.end());
     static_assert(std::distance(marlins.begin(), marlins.end()) == 0);
+    static_assert(default_constructed_count_dyn_array_is_constexpr());
+    static_assert(copy_assigned_dyn_array_is_constexpr());
 }
 #endif /* GSL_HAS_CONSTEXPR_ALLOCATOR */
 

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -1,8 +1,13 @@
 #include <gtest/gtest.h>
 
+#include "deathTestCommon.h"
 #include <gsl/dyn_array>
 #include <gsl/util>
 #include "gsl/dyn_array"
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <sstream>
 #include <type_traits>
 
 // Despite using <algorithm> and <ranges> utilities in this test, they
@@ -414,6 +419,87 @@ TEST(dyn_array_tests, reverse_iterator)
     EXPECT_EQ(*it++, 'b');
     EXPECT_EQ(*it++, 'a');
 }
+
+TEST(dyn_array_tests, copy_assignment)
+{
+    gsl::dyn_array<char> rays(3, 'r');
+    const gsl::dyn_array<char> rangers{'a', 'b', 'c'};
+
+    auto& assigned = (rays = rangers);
+
+    EXPECT_EQ(&assigned, &rays);
+    EXPECT_EQ(rays.size(), rangers.size());
+    EXPECT_EQ(rays[0], 'a');
+    EXPECT_EQ(rays[1], 'b');
+    EXPECT_EQ(rays[2], 'c');
+}
+
+TEST(dyn_array_tests, random_access_iterator_arithmetic)
+{
+    gsl::dyn_array<char> bluejays{'a', 'b', 'c', 'd'};
+
+    auto first = bluejays.begin();
+    auto third = first + 2;
+
+    EXPECT_EQ(*third, 'c');
+    EXPECT_EQ(third - first, 2);
+    EXPECT_EQ(*(third - 1), 'b');
+    EXPECT_EQ(*std::prev(third), 'b');
+}
+
+TEST(dyn_array_tests, input_iterator_constructor)
+{
+    std::istringstream stream{"n a t s"};
+    std::istream_iterator<char> first{stream};
+    const std::istream_iterator<char> last{};
+
+    gsl::dyn_array<char> nationals(first, last);
+
+    ASSERT_EQ(nationals.size(), 4);
+    EXPECT_EQ(nationals[0], 'n');
+    EXPECT_EQ(nationals[1], 'a');
+    EXPECT_EQ(nationals[2], 't');
+    EXPECT_EQ(nationals[3], 's');
+}
+
+TEST(dyn_array_tests, contract_violations)
+{
+    const auto terminateHandler = std::set_terminate([] {
+        std::cerr << "Expected Death. dyn_array_contract_violations";
+        std::abort();
+    });
+    const auto expected = GetExpectedDeathString(terminateHandler);
+
+    gsl::dyn_array<char> values(3, 'v');
+    gsl::dyn_array<char> other(3, 'o');
+
+    EXPECT_DEATH(values[values.size()], expected);
+    EXPECT_DEATH((void) *values.end(), expected);
+    EXPECT_DEATH(++values.end(), expected);
+    EXPECT_DEATH(--values.begin(), expected);
+    EXPECT_DEATH((void) (values.begin() == other.begin()), expected);
+}
+
+#ifdef _MSC_VER
+TEST(dyn_array_tests, unchecked_iterators)
+{
+    gsl::dyn_array<char> values;
+    const gsl::dyn_array<char> const_values(3, 'v');
+
+    EXPECT_TRUE((std::is_same<decltype(const_values._Unchecked_begin()), const char*>::value));
+    EXPECT_TRUE((std::is_same<decltype(const_values._Unchecked_end()), const char*>::value));
+
+    std::size_t count = 0;
+    for (const auto value : const_values) {
+        EXPECT_EQ(value, 'v');
+        ++count;
+    }
+    EXPECT_EQ(count, const_values.size());
+
+    EXPECT_EQ(values._Unchecked_begin(), nullptr);
+    EXPECT_EQ(values._Unchecked_end(), nullptr);
+}
+#endif /* _MSC_VER */
 
 TEST(DynArrayTests, TypeConsistency)
 {

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -19,7 +19,7 @@ static_assert(sizeof(gsl::dyn_array<int>) == 2 * sizeof(void*),
 
 #ifdef GSL_HAS_CONCEPTS
 static_assert(std::input_iterator<gsl::dyn_array<int>::iterator>,
-              "gsl_dyn_array should expose a valid input_iterator");
+              "gsl::dyn_array should expose a valid input_iterator");
 #endif /* GSL_HAS_CONCEPTS */
 
 #ifdef GSL_HAS_RANGES

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1299,7 +1299,7 @@ TEST(span_test, conversions)
 #if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
     span s = arr;
     span cs = s;
-#else // ^^^ deduction guides /// no deduction guides vvv
+#else  // ^^^ deduction guides /// no deduction guides vvv
     span<int, 5> s = arr;
     span<int, 5> cs = s;
 #endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -32,14 +32,14 @@
 #include <vector> // for vector
 
 // the string_view include and macro are used in the deduction guide verification
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 #ifdef __has_include
 #if __has_include(<string_view>)
 #include <string_view>
 #define HAS_STRING_VIEW
 #endif // __has_include(<string_view>)
 #endif // __has_include
-#endif // GSL_HAS_DEDUCTION_GUIDES
+#endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 #if defined(__cplusplus) && __cplusplus >= 202002L
 #include <span>
 #endif // __cplusplus >= 202002L
@@ -1211,7 +1211,7 @@ TEST(span_test, default_constructible)
 
 TEST(span_test, std_container_ctad)
 {
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
     // this test is just to verify that these compile
     {
         std::vector<int> v{1, 2, 3, 4};
@@ -1230,7 +1230,7 @@ TEST(span_test, std_container_ctad)
         static_assert(std::is_same<decltype(sp), gsl::span<const char>>::value);
     }
 #endif
-#endif // GSL_HAS_DEDUCTION_GUIDES
+#endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 }
 
 TEST(span_test, front_back)
@@ -1296,13 +1296,13 @@ TEST(span_test, conversions)
 {
     int arr[5] = {1, 2, 3, 4, 5};
 
-#ifdef GSL_HAS_DEDUCTION_GUIDES
+#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
     span s = arr;
     span cs = s;
 #else // ^^^ deduction guides /// no deduction guides vvv
     span<int, 5> s = arr;
     span<int, 5> cs = s;
-#endif // GSL_HAS_DEDUCTION_GUIDES
+#endif // defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201703L)
 
     EXPECT_TRUE(cs.size() == s.size());
     EXPECT_TRUE(cs.data() == s.data());

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -32,14 +32,14 @@
 #include <vector> // for vector
 
 // the string_view include and macro are used in the deduction guide verification
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#ifdef GSL_HAS_DEDUCTION_GUIDES
 #ifdef __has_include
 #if __has_include(<string_view>)
 #include <string_view>
 #define HAS_STRING_VIEW
 #endif // __has_include(<string_view>)
 #endif // __has_include
-#endif // (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#endif // GSL_HAS_DEDUCTION_GUIDES
 #if defined(__cplusplus) && __cplusplus >= 202002L
 #include <span>
 #endif // __cplusplus >= 202002L
@@ -1211,7 +1211,7 @@ TEST(span_test, default_constructible)
 
 TEST(span_test, std_container_ctad)
 {
-#if (defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L))
+#ifdef GSL_HAS_DEDUCTION_GUIDES
     // this test is just to verify that these compile
     {
         std::vector<int> v{1, 2, 3, 4};
@@ -1230,7 +1230,7 @@ TEST(span_test, std_container_ctad)
         static_assert(std::is_same<decltype(sp), gsl::span<const char>>::value);
     }
 #endif
-#endif
+#endif // GSL_HAS_DEDUCTION_GUIDES
 }
 
 TEST(span_test, front_back)
@@ -1296,13 +1296,13 @@ TEST(span_test, conversions)
 {
     int arr[5] = {1, 2, 3, 4, 5};
 
-#if defined(__cpp_deduction_guides) && (__cpp_deduction_guides >= 201611L)
+#ifdef GSL_HAS_DEDUCTION_GUIDES
     span s = arr;
     span cs = s;
-#else
+#else // ^^^ deduction guides /// no deduction guides vvv
     span<int, 5> s = arr;
     span<int, 5> cs = s;
-#endif
+#endif // GSL_HAS_DEDUCTION_GUIDES
 
     EXPECT_TRUE(cs.size() == s.size());
     EXPECT_TRUE(cs.data() == s.data());


### PR DESCRIPTION
resolves: https://github.com/microsoft/GSL/issues/1169

Implement gsl::dyn_array<T, Allocator> as specified by the CppCoreGuidelines here:
https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/dyn_array.md

Currently the implementation is feature complete and all tests on modern compilers (with supported language versions) are passing.

What needs to be done:

- [x] Create docs
- [ ] Run dyn_array tests under ASAN (nonblocking: nice to have)
- [x] Flesh out some more tests (nonblocking: nice to have, almost out of baseball teams)

What is done (this is a running checklist; I'll delete and rewrite this message before merging):

- [x] Basic Functionality
- [x] Tests of basic functionality
- [x] Tests for constexpr functions
- [x] Tests/Support for ranges
- [x] Ensure support for C++14, C++17, C++20, and C++23
- [x] Tests for custom allocators
- [x] More constexpr tests using a constexpr allocator
- [x] Tests for const iterators
- [x] Sanity-check static_assertions to make sure gsl::dyn_array::iterator is a proper random-access iterator.
- [x] Sanity-check static_assertions to make sure gsl::dyn_array is (mostly) a proper allocator-aware container
- [x] Tests for construction of gsl::dyn_array from std::initializer_list
- [x] Tests/Support for operations on const gsl::dyn_array
- [x] Support for MSVC's unchecked iterators
- [x] Tests/Support for reverse iterators
- [x] Deduction guides for gsl::dyn_array
- [x] Ensure support for clang, gcc, MSVC