### PR TITLE
gsl::strict_not_null: C.66 Make move ctor noexcept

### DIFF
--- a/include/gsl/pointers
+++ b/include/gsl/pointers
@@ -298,8 +298,8 @@ public:
     {}
 
     // To avoid invalidating the "not null" invariant, the contained pointer is actually copied
-    // instead of moved. If it is a custom pointer, its constructor could in theory throw exceptions.
-    strict_not_null(strict_not_null&& other) noexcept(std::is_nothrow_copy_constructible<T>::value) = default;
+    // instead of moved. If it is a custom pointer type, its copy constructor must not throw exceptions.
+    strict_not_null(strict_not_null&& other) noexcept = default;
     strict_not_null(const strict_not_null& other) = default;
     strict_not_null& operator=(const strict_not_null& other) = default;
     strict_not_null& operator=(const not_null<T>& other)


### PR DESCRIPTION
The `strict_not_null` move ctor actually calls the copy ctor, as explained in the comment added in commit d69e578519840b9b74eff26ac01465ac07698063. The comment also says that a custom pointer type copy ctor "could in theory throw exceptions". However, I don't think that such a smart pointer type should exist in practise.

Also, it violates C66, see  https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept

So just use a `noexcept` for all types.