### PR TITLE
dyn_array: fix include tree

### DIFF
--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -26,6 +26,7 @@
 #include <iterator>
 #include <memory>
 #include <type_traits>
+#include <vector>
 
 #if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
 #include <ranges>

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -21,6 +21,7 @@
 #include "./algorithm" // copy
 #include "./assert"    // Ensures/Expects
 #include "./byte"      // byte
+#include "./dyn_array" // dyn_array
 #include "./pointers"  // owner, not_null
 #include "./span"      // span
 #include "./util"      // finally()/narrow_cast()...


### PR DESCRIPTION
simple gsl::dyn_array examples were failing to compile for the following reasons:
 - gsl/gsl was not including dyn_array
 - dyn_array was not including \<vector\>

 This fixes both issues so trivial examples of using gsl::dyn_array
 work.