### PR TITLE
ci: Use microsoft/setup-msbuild@v3

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v6
-      - uses: microsoft/setup-msbuild@v2
+      - uses: microsoft/setup-msbuild@v3
 
       - name: Run CMake (configure, build, test)
         uses: ./.github/workflows/cmake


### PR DESCRIPTION
Forgot this in commit 688ffcde9018910bef22dae9da9de974803dc982.

References:

Warnings can be seen on https://github.com/microsoft/GSL/actions/runs/23479082417:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: microsoft/setup-msbuild@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


The v3 release is https://github.com/microsoft/setup-msbuild/releases/tag/v3