### PR TITLE
narrow_cast instead of static_cast

### DIFF
--- a/include/gsl/span_ext
+++ b/include/gsl/span_ext
@@ -149,7 +149,7 @@ constexpr ElementType& at(span<ElementType, Extent> s, index i)
 template <class ElementType, std::size_t Extent>
 constexpr std::ptrdiff_t ssize(const span<ElementType, Extent>& s) noexcept
 {
-    return static_cast<std::ptrdiff_t>(s.size());
+    return gsl::narrow_cast<std::ptrdiff_t>(s.size());
 }
 
 // [span.iter] Free functions for begin/end functions


### PR DESCRIPTION
This removes the "warning C26472: Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow (type.1)." issued by VS2026.
