### PR TITLE
ci: Bump actions/setup-java@v5

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
         run: mkdir -p build
         working-directory: .
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 8
           distribution: zulu


### PR DESCRIPTION
Forgot this in commit 688ffcde9018910bef22dae9da9de974803dc982.

References:

Warnings can be seen on https://github.com/microsoft/GSL/actions/runs/23504672152:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-java@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


Ref: https://github.com/actions/setup-java/releases