### PR TITLE
fix(cmake): find_package(GTest) before pkg-config / download (#1256)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,16 @@ if(IOS)
     add_compile_definitions(GTEST_HAS_DEATH_TEST=1 IOS_PROCESS_DELAY_WORKAROUND=1)
 endif()
 
-pkg_search_module(GTestMain gtest_main)
+# Prefer CMake package config (vcpkg / most package managers) before pkg-config,
+# which is often unavailable on Windows (#1256).
+find_package(GTest QUIET)
+if (GTest_FOUND)
+    set(GTestMain_FOUND TRUE)
+    set(GTestMain_LIBRARIES GTest::gtest_main)
+else()
+    pkg_search_module(GTestMain gtest_main)
+endif()
+
 if (NOT GTestMain_FOUND)
     # No pre-installed GTest is available, try to download it using Git.
     find_package(Git REQUIRED QUIET)


### PR DESCRIPTION
﻿## Summary
Detects a preinstalled GTest via `find_package(GTest)` before falling back to pkg-config / Git download (#1256).

`pkg_search_module` needs `.pc` files, which vcpkg and many Windows installs do not provide. Those packages ship `GTestConfig.cmake` instead, so tests always re-downloaded GTest even when it was already available.

## Change
1. `find_package(GTest QUIET)` → use `GTest::gtest_main`
2. Else `pkg_search_module(GTestMain gtest_main)` (unchanged)
3. Else download via Git (unchanged)

Closes #1256
