### PR TITLE
Let dyn_array_iterator convert to its const_iterator

### DIFF
--- a/include/gsl/dyn_array
+++ b/include/gsl/dyn_array
@@ -288,6 +288,8 @@ namespace details
         size_type _pos{};
         size_type _end_pos{};
 
+        template <typename>
+        friend class dyn_array_iterator;
         template <typename, typename>
         friend class ::gsl::dyn_array;
     };

--- a/tests/dyn_array_tests.cpp
+++ b/tests/dyn_array_tests.cpp
@@ -585,6 +585,15 @@ TEST(dyn_array_tests, const_operations)
     EXPECT_EQ(pirates[0], 'a');
 }
 
+TEST(dyn_array_tests, iterator_converts_to_const_iterator)
+{
+    gsl::dyn_array<char> mariners{'a', 'b', 'c'};
+    gsl::dyn_array<char>::const_iterator it = mariners.begin();
+    EXPECT_EQ(*it, 'a');
+    EXPECT_TRUE(it == mariners.cbegin());
+    EXPECT_TRUE(mariners.cend() == mariners.end());
+}
+
 TEST(dyn_array_tests, reverse_iterator)
 {
     const gsl::dyn_array<char> padres{'a', 'b', 'c'};


### PR DESCRIPTION
Fixes #1269.

`dyn_array_iterator<T>`'s conversion to `dyn_array_iterator<const T>` builds the target through that specialization's private state constructor, which befriended only `gsl::dyn_array`, so the conversion was an access error at every use. The iterator now befriends its own specializations, as `span_iterator` does.

The new test assigns `begin()` to a `const_iterator` and compares `cend()` with `end()`; it fails to compile on main.
