### PR TITLE
remove space in GSL_SUPPRESS

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -221,7 +221,7 @@ namespace details
             if (n != 0) Expects(begin_ && current_ && end_);
             if (n > 0) Expects(current_ - begin_ >= n);
             if (n < 0) Expects(end_ - current_ >= -n);
-            GSL_SUPPRESS(bounds .1)
+            GSL_SUPPRESS(bounds.1)
             current_ -= n;
             return *this;
         }

--- a/tests/notnull_tests.cpp
+++ b/tests/notnull_tests.cpp
@@ -138,11 +138,11 @@ struct NonCopyableNonMovable
 namespace
 {
 // clang-format off
-GSL_SUPPRESS(f .4) // NO-FORMAT: attribute
+GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
 // clang-format on
 bool helper(not_null<int*> p) { return *p == 12; }
 // clang-format off
-GSL_SUPPRESS(f .4) // NO-FORMAT: attribute
+GSL_SUPPRESS(f.4) // NO-FORMAT: attribute
 // clang-format on
 bool helper_const(not_null<const int*> p) { return *p == 12; }
 

--- a/tests/owner_tests.cpp
+++ b/tests/owner_tests.cpp
@@ -21,7 +21,7 @@
 
 using namespace gsl;
 
-GSL_SUPPRESS(f .23) // NO-FORMAT: attribute
+GSL_SUPPRESS(f.23) // NO-FORMAT: attribute
 void f(int* i) { *i += 1; }
 
 TEST(owner_tests, basic_test)


### PR DESCRIPTION
As VS2026 wants a string literal in `[[gsl::suppress(...)]]` it is a difference, if you `GSL_SUPPRESS(a.1)` without space or `GSL_SUPPRESS(a .1)` with space. The version with the space does not work, so this commit removes the spaces.
