### PR TITLE
Ensure iterators convert to const iterators

### DIFF
--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -185,10 +185,7 @@ namespace details
             Ensures(_pos <= _end_pos);
         }
 
-        constexpr operator dyn_array_iterator<const T>() const
-        {
-            return {_ptr, _pos, _end_pos};
-        }
+        constexpr operator dyn_array_iterator<const T>() const { return {_ptr, _pos, _end_pos}; }
 
 #if defined(_MSC_VER) && defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
         constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }

--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -185,6 +185,11 @@ namespace details
             Ensures(_pos <= _end_pos);
         }
 
+        constexpr operator dyn_array_iterator<const T>() const
+        {
+            return {_ptr, _pos, _end_pos};
+        }
+
 #if defined(_MSC_VER) && defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
         constexpr operator pointer() const { return _ptr + gsl::narrow<size_type>(_pos); }
 #endif /* defined(_MSC_VER) && __cpp_lib_ranges >= 201911L */

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -16,6 +16,9 @@
 
 static_assert(sizeof(gsl::dyn_array<int>) == 2 * sizeof(void*),
               "gsl::dyn_array (with the default allocator) should be 16 bytes");
+static_assert(
+    std::is_convertible<gsl::dyn_array<int>::iterator, gsl::dyn_array<int>::const_iterator>::value,
+    "gsl::dyn_array iterator should be implicitly convertible to const_iterator");
 
 #if defined(__cpp_lib_concepts) && (__cpp_lib_concepts >= 202002L)
 static_assert(std::input_iterator<gsl::dyn_array<int>::iterator>,

--- a/tests/span_compatibility_tests.cpp
+++ b/tests/span_compatibility_tests.cpp
@@ -601,6 +601,9 @@ static_assert(std::is_same<gsl::span<const int, 3>::const_reference, const int&>
               "span<const int, 3>::const_reference should be const int&");
 
 // assertions for span_iterator
+static_assert(
+    std::is_convertible<gsl::span<int>::iterator, gsl::span<const int>::iterator>::value,
+    "span<int>::iterator should be implicitly convertible to span<const int>::iterator");
 static_assert(std::is_same<std::iterator_traits<gsl::span<int>::iterator>::pointer, int*>::value,
               "span<int>::iterator's pointer should be int*");
 static_assert(

--- a/tests/span_compatibility_tests.cpp
+++ b/tests/span_compatibility_tests.cpp
@@ -601,9 +601,8 @@ static_assert(std::is_same<gsl::span<const int, 3>::const_reference, const int&>
               "span<const int, 3>::const_reference should be const int&");
 
 // assertions for span_iterator
-static_assert(
-    std::is_convertible<gsl::span<int>::iterator, gsl::span<const int>::iterator>::value,
-    "span<int>::iterator should be implicitly convertible to span<const int>::iterator");
+static_assert(std::is_convertible<gsl::span<int>::iterator, gsl::span<const int>::iterator>::value,
+              "span<int>::iterator should be implicitly convertible to span<const int>::iterator");
 static_assert(std::is_same<std::iterator_traits<gsl::span<int>::iterator>::pointer, int*>::value,
               "span<int>::iterator's pointer should be int*");
 static_assert(


### PR DESCRIPTION
## Summary
- add compile-time assertions for implicit iterator-to-const-iterator conversion in `dyn_array` and `span`
- add the missing implicit conversion to `dyn_array_iterator`

## Testing
- MSVC C++14: `dyn_array_tests`, `span_compatibility_tests`
- MSVC C++20: `dyn_array_tests`, `span_compatibility_tests`