### PR TITLE
Bump GSL to v5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14...3.16)
 
-project(GSL VERSION 4.2.0 LANGUAGES CXX)
+project(GSL VERSION 5.0.0 LANGUAGES CXX)
 
 add_library(GSL INTERFACE)
 add_library(Microsoft.GSL::GSL ALIAS GSL)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ include(FetchContent)
 
 FetchContent_Declare(GSL
     GIT_REPOSITORY "https://github.com/microsoft/GSL"
-    GIT_TAG "v4.2.0"
+    GIT_TAG "v5.0.0"
     GIT_SHALLOW ON
 )
 


### PR DESCRIPTION
## Summary
- bump the CMake project version to 5.0.0
- update the README FetchContent tag to v5.0.0

## Validation
- `cmake -S . -B build/version-check -DGSL_TEST=OFF -DGSL_INSTALL=ON`
- `git diff --check`