### PR TITLE
Support find_package for GTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,8 +22,17 @@ if(IOS)
     add_compile_definitions(GTEST_HAS_DEATH_TEST=1 IOS_PROCESS_DELAY_WORKAROUND=1)
 endif()
 
-pkg_search_module(GTestMain gtest_main)
-if (NOT GTestMain_FOUND)
+find_package(GTest QUIET)
+
+if(GTest_FOUND)
+    set(GTestMain_LIBRARIES GTest::gtest_main)
+endif()
+
+if(NOT GTest_FOUND)
+    pkg_search_module(GTestMain gtest_main)
+endif()
+
+if(NOT GTest_FOUND AND NOT GTestMain_FOUND)
     # No pre-installed GTest is available, try to download it using Git.
     find_package(Git REQUIRED QUIET)
 


### PR DESCRIPTION
## Summary

This change attempts to locate a pre-installed GoogleTest using `find_package(GTest QUIET)` before falling back to `pkg_search_module` and downloading GoogleTest.

This avoids redundant downloads when GoogleTest is already installed through CMake package managers such as vcpkg, while preserving the existing fallback behavior.

Fixes #1256