### PR TITLE
Patches for GSLv4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dyn_array                                                                | &#x26
 move_owner                                                               | &#x2610;   | A helper function that moves one `owner` to the other
 [final_action](docs/headers.md#user-content-H-util-final_action)         | &#x2611;   | A RAII style class that invokes a functor on its destruction
 [finally](docs/headers.md#user-content-H-util-finally)                   | &#x2611;   | A helper function instantiating [final_action](docs/headers.md#user-content-H-util-final_action)
-[GSL_SUPPRESS](docs/headers.md#user-content-H-assert-gsl_suppress)       | &#x2611;   | A macro that takes an argument and turns it into `[[gsl::suppress(x)]]` or `[[gsl::suppress("x")]]`
+[GSL_SUPPRESS](docs/headers.md#user-content-H-assert-gsl_suppress)       | &#x2611;   | A macro that takes an argument and turns it into `[[gsl::suppress(x)]]` or `[[gsl::suppress("x")]]` depending on the compiler.
 [[implicit]]                                                             | &#x2610;   | A "marker" to put on single-argument constructors to explicitly make them non-explicit
 [index](docs/headers.md#user-content-H-util-index)                       | &#x2611;   | A type to use for all container and array indexing (currently an alias for `std::ptrdiff_t`)
 [narrow](docs/headers.md#user-content-H-narrow-narrow)                   | &#x2611;   | A checked version of `narrow_cast`; it can throw [narrowing_error](docs/headers.md#user-content-H-narrow-narrowing_error)

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -49,9 +49,9 @@ See [GSL.assert: Assertions](https://isocpp.github.io/CppCoreGuidelines/CppCoreG
 This macro can be used to suppress a code analysis warning.
 
 The core guidelines request tools that check for the rules to respect suppressing a rule by writing
-`[[gsl::suppress(tag)]]` or `[[gsl::suppress(tag, justification: "message")]]`.
+`[[gsl::suppress("tag")]]` or `[[gsl::suppress("tag", justification: "message")]]`.
 
-Clang does not use exactly that syntax, but requires `tag` to be put in double quotes `[[gsl::suppress("tag")]]`.
+Older versions of MSVC (VS 2022 and earlier) only understand `[[gsl::suppress(tag)]]` without the double quotes around `tag`.
 
 For portable code you can use `GSL_SUPPRESS(tag)`.
 

--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -47,13 +47,14 @@
 //
 #if defined(__clang__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
-#define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1950
+// Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
 #else
 #define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
+#endif // defined(__clang__)
 
 #if defined(__clang__) || defined(__GNUC__)
 #define GSL_LIKELY(x) __builtin_expect(!!(x), 1)

--- a/include/gsl/assert
+++ b/include/gsl/assert
@@ -51,7 +51,7 @@
 // Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
 #define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
 #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
-#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
 #else
 #define GSL_SUPPRESS(x)
 #endif // defined(__clang__)


### PR DESCRIPTION
Fixes #1231
Fixes #1242

The motivation of this patch is to get rid of the C4875 warnings in the latest versions of the MSVC toolset.

This change is a cherry-pick of #1213 and #1226 (authored by @beinhaerter) and will be released as GSL version 4.2.2.